### PR TITLE
Make new servers automatically assume the default role,

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -28,6 +28,7 @@ File { backup => 'main' }
 # specified in the console for that node.
 
 node default {
+  include profile::base
 }
 
 


### PR DESCRIPTION
for example so that you can login as you.

Otherwise you cannot get in until you explicitly create a new class for the server.
