### PR TITLE
[INFRA-231]

### DIFF
--- a/dist/profile/manifests/jenkinsadmin.pp
+++ b/dist/profile/manifests/jenkinsadmin.pp
@@ -13,7 +13,7 @@ class profile::jenkinsadmin (
 
   # Tag is the docker container image tag from our build process, this job:
   # <https://ci.jenkins-ci.org/view/Infrastructure/job/infra_ircbot>
-  $tag = 'build40'
+  $tag = 'build41'
   $user = 'ircbot'
 
   docker::image { 'jenkinsciinfra/ircbot':


### PR DESCRIPTION
Build #41 contains the fix we need to authenticate `jenkins-admin` against nickserv.
