### PR TITLE
Upgrade the pe_gem provider moduel to the pe_puppetmaster_gem provider

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -73,6 +73,9 @@ fixtures:
     datadog_agent:
       repo: 'datadog/datadog_agent'
       ref: '1.4.0'
+    pe_puppetserver_gem:
+      repo: 'puppetlabs/pe_puppetserver_gem'
+      ref: '0.0.1'
 
 
 # Setting up a couple of symlinks to make it easier to treat profiles and roles

--- a/Puppetfile
+++ b/Puppetfile
@@ -13,7 +13,7 @@ mod "stdlib",
 
 mod 'puppetlabs/ruby', '0.2.0'
 mod "puppetlabs/gcc", '0.2.0'
-mod "puppetlabs/pe_gem", '0.0.1'
+mod "puppetlabs/pe_puppetserver_gem", '0.0.1'
 mod "puppetlabs/inifile", '1.0.3'
 mod "puppetlabs/vcsrepo", '1.1.0'
 mod "puppetlabs/git", '0.2.0'

--- a/spec/classes/profile/puppetmaster_spec.rb
+++ b/spec/classes/profile/puppetmaster_spec.rb
@@ -9,9 +9,27 @@ describe 'profile::puppetmaster' do
 
   it { should contain_file('/etc/puppetlabs/puppet/hiera.yaml') }
   it { should contain_class 'jenkins_keys' }
-  it { should contain_class 'irc' }
   it { should contain_firewall('010 allow dashboard traffic').with_action('accept').with_port(443) }
   it { should contain_firewall('011 allow r10k webhooks').with_action('accept').with_port(9013) }
   it { should contain_firewall('012 allow puppet agents').with_action('accept').with_port(8140) }
   it { should contain_firewall('013 allow mcollective').with_action('accept').with_port(61613) }
+
+  context 'setting up the irc reporter' do
+    let(:facts) do
+      {
+        :is_pe => true,
+        :pe_version => '3.7.2',
+      }
+    end
+    it { should contain_class 'irc' }
+
+    context 'the puppet-irc module' do
+      # https://issues.jenkins-ci.org/browse/INFRA-502
+      it 'should use the appropriate $gem_provider' do
+        expect(subject).to contain_package('carrier-pigeon').with({
+          :provider => 'pe_puppetserver_gem',
+        })
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes INFRA-502

It appears that this module
(https://github.com/puppetlabs/puppetlabs-puppetserver_gem) is what should be
ultimately be used but it appears that under PE 3.7.2 (from my observations)
the $pe_server_version fact is not being implemented which means this branch
won't execute properly:
    https://github.com/jenkins-infra/puppet-irc/blob/0238cfd785442e90c473e67de24ed244ccdc90f1/manifests/params.pp#L18
