### PR TITLE
DO NOT MERGE YET [INFRA-261] switch wiki to lettuce

### DIFF
--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -89,13 +89,14 @@ lists      3600    IN    MX    0    smtp4.osuosl.org.
 ;   this policy enables the e-mail originating from these hosts to be whitelisted.
 ;    199.193.196.24     (cucumber)
 ;    140.211.15.*       (eggplant and its subnet)
+;    140.211.8.*        (lettuceand its subnet)
 ;    173.203.60.151     (spinach)
 ;    140.211.166.128/25 (OSUOSL mail relays)
 ;    "~all" in the end makes the rest soft failures (as opposed to -all for hard failure)
 ;
 ;   when modifying, use http://www.kitterman.com/spf/validate.html to test
-@ 3600 IN  TXT "v=spf1 mx ip4:199.193.196.24 ip4:140.211.15.0/24 ip4:173.203.60.151 ip4:140.211.166.128/25 ~all"
-@ 3600 IN  SPF "v=spf1 mx ip4:199.193.196.24 ip4:140.211.15.0/24 ip4:173.203.60.151 ip4:140.211.166.128/25 ~all"
+@ 3600 IN  TXT "v=spf1 mx ip4:199.193.196.24 ip4:140.211.15.0/24 ip4:140.211.9.0/25 ip4:173.203.60.151 ip4:140.211.166.128/25 ~all"
+@ 3600 IN  SPF "v=spf1 mx ip4:199.193.196.24 ip4:140.211.15.0/24 ip4:140.211.9.0/25 ip4:173.203.60.151 ip4:140.211.166.128/25 ~all"
 
 ; DKIM
 cucumber._domainkey     1W IN TXT ("v=DKIM1;p="

--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -39,8 +39,7 @@ ns2         3600    IN    A    173.203.60.151 ; spinach (Rackspace)
 www         3600    IN    CNAME    @
 issues      3600    IN    CNAME    eggplant
 newissues   3600    IN    CNAME    cabbage
-wiki        3600    IN    CNAME    eggplant
-wiki2       3600    IN    CNAME    cabbage
+wiki        3600    IN    CNAME    lettuce
 updates     3600    IN    CNAME    gherkin
 downloads   3600    IN    CNAME    gherkin
 fisheye     3600    IN    CNAME    gherkin


### PR DESCRIPTION
This is one of the last steps. Switch the name server to drive production traffic to lettuce.

**This change needs to be coordinated with Confluence production site switch over. Do not merge yet.**
