### PR TITLE
fixing problem in meetings.jenkins-ci.org virtual host

### DIFF
--- a/dist/profile/manifests/robobutler.pp
+++ b/dist/profile/manifests/robobutler.pp
@@ -70,6 +70,7 @@ class profile::robobutler (
 
   apache::vhost { 'meetings.jenkins-ci.org':
       docroot         => $logdir,
+      port            => '80',
       access_log      => false,
       error_log_file  => 'meetings.jenkins-ci.org/error.log',
       log_level       => 'warn',


### PR DESCRIPTION
This error wasn't previously apparent because that was the only virtual host it served.

Now that I'm adding `wiki.jenkins-ci.org` the problem is becoming more visible
