### PR TITLE
Introduce role-based serverspec testing, powered by Vagrant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'puppet', '~> 3.4.0'
 gem 'r10k'
 gem 'puppetlabs_spec_helper', :github => 'jenkins-infra/puppetlabs_spec_helper'
 gem 'pry'
+gem 'serverspec'
 
 group :development do
   # XXX: Shouldn't be needed anywhere by rtyler's machine, since Vagrant does'nt
@@ -21,4 +22,5 @@ end
 # Vagrant plugins
 group :plugins do
   gem 'vagrant-aws', :github => 'mitchellh/vagrant-aws'
+  gem 'vagrant-serverspec', :github => 'jvoorhis/vagrant-serverspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,13 @@ GIT
       rspec-puppet (>= 0.1.1)
 
 GIT
+  remote: git://github.com/jvoorhis/vagrant-serverspec.git
+  revision: 253ec6e787e8fc6698f1fccc7426aad7cd1da6eb
+  specs:
+    vagrant-serverspec (0.0.1)
+      serverspec (~> 0.12.0)
+
+GIT
   remote: git://github.com/mitchellh/vagrant-aws.git
   revision: d125a2f8ca5422f55f555ab921aaac968d1e6e72
   specs:
@@ -82,6 +89,7 @@ GEM
     formatador (0.2.4)
     hiera (1.3.2)
       json_pure
+    highline (1.6.21)
     i18n (0.6.9)
     json_pure (1.8.1)
     listen (2.7.3)
@@ -135,7 +143,13 @@ GEM
     rspec-mocks (2.14.6)
     rspec-puppet (1.0.1)
       rspec
+    serverspec (0.12.0)
+      highline
+      net-ssh
+      rspec (>= 2.13.0)
+      specinfra (>= 0.0.2)
     slop (3.5.0)
+    specinfra (1.8.0)
     systemu (2.5.2)
     timers (1.1.0)
     wdm (0.1.0)
@@ -153,5 +167,7 @@ DEPENDENCIES
   r10k
   rake
   rspec-puppet
+  serverspec
   vagrant!
   vagrant-aws!
+  vagrant-serverspec!

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,12 @@ Vagrant.configure("2") do |config|
     veggie = File.basename(role).gsub('.pp', '')
 
     config.vm.define(veggie) do |node|
+      node.vm.provider(:aws) do |aws, override|
+        aws.tags = {
+          :Name => veggie
+        }
+      end
+
       node.vm.provision 'puppet' do |puppet|
         puppet.manifest_file = File.basename(role)
         puppet.manifests_path = File.dirname(role)
@@ -38,6 +44,10 @@ Vagrant.configure("2") do |config|
         }
         puppet.hiera_config_path = 'spec/fixtures/hiera.yaml'
         puppet.options = "--verbose --execute 'include role::#{veggie}\n include profile::vagrant'"
+      end
+
+      node.vm.provision :serverspec do |spec|
+        spec.pattern = "spec/server/#{veggie}/*.rb"
       end
     end
   end

--- a/spec/server/edamame/edamame_spec.rb
+++ b/spec/server/edamame/edamame_spec.rb
@@ -1,0 +1,5 @@
+require_relative './../spec_helper'
+
+describe 'edamame' do
+  it_behaves_like "a standard Linux machine"
+end

--- a/spec/server/spec_helper.rb
+++ b/spec/server/spec_helper.rb
@@ -1,0 +1,17 @@
+require_relative './../spec_helper'
+
+# Server spec requirements!
+require 'serverspec'
+require 'pathname'
+require 'net/ssh'
+# Including these at a top level to make sure we have some methods for our DSL
+# that we need for server spec
+include SpecInfra::Helper::Ssh
+include SpecInfra::Helper::DetectOS
+
+
+# Load all our helpful support files
+support_dir = File.expand_path(File.dirname(__FILE__) + '/support')
+Dir["#{support_dir}/**/*.rb"].each do |f|
+  require f
+end

--- a/spec/server/spinach/spinach_spec.rb
+++ b/spec/server/spinach/spinach_spec.rb
@@ -1,0 +1,5 @@
+require_relative './../spec_helper'
+
+describe 'spinach' do
+  it_behaves_like "a standard Linux machine"
+end

--- a/spec/server/support/basic_shared_contexts.rb
+++ b/spec/server/support/basic_shared_contexts.rb
@@ -1,0 +1,15 @@
+require 'rspec'
+
+shared_examples "a standard Linux machine" do
+  describe port(22) do
+    it { should be_listening }
+  end
+
+  # Make sure all our usual users are in place
+  %w(abayer tyler kohsuke).each do |username|
+    describe user(username) do
+      it { should exist }
+      it { should have_home_directory "/home/#{username}" }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,19 +1,28 @@
 require 'rubygems'
-require 'pry'
+require 'rspec'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'pry'
 
 FIXTURES_PATH = File.expand_path(File.dirname(__FILE__) + '/fixtures')
 # Set up our $LOAD_PATH to properly include custom provider code from modules
 # in spec/fixtures
 $LOAD_PATH.unshift(*Dir["#{FIXTURES_PATH}/modules/*/lib"])
 
+
 RSpec.configure do |c|
+  c.mock_with :rspec
+  # Use color in STDOUT
+  c.color_enabled = true
+  c.formatter = :documentation
+
   c.hiera_config = File.join(FIXTURES_PATH, 'hiera.yaml')
   c.default_facts = {
     :osfamily => 'Debian',
   }
-  c.mock_with :rspec
+
   c.before(:each) do
+    # Workaround until this is fixed:
+    #   <https://tickets.puppetlabs.com/browse/PUP-1547>
     require 'puppet/confine/exists'
     Puppet::Confine::Exists.any_instance.stubs(:which => '')
   end


### PR DESCRIPTION
This allows for writing and running acceptance tests for specific roles
(dist/role/manifests/*.pp) and spinning up a Vagrant AWS machine with that
role, then running the appropriate serverspec tests against it.
