### PR TITLE
Remove puppet_rnu_reports which fail in production

### DIFF
--- a/hieradata/clients/jenkins-puppet.osuosl.org.yaml
+++ b/hieradata/clients/jenkins-puppet.osuosl.org.yaml
@@ -1,1 +1,0 @@
-datadog_agent::puppet_run_reports: true


### PR DESCRIPTION
We need a better means of enabling the puppet agent reporting
