### PR TITLE
[INFRA-102] Redirect was redirecting everything, not just the top page

### DIFF
--- a/dist/profile/templates/archives/vhost.conf
+++ b/dist/profile/templates/archives/vhost.conf
@@ -16,4 +16,4 @@ MinBandwidth all 0
 
 # We want people to start from mirrors so that they find the fastest download target
 # The 'archives' server is just one of many destinations
-Redirect /            http://mirrors.jenkins-ci.org/
+RedirectMatch ^/$            http://mirrors.jenkins-ci.org/


### PR DESCRIPTION
I always forget that 'Redirect' is a prefix match, not the whole match. So it resulted in every access sent back to the mirror controller machine. This change fixes that.

(I made this commit from GitHub UI and that resulted in my making changes directly in the staging branch. My bad)
