### PR TITLE
Increasing the bandwidth of archives server

### DIFF
--- a/dist/profile/templates/archives/vhost.conf
+++ b/dist/profile/templates/archives/vhost.conf
@@ -6,10 +6,10 @@ CustomLog "|/usr/sbin/rotatelogs /var/log/apache2/archives.jenkins.org/access.lo
 # all the concurrent users will share this bandwidth pool, so if 10 people download
 # at the same time, they get tenth the bandwidth each.
 #
-# 100KB/sec constant transfer is equivalent of 260GB/month transfer.
-# At $0.12/GB, that costs about $30/month
+# 1000KB/sec constant transfer is equivalent of 2600GB/month transfer.
+# At $0.12/GB, that costs about $300/month
 
 BandwidthModule On
 ForceBandWidthModule On
-Bandwidth all 102400
+Bandwidth all 1024000
 MinBandwidth all 0


### PR DESCRIPTION
We are only using about $600/month out of the allowance from Rackspace,
so we can afford to pay $300/month for archives and still come within
the allownce.
