### PR TITLE
Deploy datadog node to every node

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -70,6 +70,9 @@ fixtures:
     vcsrepo:
       repo: 'puppetlabs/vcsrepo'
       ref: '1.1.0'
+    datadog_agent:
+      repo: 'datadog/datadog_agent'
+      ref: '1.2.0'
 
 
 # Setting up a couple of symlinks to make it easier to treat profiles and roles

--- a/Puppetfile
+++ b/Puppetfile
@@ -72,3 +72,5 @@ mod 'nanliu/staging', '0.4.0'
 mod 'saz/ssh', '2.3.6'
 
 mod 'puppetlabs/lvm', '0.3.2'
+
+mod 'datadog/datadog_agent', '1.2.0'

--- a/dist/profile/manifests/base.pp
+++ b/dist/profile/manifests/base.pp
@@ -15,6 +15,8 @@ class profile::base {
     },
   }
 
+  include datadog_agent
+
   # Cleaning up after infra-puppet
   ##############################################################################
   cron { 'pull puppet updates':

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -99,4 +99,5 @@ profile::apache-cert::secret-key-wiki-jira: |
 
 profile::jira::image_tag: build4
 
+datadog_agent::api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAJX7oKxfhXnPTTFApoOCm97Fg72Rw8KIA9/pvLbiwYtXJBZBTXFUu3QJwXsqx3yLAvjGRLDmUV18Es8BH4Dppu7ZeIbhlvPwoNcusKUp0v5e9QV72er0SAuYg2qIisMUW0QhhqKCK6T6Owns+HweqNOZYzIwaFfaPK4RVUn5slKJNtoLwo4iV92QHKBi0Ge45tAM9p7jjv7qRJN1rgrN71OzY9CHE+V4DmsP+vmPJi37GSjrKs+g/saGQmodpMfkn1B9Qyrow8wrzPYkBD/IPKZMTklbPdbibBJeVFEeG4lI7yiR0PPfc/ms0zFe9HP++ixCSf+e8qdCjbTMZaAm6HzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDVY9nVGOH/O+HKrI1h57NLgDDswiScHBM5Q7uDwSpLI/csO3ave7EULHetXnZwuRkVnxX6uP80tycD2ZDYQjidr4A=]
 # vim: ft=yaml ts=2 sw=2 nowrap et

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ RSpec.configure do |c|
     :osfamily => 'Debian',
     :kernel => 'Linux',
     :lsbdistid => 'Ubuntu',
+    :operatingsystem => 'Ubuntu',
     :operatingsystemrelease => '12.04',
     :concat_basedir => '/tmp',
   }


### PR DESCRIPTION
Thanks to [the support from Datadog the company](https://twitter.com/jhotta/status/581980645733244928), we can use Datadog in our infrastructure. So this change deploys datadog everywhere by adding it to `profile::base`.
