### PR TITLE
Adding another volume to okra

### DIFF
--- a/hieradata/clients/okra.yaml
+++ b/hieradata/clients/okra.yaml
@@ -3,7 +3,8 @@ lvm::volume_groups:
   archives:
     physical_volumes:
       - /dev/xvdb
+      - /dev/xvdd
     logical_volumes:
       releases:
-        size: 149G
+        size: 299G
         mountpath: /srv/releases


### PR DESCRIPTION
archives area has grown past 150GB, and it's blocking UC.

150GB volume was added via Rackspace cloud console, and this step makes the OS use the new volume.
