### PR TITLE
Codifying Datadog checker definitions from fragments

### DIFF
--- a/dist/profile/files/apache-misc/apache_check.yaml
+++ b/dist/profile/files/apache-misc/apache_check.yaml
@@ -1,0 +1,1 @@
+    -   apache_status_url: http://localhost/server-status?auto

--- a/dist/profile/files/confluence/http_check.yaml
+++ b/dist/profile/files/confluence/http_check.yaml
@@ -1,0 +1,3 @@
+  - name: Confluence
+    url: https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin
+    timeout: 1

--- a/dist/profile/files/confluence/process_check.yaml
+++ b/dist/profile/files/confluence/process_check.yaml
@@ -1,0 +1,6 @@
+  - name: Confluence
+    search_string: ['-Dcatalina.home=/srv/wiki']
+    exact_match: false
+    thresholds:
+      # expect exactly 1 instance
+      critical: [0, 1]

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -117,6 +117,16 @@ class profile::confluence (
   profile::apache-maintenance { 'wiki.jenkins-ci.org':
   }
 
+  profile::datadog_check { 'confluence-http-check':
+    checker   => 'http_check',
+    source    => 'puppet:///modules/profile/confluence/http_check.yaml',
+  }
+
+  profile::datadog_check { 'confluence-process-check':
+    checker   => 'process',
+    source    => 'puppet:///modules/profile/confluence/process_check.yaml',
+  }
+
   host { 'wiki.jenkins-ci.org':
     ip => '127.0.0.1',
   }

--- a/dist/profile/manifests/datadog_check.pp
+++ b/dist/profile/manifests/datadog_check.pp
@@ -1,0 +1,29 @@
+# Assemble fragments into datadog checker configuration files
+#
+define profile::datadog_check(
+  $checker,
+  $source    = undef,
+  $content   = undef,
+) {
+  $target ="${datadog_agent::params::conf_dir}/${checker}.yaml"
+
+  # define the header section
+  if !defined(Concat[$target]) {
+    concat { $target:
+      owner => 'root',
+      group => 'root',
+    }
+
+    concat::fragment { "${target}-header":
+      target  => $target,
+      content => "init_config:\n\ninstances:\n",
+      order   => '00',
+    }
+  }
+
+  concat::fragment { $name:
+    target  => $target,
+    source  => $source,
+    content => $content,
+  }
+}

--- a/spec/classes/profile/confluence_spec.rb
+++ b/spec/classes/profile/confluence_spec.rb
@@ -7,4 +7,6 @@ describe 'profile::confluence' do
 
   it { should contain_firewall('400 allow http').with_action('accept').with_port(80) }
   it { should contain_firewall('401 allow https').with_action('accept').with_port(443) }
+
+  it { should contain_file '/etc/dd-agent/conf.d/http_check.yaml' }
 end


### PR DESCRIPTION
This allows us to compose `http_check.yaml` from various classes.
