### PR TITLE
Fixing puppet failures

### DIFF
--- a/dist/profile/manifests/accounts.pp
+++ b/dist/profile/manifests/accounts.pp
@@ -2,6 +2,10 @@
 # Profile defining all the `account` resources with all our important account
 # information
 class profile::accounts {
+  group { 'atlassian-admins':
+    ensure => present,
+  }
+
   $accounts = hiera_hash('accounts')
   create_resources('account', $accounts)
 }

--- a/dist/profile/manifests/atlassian.pp
+++ b/dist/profile/manifests/atlassian.pp
@@ -15,7 +15,7 @@ class profile::atlassian {
   apache::mod { 'proxy_http':
   }
 
-  sudo::conf { $group_name:
+  sudo::conf { 'atlassian-admins':
     priority => 10,
     content  => "%atlassian-admins ALL=(ALL) NOPASSWD: /usr/sbin/service",
     require  => Group[$group_name],

--- a/dist/profile/manifests/atlassian.pp
+++ b/dist/profile/manifests/atlassian.pp
@@ -9,21 +9,15 @@ class profile::atlassian {
   include profile::docker
   include sudo
 
-  $group_name = 'atlassian-admins'
-
   apache::mod { 'proxy':
   }
 
   apache::mod { 'proxy_http':
   }
 
-  group { $group_name:
-    ensure => present,
-  }
-
   sudo::conf { $group_name:
     priority => 10,
-    content  => "%${group_name} ALL=(ALL) NOPASSWD: /usr/sbin/service",
+    content  => "%atlassian-admins ALL=(ALL) NOPASSWD: /usr/sbin/service",
     require  => Group[$group_name],
   }
 }

--- a/dist/profile/manifests/atlassian.pp
+++ b/dist/profile/manifests/atlassian.pp
@@ -9,15 +9,17 @@ class profile::atlassian {
   include profile::docker
   include sudo
 
+  $group_name = 'atlassian-admins'
+
   apache::mod { 'proxy':
   }
 
   apache::mod { 'proxy_http':
   }
 
-  sudo::conf { 'atlassian-admins':
+  sudo::conf { $group_name:
     priority => 10,
-    content  => "%atlassian-admins ALL=(ALL) NOPASSWD: /usr/sbin/service",
+    content  => "%${group_name} ALL=(ALL) NOPASSWD: /usr/sbin/service",
     require  => Group[$group_name],
   }
 }

--- a/spec/classes/profile/accounts_spec.rb
+++ b/spec/classes/profile/accounts_spec.rb
@@ -4,4 +4,6 @@ describe 'profile::accounts' do
   it { should contain_account 'tyler' }
   it { should contain_account 'kohsuke' }
   it { should contain_account 'abayer' }
+
+  it { should contain_group('atlassian-admins') }
 end

--- a/spec/classes/profile/atlassian_spec.rb
+++ b/spec/classes/profile/atlassian_spec.rb
@@ -10,8 +10,6 @@ describe 'profile::atlassian' do
   end
 
   context 'atlassian sudo specifics' do
-    it { should contain_group('atlassian-admins') }
-
     it { should contain_sudo__conf 'atlassian-admins' }
   end
 


### PR DESCRIPTION
Accounts are created on every machine, so atlassian-admins group must
also exist everywhere, too.
