### PR TITLE
Override the host name

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,7 +20,7 @@ fixtures:
       ref: '4e3cee3'
     docker:
       repo: 'git://github.com/jenkins-infra/garethr-docker.git'
-      ref: '2e87e66e'
+      ref: 'e7081ff'
     apache-logcompressor:
       repo: 'git://github.com/jenkins-infra/puppet-apache-logcompressor.git'
 

--- a/Puppetfile
+++ b/Puppetfile
@@ -35,7 +35,7 @@ mod 'reidmv/yamlfile'
 mod 'adrien/filemapper'
 
 mod 'docker', :git => 'git://github.com/jenkins-infra/garethr-docker.git',
-              :ref => '2e87e66'
+              :ref => 'e7081ff'
 
 # Deps for docker
 mod 'puppetlabs/apt', '1.6.0'


### PR DESCRIPTION
Datadog detects its `jenkins-confluence.osuosl.org` as the host name, which makes the DD dashboard inconsistent.

Explicitly set the host name to clean this up.
