### PR TITLE
Make both the pe_gem and pe_puppetserver_gem present.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -14,6 +14,7 @@ mod "stdlib",
 mod 'puppetlabs/ruby', '0.2.0'
 mod "puppetlabs/gcc", '0.2.0'
 mod "puppetlabs/pe_puppetserver_gem", '0.0.1'
+mod "puppetlabs/pe_gem", '0.0.1'
 mod "puppetlabs/inifile", '1.0.3'
 mod "puppetlabs/vcsrepo", '1.1.0'
 mod "puppetlabs/git", '0.2.0'


### PR DESCRIPTION
There are still some old modules that need to the `pe_gem` provider to be
installed. All of this will become easier in the next PE server upgrade

References INFRA-502
