### PR TITLE
[INFRA-41] JIRA deployment step 1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -63,7 +63,7 @@ mod 'apache-logcompressor', :git => 'git://github.com/jenkins-infra/puppet-apach
 mod "puppetlabs/concat", '1.0.4'
 
 
-mod 'rtyler/groovy', '1.0.2'
+mod 'rtyler/groovy', '1.0.3'
 # Dependency of `groovy
 mod 'nanliu/staging', '0.4.0'
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,9 @@ Vagrant.configure("2") do |config|
   config.vm.box = 'dummy'
   config.vm.box_url = 'https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box'
 
+  # modules/account/.travis.yml has incorrect link target, and this blows up
+  # when vagrant tries to rsync files as it tries to resolves symlinks.
+  # see http://www.trilithium.com/johan/2011/09/delete-broken-symlinks/
   `find -L . -type l -delete`
 
   config.vm.provider(:aws) do |aws, override|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = 'dummy'
   config.vm.box_url = 'https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box'
 
+  `find -L . -type l -delete`
+
   config.vm.provider(:aws) do |aws, override|
     aws.access_key_id = access_key_id
     aws.secret_access_key = secret_access_key

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -29,6 +29,7 @@ class profile::jira (
     ports    => ['8080:8080'],
     image    => "jenkinsciinfra/mock-webapp:${image_tag}",
     volumes  => ['/srv/jira/home:/srv/jira/home'],
+    env      => ['APP="Jenkins JIRA"'],
   }
 
   apache::mod { 'proxy':
@@ -58,5 +59,9 @@ class profile::jira (
     docroot         => '/srv/jira/docroot',
     redirect_status => 'temp',
     redirect_dest   => 'https://issues.jenkins-ci.org/'
+  }
+
+  host { 'issues.jenkins-ci.org':
+    ip => '127.0.0.1',
   }
 }

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -25,11 +25,12 @@ class profile::jira (
   }
 
   docker::run { 'jira':
-    command  => undef,
-    ports    => ['8080:8080'],
-    image    => "jenkinsciinfra/mock-webapp:${image_tag}",
-    volumes  => ['/srv/jira/home:/srv/jira/home'],
-    env      => ['APP="Jenkins JIRA"'],
+    command         => undef,
+    ports           => ['8080:8080'],
+    image           => "jenkinsciinfra/mock-webapp:${image_tag}",
+    volumes         => ['/srv/jira/home:/srv/jira/home'],
+    env             => ['APP="Jenkins JIRA"'],
+    restart_service => true,
   }
 
   apache::mod { 'proxy':

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -1,4 +1,5 @@
 # Run containerized JIRA to serve issues.jenkins-ci.org
+# see https://github.com/jenkins-infra/jira for how the container is put together
 class profile::jira (
   # all injected from hiera
   $image_tag,

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -12,10 +12,12 @@ class profile::jira (
     ensure => directory,
   }
   file { '/srv/jira/home':
-    ensure => directory,
+    ensure  => directory,
+    recurse => true,
   }
   file { '/srv/jira/docroot':
-    ensure => directory,
+    ensure  => directory,
+    recurse => true,
   }
 
   docker::image { 'jenkinsciinfra/mock-webapp':
@@ -27,6 +29,12 @@ class profile::jira (
     ports    => ['8080:8080'],
     image    => "jenkinsciinfra/mock-webapp:${image_tag}",
     volumes  => ['/srv/jira/home:/srv/jira/home'],
+  }
+
+  apache::mod { 'proxy':
+  }
+
+  apache::mod { 'proxy_http':
   }
 
   apache::vhost { 'issues.jenkins-ci.org':

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -11,6 +11,12 @@ class profile::jira (
   file { '/var/log/apache2/issues.jenkins-ci.org':
     ensure => directory,
   }
+  file { '/srv/jira/home':
+    ensure => directory,
+  }
+  file { '/srv/jira/docroot':
+    ensure => directory,
+  }
 
   docker::image { 'jenkinsciinfra/mock-webapp':
     image_tag => $image_tag,
@@ -27,6 +33,8 @@ class profile::jira (
     servername      => 'issues.jenkins-ci.org',
     vhost_name      => '*',
     port            => '443',
+    ssl             => true,
+    docroot         => '/srv/jira/docroot',
     access_log      => false,
     error_log_file  => 'issues.jenkins-ci.org/error.log',
     log_level       => 'warn',
@@ -34,5 +42,13 @@ class profile::jira (
 
     notify          => Service['apache2'],
     require         => File['/var/log/apache2/issues.jenkins-ci.org'],
+  }
+  apache::vhost { 'issues.jenkins-ci.org non-ssl':
+    # redirect non-SSL to SSL
+    servername      => 'issues.jenkins-ci.org',
+    port            => '80',
+    docroot         => '/srv/jira/docroot',
+    redirect_status => 'temp',
+    redirect_dest   => 'https://issues.jenkins-ci.org/'
   }
 }

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -1,0 +1,38 @@
+# Run containerized JIRA to serve issues.jenkins-ci.org
+class profile::jira (
+  # all injected from hiera
+  $image_tag,
+) {
+  # as a preparation, deploying mock-webapp and not the real jira
+
+  include profile::docker
+  include profile::apache-misc
+
+  file { '/var/log/apache2/issues.jenkins-ci.org':
+    ensure => directory,
+  }
+
+  docker::image { 'jenkinsciinfra/mock-webapp':
+    image_tag => $image_tag,
+  }
+
+  docker::run { 'jira':
+    command  => undef,
+    ports    => ['8080:8080'],
+    image    => "jenkinsciinfra/mock-webapp:${image_tag}",
+    volumes  => ['/srv/jira/home:/srv/jira/home'],
+  }
+
+  apache::vhost { 'issues.jenkins-ci.org':
+    servername      => 'issues.jenkins-ci.org',
+    vhost_name      => '*',
+    port            => '443',
+    access_log      => false,
+    error_log_file  => 'issues.jenkins-ci.org/error.log',
+    log_level       => 'warn',
+    custom_fragment => template("${module_name}/jira/vhost.conf"),
+
+    notify          => Service['apache2'],
+    require         => File['/var/log/apache2/issues.jenkins-ci.org'],
+  }
+}

--- a/dist/profile/templates/jira/vhost.conf
+++ b/dist/profile/templates/jira/vhost.conf
@@ -1,0 +1,25 @@
+SSLEngine On
+
+# Redirect from old project key
+RedirectMatch /browse/HUDSON-(.+)       /browse/JENKINS-$1
+Redirect /secure/Signup!default.jspa	https://jenkins-ci.org/account
+Redirect /secure/ForgotLoginDetails.jspa	https://jenkins-ci.org/account
+
+<Proxy *>
+    Order allow,deny
+    Allow from all
+</Proxy>
+
+ProxyPassMatch	^/browse/HUDSON-	!
+ProxyPass	/secure/Signup!default.jspa	!
+ProxyPass	/secure/ForgotLoginDetails.jspa	!
+ProxyPass 	 / http://localhost:8080/
+ProxyPassReverse / http://localhost:8080/
+ProxyPreserveHost On
+
+CustomLog "|/usr/sbin/rotatelogs /var/log/apache2/issues.jenkins-ci.org/access.log.%Y%m%d%H%M%S 86400" combined
+ErrorLog /var/log/apache2/error.log
+
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+LogLevel warn

--- a/dist/role/manifests/edamame.pp
+++ b/dist/role/manifests/edamame.pp
@@ -5,4 +5,5 @@ class role::edamame {
   include profile::robobutler
   include profile::sudo::osu
   include profile::bind
+  include profile::jira
 }

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -61,4 +61,6 @@ profile::jenkinsadmin::nick_password: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYC
 profile::robobutler::nick: robobutler
 profile::robobutler::password: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEABVdkhSaLYP67aKwr9xtAmgJodLoRa07Mt2sErWwXlICuI3M45r+OUsAjHg+7A1ou/uZZTvT00Y53OuCGp03kvuaTgJy/odOVxj9BR0XI8yw94q+/VR5TqNfub76JcHQ5nRKMpvNHc+a31VFVP+gtZ38SMHUF/OUBu8c3qTcBdKPG0KJtnI3JVAiOUiYcDCSAf55AwaqqUZYETj2b5428UAWcw5fWr5+yWyS8jCpvvxRZg1M6FcaL23pJh1fnU5IDPoKo3S03aPsRv+1O1ztliaw3pBcXnid6m5RJYshx+cF2PjoXlao/7zs0PN+DYz6V4jKkqLMsIrEtq8vy2rcBmTBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCRYFvchg57uCM+JWkUSoHTgDBWkeBzwDPHBOe31gkH43kNrO8OnqrlP5rA5agte04g08TPL/4nwAV10uuMWJGxmwU=]
 
+profile::jira::image_tag: build4
+
 # vim: ft=yaml ts=2 sw=2 nowrap et

--- a/spec/classes/profile/jira_spec.rb
+++ b/spec/classes/profile/jira_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'profile::jira' do
+  it { should contain_class 'docker' }
+  it { should contain_file '/srv/jira/home' }
+  it { should contain_service('docker-jira') }
+end

--- a/spec/server/edamame/edamame_spec.rb
+++ b/spec/server/edamame/edamame_spec.rb
@@ -33,5 +33,14 @@ describe 'edamame' do
     describe port(8080) do
       it { should be_listening }
     end
+
+    # test out reverse proxy to JIRA
+    # use '--insecure' flag to skip SSL certificate check, as test boxes won't have the real private key nor the certificate
+    describe command("curl --insecure -L http://issues.jenkins-ci.org/") do
+      its(:stdout) { should match /Jenkins JIRA/ }
+    end
+    describe command("curl --insecure -L https://issues.jenkins-ci.org/") do
+      its(:stdout) { should match /Jenkins JIRA/ }
+    end
   end
 end

--- a/spec/server/edamame/edamame_spec.rb
+++ b/spec/server/edamame/edamame_spec.rb
@@ -29,4 +29,9 @@ describe 'edamame' do
     end
   end
 
+  context 'JIRA' do
+    describe port(8080) do
+      it { should be_listening }
+    end
+  end
 end

--- a/spec/server/edamame/edamame_spec.rb
+++ b/spec/server/edamame/edamame_spec.rb
@@ -42,5 +42,8 @@ describe 'edamame' do
     describe command("curl --insecure -L https://issues.jenkins-ci.org/") do
       its(:stdout) { should match /Jenkins JIRA/ }
     end
+    describe command("ls -la /var/log/apache2/issues.jenkins-ci.org") do
+      its(:stdout) { should match 'access.log.[0-9]{14}' }
+    end
   end
 end

--- a/vagrant-aws
+++ b/vagrant-aws
@@ -2,4 +2,4 @@
 
 export VAGRANT_DEFAULT_PROVIDER=aws
 
-exec vagrant $@
+exec bundle exec vagrant $@


### PR DESCRIPTION
This is the first of the series of changes to deploy JIRA in more manageable fashion.

In this change, I'm deploying a fake webapp container instead of actual JIRA container. This allows us to test the way we manage Apache on edamame. The change has been successfully tested through serverspec.

In developing this PR, I had to fix a few problems in the way vagrant/serverspec runs. So those are a part of this change.

Once this change gets deployed to production, I can work toward replacing the fake webapp by the actual JIRA container, which involves some manual work and service down time.
