### PR TITLE
Enable mcollective agents to connect back to the puppet master

### DIFF
--- a/dist/profile/manifests/puppetmaster.pp
+++ b/dist/profile/manifests/puppetmaster.pp
@@ -55,6 +55,12 @@ class profile::puppetmaster {
     action => 'accept',
   }
 
+  firewall { '013 allow mcollective':
+    proto  => 'tcp',
+    port   => 61613,
+    action => 'accept',
+  }
+
   service { 'pe-puppetserver':
     ensure     => running,
     hasrestart => true,

--- a/spec/classes/profile/puppetmaster_spec.rb
+++ b/spec/classes/profile/puppetmaster_spec.rb
@@ -13,4 +13,5 @@ describe 'profile::puppetmaster' do
   it { should contain_firewall('010 allow dashboard traffic').with_action('accept').with_port(443) }
   it { should contain_firewall('011 allow r10k webhooks').with_action('accept').with_port(9013) }
   it { should contain_firewall('012 allow puppet agents').with_action('accept').with_port(8140) }
+  it { should contain_firewall('013 allow mcollective').with_action('accept').with_port(61613) }
 end


### PR DESCRIPTION
Looks like I missed a port when I was opening back up firewall ports earlier in the month
