### PR TITLE
Fix the it { should compile } issue on tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,8 @@ RSpec.configure do |c|
     :osfamily => 'Debian',
   }
   c.mock_with :rspec
+  c.before(:each) do
+    require 'puppet/confine/exists'
+    Puppet::Confine::Exists.any_instance.stubs(:which => '')
+  end
 end


### PR DESCRIPTION
Currently the CI fails on it should compile.
This commit fixes it and allow tests to pass

See: https://tickets.puppetlabs.com/browse/PUP-1547
