### PR TITLE
Prepare apache conf for maintenance mode

### DIFF
--- a/dist/profile/files/apache-maintenance/maintenance.html
+++ b/dist/profile/files/apache-maintenance/maintenance.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+<div align=middle style="font-size:2em">
+  <img src=http://mirror.xmission.com/jenkins/art/jenkins-logo/256x256/logo.png>
+<br>
+  Our site is currently down for maintenance. Please check <a href="http://twitter.com/jenkinsci">our twitter</a> account for updates.
+</div>
+</body>
+</html>

--- a/dist/profile/manifests/apache-maintenance.pp
+++ b/dist/profile/manifests/apache-maintenance.pp
@@ -1,0 +1,22 @@
+# Generates the apache virtual host config file for the maintenance mode
+#
+# This puts a file under /etc/apache2/sites-available/SITENAME.maintenance
+# and you can manually symlink this from sites-enabled to put the maintenance mode UI
+define profile::apache-maintenance {
+  # $name refers to the site name
+
+  # Template uses: $addr_port
+  file { '/var/www/maintenance':
+    ensure => directory,
+  }
+
+  file { '/var/www/maintenance/maintenance.html':
+    ensure  => present,
+    source  => "puppet:///modules/${module_name}/apache-maintenance/maintenance.html",
+  }
+
+  file { "/etc/apache2/sites-available/${name}.maintenance":
+    ensure  => present,
+    content => template("${module_name}/apache-maintenance/maintenance.conf.erb"),
+  }
+}

--- a/dist/profile/manifests/apache-misc.pp
+++ b/dist/profile/manifests/apache-misc.pp
@@ -47,4 +47,7 @@ class profile::apache-misc(
     port   => 443,
     action => 'accept',
   }
+
+  # Prepare maintenance screen
+
 }

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -115,6 +115,9 @@ class profile::confluence (
       action => 'accept',
   }
 
+  profile::apache-maintenance { 'wiki.jenkins-ci.org':
+  }
+
   host { 'wiki.jenkins-ci.org':
     ip => '127.0.0.1',
   }

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -97,6 +97,9 @@ class profile::jira (
     redirect_dest   => 'https://issues.jenkins-ci.org/'
   }
 
+  profile::apache-maintenance { 'issues.jenkins-ci.org':
+  }
+
   host { 'issues.jenkins-ci.org':
     ip => '127.0.0.1',
   }

--- a/dist/profile/templates/apache-maintenance/maintenance.conf.erb
+++ b/dist/profile/templates/apache-maintenance/maintenance.conf.erb
@@ -1,0 +1,31 @@
+# MANAGED BY PUPPET. DO NOT MODIFY.
+# used during the maintenance outage
+<VirtualHost *:443>
+	ServerName <%= @name %>
+
+	SSLEngine On
+
+	ErrorDocument 503 /maintenance.html
+	## uncomment below to enter maintenance mode
+	RedirectMatch 503 ^/(?!maintenance)
+
+	#RewriteEngine on
+	#RewriteCond %{REQUEST_URI} !/maintenance.html$
+	#RewriteRule $ /maintenance.html [R=302,L]
+
+	DocumentRoot /var/www/maintenance
+
+	Customlog /dev/null combined
+	ErrorLog /var/log/apache2/error.log
+
+	# Possible values include: debug, info, notice, warn, error, crit,
+	# alert, emerg.
+	LogLevel warn
+
+</VirtualHost>
+<VirtualHost *:80>
+	ServerName <%= @name %>
+	Redirect temp / https://<%= @name %>/
+
+	Customlog /dev/null combined
+</VirtualHost>

--- a/spec/classes/profile/jira_spec.rb
+++ b/spec/classes/profile/jira_spec.rb
@@ -4,4 +4,6 @@ describe 'profile::jira' do
   it { should contain_class 'docker' }
   it { should contain_file '/srv/jira/home' }
   it { should contain_service('docker-jira') }
+  it { should contain_file '/var/www/maintenance/maintenance.html' }
+  it { should contain_file '/etc/apache2/sites-available/issues.jenkins-ci.org.maintenance' }
 end


### PR DESCRIPTION
During maintenance work, it's convenient to be able to put up maintenance page.

This change prepares such apache configuration file in `/etc/apache2/sites-available` so that an admin can manually put it up during maintenance.
