### PR TITLE
Puppet node name changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ to production, it will be automatically deployed to production hosts.
 
 ## Installing agents
 
-For installing agents refer to the [installing agents](http://docs.puppetlabs.com/pe/latest/install_basic.html#installing-agents) section of the PuppetLabs documentation.
+For installing agents refer to the [installing agents](http://docs.puppetlabs.com/pe/latest/install_agents.html) section of the PuppetLabs documentation.
 
 ## Contributing
 

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -36,18 +36,18 @@ node 'jenkins-puppet.osuosl.org' {
   include role::puppetmaster
 }
 
-# edamame
-node 'jenkins-confluence.osuosl.org' {
+# edamame (aka jenkins-confluence.osuosl.org)
+node 'edamame' {
   include role::edamame
 }
 
 # lettuce
-node 'jenkins-lettuce.osuosl.org' {
+node 'lettuce' {
   include role::lettuce
 }
 
 # spinach
-node 'spinach.jenkins-ci.org' {
+node 'spinach' {
   include role::spinach
 }
 


### PR DESCRIPTION
`confluence` is a service name. It should be using the real host name `edamame` instead.

For consistency, using this opportunity to set short vegetable names for everything.
