### PR TITLE
Add support for managing sudoers access across machines

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,6 +24,9 @@ fixtures:
     account:
       repo: 'git://github.com/jenkins-infra/puppet-account.git'
       ref: '03280b8'
+    sudo:
+      repo: 'git://github.com/saz/puppet-sudo.git'
+      ref: 'v3.0.6'
 # Setting up a couple of symlinks to make it easier to treat profiles and roles
 # just as another set of "modules" in our environment
   symlinks:

--- a/Puppetfile
+++ b/Puppetfile
@@ -19,7 +19,11 @@ mod "puppetlabs/vcsrepo", '0.2.0'
 mod "puppetlabs/git", '0.0.3'
 mod "gentoo/portage", '2.2.0-rc1'
 
+# Used for setting up ntp daemons on all machines to have a correct time
 mod "puppetlabs/ntp", '3.0.3'
+
+# Module for managing sudoers across all machines
+mod 'saz/sudo', '3.0.6'
 
 # Needed for managing .yaml files from within Puppet
 mod 'reidmv/yamlfile'

--- a/README.md
+++ b/README.md
@@ -59,4 +59,5 @@ to production, it will be automatically deployed to production hosts.
 
 * `#jenkins-infra` on the [Freenode](http://freenode.net) IRC network
 *  [INFRA project](https://issues.jenkins-ci.org/browse/INFRA) in JIRA.
+* [infra@lists.jenkins-ci.org](http://lists.jenkins-ci.org/mailman/listinfo/jenkins-infra)
 

--- a/dist/profile/manifests/sudo.pp
+++ b/dist/profile/manifests/sudo.pp
@@ -1,0 +1,27 @@
+#
+# Main sudo management profile
+class profile::sudo {
+  include ::sudo
+
+  sudo::conf { 'env-defaults':
+    content => 'Defaults        env_reset',
+  }
+
+  sudo::conf { 'secure-path':
+    content => 'Defaults        secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"',
+  }
+
+  sudo::conf { 'root':
+    content  => 'root ALL=(ALL) ALL',
+  }
+
+  sudo::conf { 'admins':
+    priority => '10',
+    content  => '%admin ALL=(ALL) ALL',
+  }
+
+  sudo::conf { 'sudo':
+    priority => '10',
+    content  => '%sudo ALL=(ALL) ALL',
+  }
+}

--- a/dist/profile/manifests/sudo/osu.pp
+++ b/dist/profile/manifests/sudo/osu.pp
@@ -1,0 +1,10 @@
+#
+# profile to define the additional sudoer requirements for machines in the
+# OSUOSL which have an `osuadmin` role account on them
+class profile::sudo::osu {
+  include profile::sudo
+
+  sudo::conf { 'osuadmin':
+      content => 'osuadmin  ALL=(ALL) ALL',
+  }
+}

--- a/dist/role/manifests/puppetmaster.pp
+++ b/dist/role/manifests/puppetmaster.pp
@@ -4,4 +4,5 @@ class role::puppetmaster {
   include profile::accounts
   include profile::puppetmaster
   include profile::r10k
+  include profile::sudo::osu
 }

--- a/spec/classes/profile/sudo/osu_spec.rb
+++ b/spec/classes/profile/sudo/osu_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'profile::sudo::osu' do
+  it { should contain_class 'profile::sudo' }
+
+  it { should contain_sudo__conf 'osuadmin' }
+end

--- a/spec/classes/profile/sudo_spec.rb
+++ b/spec/classes/profile/sudo_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'profile::sudo' do
+  it { should contain_class 'sudo' }
+
+  it { should contain_sudo__conf 'admins' }
+  it { should contain_sudo__conf 'sudo' }
+  it { should contain_sudo__conf 'root' }
+
+  it { should contain_sudo__conf 'env-defaults' }
+  it { should contain_sudo__conf 'secure-path' }
+end

--- a/spec/classes/role/puppetmaster_spec.rb
+++ b/spec/classes/role/puppetmaster_spec.rb
@@ -7,4 +7,5 @@ describe 'role::puppetmaster' do
 
   it { should contain_class 'profile::puppetmaster' }
   it { should contain_class 'profile::accounts' }
+  it { should contain_class 'profile::sudo::osu' }
 end


### PR DESCRIPTION
This includes the saz/sudo module and defines a difference in sudoer needs
between OSUOSL managed machines and those outside of the OSUOSL datacenter,
which won't have an `osuadmin` account on them

[FIXED INFRA-17]
