### PR TITLE
Use the correct (OSUOSL) SMTP server for the PE Console

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -16,3 +16,7 @@ mod "gentoo/portage", '2.2.0-rc1'
 
 mod "puppetlabs/ntp", '3.0.3'
 
+# Needed for managing .yaml files from within Puppet
+mod 'reidmv/yamlfile'
+# Needed by `yamlfile`
+mod 'adrien/filemapper'

--- a/dist/profile/manifests/puppetmaster.pp
+++ b/dist/profile/manifests/puppetmaster.pp
@@ -24,4 +24,13 @@ class profile::puppetmaster {
     setting => 'manifest',
     value   => '/etc/puppetlabs/puppet/environments/$environment/manifests/site.pp',
   }
+
+
+  ## Ensure we're setting the right SMTP server
+  yaml_setting { 'console smtp server':
+    target => '/etc/puppetlabs/console-auth/config.yml',
+    key    => 'smtp/address',
+    value  => 'smtp.osuosl.org',
+    notify => Service['pe-httpd'],
+  }
 }


### PR DESCRIPTION
From within the OSUOSL there isn't a need for auth or TLS for the SMTP server

[FIXED INFRA-6]
