### PR TITLE
recurse tries to manage files in the directory.

### DIFF
--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -26,11 +26,9 @@ class profile::jira (
     ensure  => directory,
     owner   => 'jira',
     group   => 'jira',
-    recurse => true,
   }
   file { '/srv/jira/docroot':
     ensure  => directory,
-    recurse => true,
   }
 
   # JIRA stores LDAP access information in database, not in file


### PR DESCRIPTION
I thought it was for creating parent directories recursively. Ouch.
