### PR TITLE
Re-introduce eggplant into the managed Jenkins infrastructure

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -18,8 +18,8 @@ fixtures:
     docker:
       repo: 'git://github.com/jenkins-infra/garethr-docker.git'
       ref: '864450c'
-    apache-logcompressor:
-      repo: 'git://github.com/jenkins-infra/puppet-apache-logcompressor.git'
+    apachelogcompressor:
+      repo: 'git://github.com/jenkins-infra/puppet-apachelogcompressor.git'
 
   forge_modules:
     stdlib:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ gem 'parallel_tests'
 # Needed for integration tests
 gem 'beaker'
 # This gem is like, never released
-gem 'puppet-lint', :github => 'rodjek/puppet-lint', :ref => '2546fed6be894bbcff15c3f48d4b6f6bc15d94d1'
+gem 'puppet-lint', :github => 'rodjek/puppet-lint',
+                   :ref => '2546fed6be894bbcff15c3f48d4b6f6bc15d94d1'
 gem 'puppet', '~> 3.4.0'
 # Needed to make sure we can install modules and then run a `puppet apply` in
 # vagrant

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
+    addressable (2.4.0)
     autoparse (0.3.3)
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
@@ -25,7 +25,7 @@ GEM
     aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    beaker (2.28.0)
+    beaker (2.30.1)
       aws-sdk (~> 1.57)
       beaker-answers (~> 0.0)
       beaker-hiera (~> 0.0)
@@ -37,6 +37,7 @@ GEM
       hocon (~> 0.1)
       inifile (~> 2.0)
       json (~> 1.8)
+      mime-types (~> 2.99)
       minitest (~> 5.4)
       net-scp (~> 1.2)
       net-ssh (~> 2.9)
@@ -51,7 +52,7 @@ GEM
     beaker-hiera (0.1.1)
       stringify-hash (~> 0.0.0)
     builder (3.2.2)
-    byebug (8.2.0)
+    byebug (8.2.1)
     coderay (1.1.0)
     colored (1.2)
     columnize (0.9.0)
@@ -67,7 +68,7 @@ GEM
       pry (>= 0.9.9)
     debugger-ruby_core_source (1.3.8)
     diff-lcs (1.2.5)
-    docker-api (1.23.0)
+    docker-api (1.24.1)
       excon (>= 0.38.0)
       json
     excon (0.45.4)
@@ -114,17 +115,14 @@ GEM
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.9.0)
+    fog-brightbox (0.10.1)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.32.1)
+    fog-core (1.35.0)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
-      mime-types
-      net-scp (~> 1.1)
-      net-ssh (>= 2.1.3)
     fog-dynect (0.0.2)
       fog-core
       fog-json
@@ -157,7 +155,7 @@ GEM
       fog-core
       fog-json
       fog-xml
-    fog-sakuracloud (1.3.3)
+    fog-sakuracloud (1.5.0)
       fog-core
       fog-json
     fog-serverlove (0.1.2)
@@ -221,13 +219,13 @@ GEM
     logging (2.0.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    memoist (0.12.0)
+    memoist (0.13.0)
     metaclass (0.0.4)
     method_source (0.8.2)
-    mime-types (2.6.2)
-    mini_portile (0.6.2)
+    mime-types (2.99)
+    mini_portile2 (2.0.0)
     minitar (0.5.4)
-    minitest (5.8.2)
+    minitest (5.8.3)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
@@ -236,11 +234,11 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
     net-telnet (0.1.1)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
     open_uri_redirections (0.2.1)
     parallel (1.6.1)
-    parallel_tests (1.9.0)
+    parallel_tests (2.2.1)
       parallel
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -286,7 +284,7 @@ GEM
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.0)
+    rspec-core (3.4.1)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -299,7 +297,7 @@ GEM
       rspec-support (~> 3.4.0)
     rspec-puppet (2.2.0)
       rspec
-    rspec-support (3.4.0)
+    rspec-support (3.4.1)
     rsync (1.0.9)
     semantic_puppet (0.1.1)
     serverspec (2.24.3)
@@ -308,14 +306,13 @@ GEM
       rspec-its
       specinfra (~> 2.43)
     sfl (2.2)
-    signet (0.6.1)
+    signet (0.7.0)
       addressable (~> 2.3)
-      extlib (~> 0.9)
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
     slop (3.6.0)
-    specinfra (2.44.1)
+    specinfra (2.44.7)
       net-scp
       net-ssh (~> 2.7)
       net-telnet
@@ -347,3 +344,6 @@ DEPENDENCIES
   rake
   rspec-puppet
   serverspec
+
+BUNDLED WITH
+   1.10.6

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,62 @@
+/*
+ * This is a multibranch workflow file for defining how this project should be
+ * built, tested and deployed
+ */
+
+def nodeLabel = 'docker'
+
+node(nodeLabel) {
+    stage 'Clean workspace'
+    /* Running on a fresh Docker instance makes this redundant, but just in
+     * case the host isn't configured to give us a new Docker image for every
+     * build, make sure we clean things before we do anything
+     */
+    deleteDir()
+
+
+    stage 'Checkout source'
+    /*
+     * Represents the SCM configuration in a "Workflow from SCM" project build. Use checkout
+     * scm to check out sources matching Jenkinsfile with the SCM details from
+     * the build that is executing this Jenkinsfile.
+     *
+     * when not in multibranch: https://issues.jenkins-ci.org/browse/JENKINS-31386
+     */
+    checkout scm
+
+
+    stage 'Prepare Ruby'
+    /* if we can't install everything we need for Ruby in less than 15 minutes
+     * we might as well just give up
+     */
+    timeout(15) {
+        sh 'gem install bundler -N --verbose'
+        sh 'mkdir -p vendor/gems'
+        sh 'bundle install --verbose --without development --path=vendor/gems'
+    }
+    /* stashing our install gems directory so we can re-use it for
+     * parallelization of tasks later
+     */
+    stash includes: 'vendor/gems', name: 'gems'
+
+
+    /* Executing some sub-workflows in parallel */
+    parallel(
+        linting: {
+            node(nodeLabel) {
+                unstash 'gems'
+                sh 'ls'
+            }
+        },
+        rspec: {
+            node(nodeLabel) {
+                unstash 'gems'
+                sh 'ls'
+
+            }
+        },
+        failFast: true)
+}
+
+
+// vim: ft=groovy

--- a/Puppetfile
+++ b/Puppetfile
@@ -53,7 +53,7 @@ mod 'account', :git => 'git://github.com/jenkins-infra/puppet-account.git',
                :ref => '03280b8'
 
 mod 'jenkins_keys',
-  :git => 'git@github.com:jenkinsci-cert/jenkins-keys.git',
+  :git => 'git@github.com:jenkins-infra/jenkins-keys.git',
   :ref => 'bfc2222'
 
 # Apache and its dependencies

--- a/Puppetfile
+++ b/Puppetfile
@@ -59,7 +59,10 @@ mod 'jenkins_keys',
 # Apache and its dependencies
 mod "puppetlabs/apache", '1.1.1'
 # Used internally to gzip compress rotated logs
-mod 'apache-logcompressor', :git => 'git://github.com/jenkins-infra/puppet-apache-logcompressor.git'
+mod 'apachelogcompressor',
+        :git => 'git://github.com/jenkins-infra/puppet-apachelogcompressor.git',
+        :ref => '0113d7b'
+
 mod "puppetlabs/concat", '1.0.4'
 
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ infrastructure.
 
 ## Local development
 
-The amount of testing that can be done locally is still a **work in progress**
-but thus far it's advisable that you do the following:
+The amount of testing that can be done locally is as follows:
 
  * `bundle install` - To get the necessary gems to run tests locally, if you're
    unfamiliar with Ruby development you may want to use [RVM](http://rvm.io/)
@@ -39,13 +38,18 @@ but thus far it's advisable that you do the following:
 
 We're using [serverspec](http://serverspec.org) for on-machine acceptance
 testing. Combined with Vagrant, this allows us to create an acceptance test
-[per-role](dist/role/manifests) which
-provisions and tests an entire Puppet catalog on a VM.
+[per-role](dist/role/manifests) which provisions and tests an entire Puppet
+catalog on a VM.
 
-To launch a test instance, `./vagrant-aws up ROLE` where `ROLE` is [one of the defined roles](dist/role/manifests).
-You can rerun puppet and execute tests with `./vagrant-aws provision ROLE` repeatedly while the VM is up and running.
-To just rerun serverspect without puppet, `./vagrant-aws provision --provision-with serverspec ROLE`.
-When it's all done, deprovision the instance via `./vagrant-aws destroy ROLE`.
+##### Pre-requisites
+
+* Install [Vagrant](https://www.vagrantup.com)
+* Install Vagrant plugins: `vagrant plugin install vagrant-aws  vagrant-serverspec`
+
+To launch a test instance, `vagrant up ROLE` where `ROLE` is [one of the defined roles](dist/role/manifests).
+You can rerun puppet and execute tests with `vagrant provision ROLE` repeatedly while the VM is up and running.
+To just rerun serverspect without puppet, `vagrant provision --provision-with serverspec ROLE`.
+When it's all done, deprovision the instance via `vagrant destroy ROLE`.
 
 ### Updating dependencies
 For reasons that Tyler will hopefully clarify at some point, this module maintains
@@ -85,7 +89,9 @@ to production, it will be automatically deployed to production hosts.
 
 ## Installing agents
 
-For installing agents refer to the [installing agents](http://docs.puppetlabs.com/pe/latest/install_agents.html) section of the PuppetLabs documentation.
+For installing agents refer to the [installing
+agents](http://docs.puppetlabs.com/pe/latest/install_agents.html) section of
+the PuppetLabs documentation.
 
 ## Contributing
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure("2") do |config|
     # Labs apt repository, with a Docker capable (3.8) Linux kernel
     aws.ami = 'ami-69db9b59'
     aws.region = 'us-west-2'
-    aws.instance_type = 'm1.large'
+    aws.instance_type = 'm3.medium'
 
     override.ssh.username = "ubuntu"
     override.ssh.private_key_path = File.expand_path('~/.ssh/id_rsa')

--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -32,6 +32,7 @@ edamame     3600    IN    A    140.211.9.2       ; otherwise known as jenkins-co
 lists       3600    IN    A    140.211.166.34
 ns1         3600    IN    A    140.211.9.2 ; edamame
 ns2         3600    IN    A    173.203.60.151 ; spinach (Rackspace)
+ns3         3600    IN    A    162.209.106.32 ; okra (Rackspace)
 
 
 ;-----------------------------------
@@ -84,6 +85,7 @@ lists      3600    IN    MX    0    smtp4.osuosl.org.
 ; NS Records
 @           3600    IN    NS    ns1
 @           3600    IN    NS    ns2
+@           3600    IN    NS    ns3
 
 ; SPF
 ;   this policy enables the e-mail originating from these hosts to be whitelisted.

--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -13,9 +13,7 @@ JENKINS-CI.ORG.    3600    IN    SOA    ns1.jenkins-ci.org. tyler.monkeypox.org.
 @           3600    IN    A    199.193.196.24
 
 ; Primary at Contegix
-cucumber     3600    IN    A    199.193.196.24
-; Primary at Contegix' new datacenter
-gherkin     3600    IN    A    199.193.196.24
+cucumber    3600    IN    A    199.193.196.24
 
 ; VM at Rackspace
 spinach     3600    IN    A    173.203.60.151
@@ -40,25 +38,26 @@ ns3         3600    IN    A    162.209.106.32 ; okra (Rackspace)
 ; CNAME Records
 www         3600    IN    CNAME    @
 issues      3600    IN    CNAME    edamame
+gherkin     3600    IN    CNAME    cucumber
 wiki        3600    IN    CNAME    lettuce
-updates     3600    IN    CNAME    gherkin
-downloads   3600    IN    CNAME    gherkin
-fisheye     3600    IN    CNAME    gherkin
-l10n        3600    IN    CNAME    gherkin
-javadoc     3600    IN    CNAME    gherkin
-mirrors     3600    IN    CNAME    gherkin
-pkg         3600    IN    CNAME    gherkin
-usage       3600    IN    CNAME    gherkin
-stacktrace  3600    IN    CNAME    gherkin
-sorcerer    3600    IN    CNAME    gherkin
-stats       3600    IN    CNAME    gherkin
-maven       3600    IN    CNAME    gherkin
-maven2      3600    IN    CNAME    gherkin
-ci          3600    IN    CNAME    gherkin
-svn         3600    IN    CNAME    gherkin
+updates     3600    IN    CNAME    cucumber
+downloads   3600    IN    CNAME    cucumber
+fisheye     3600    IN    CNAME    cucumber
+l10n        3600    IN    CNAME    cucumber
+javadoc     3600    IN    CNAME    cucumber
+mirrors     3600    IN    CNAME    cucumber
+pkg         3600    IN    CNAME    cucumber
+usage       3600    IN    CNAME    cucumber
+stacktrace  3600    IN    CNAME    cucumber
+sorcerer    3600    IN    CNAME    cucumber
+stats       3600    IN    CNAME    cucumber
+maven       3600    IN    CNAME    cucumber
+maven2      3600    IN    CNAME    cucumber
+ci          3600    IN    CNAME    cucumber
+svn         3600    IN    CNAME    cucumber
 meetings    3600    IN    CNAME    edamame
-javanet2    3600    IN    CNAME    gherkin
-ldap        3600    IN    CNAME    gherkin
+javanet2    3600    IN    CNAME    cucumber
+ldap        3600    IN    CNAME    cucumber
 jekyll      3600    IN    CNAME    jenkinsci.github.io
 git         3600    IN    CNAME    spinach
 boxes       3600    IN    CNAME    spinach

--- a/dist/profile/files/bind/named.conf.local
+++ b/dist/profile/files/bind/named.conf.local
@@ -1,4 +1,5 @@
 zone "jenkins-ci.org" {
   type master;
   file "/etc/bind/local/jenkins-ci.org.zone";
+  allow-transfer { 140.211.166.126; };
 };

--- a/dist/profile/manifests/apache-misc.pp
+++ b/dist/profile/manifests/apache-misc.pp
@@ -6,7 +6,7 @@ class profile::apache-misc(
 ) {
   include apache
   # log rotation setting lives in another module
-  include apache-logcompressor
+  include apachelogcompressor
 
   # enable mod_status for local interface and allow datadog to monitor this
   include apache::mod::status

--- a/dist/role/manifests/edamame.pp
+++ b/dist/role/manifests/edamame.pp
@@ -1,5 +1,5 @@
 #
-# Edamame is a VM with 2x CPUs and 2GB of RAM at the OSUOSL
+# Edamame is a VM with 2x CPUs and 4GB of RAM at the OSUOSL
 class role::edamame {
   include profile::base
   include profile::robobutler

--- a/dist/role/manifests/eggplant.pp
+++ b/dist/role/manifests/eggplant.pp
@@ -1,0 +1,6 @@
+#
+# Eggplant is a VM with 2vCPUs and 2GB RAM at the OSUOSL
+class role::eggplant {
+  include profile::base
+  include profile::sudo::osu
+}

--- a/dist/role/manifests/eggplant.pp
+++ b/dist/role/manifests/eggplant.pp
@@ -3,4 +3,5 @@
 class role::eggplant {
   include profile::base
   include profile::sudo::osu
+  include profile::apache-misc
 }

--- a/dist/role/manifests/lettuce.pp
+++ b/dist/role/manifests/lettuce.pp
@@ -1,5 +1,5 @@
 #
-# Lettuce is a 2vCPU/4GB KVM-based VM at the OSUOSL
+# Lettuce is a 2vCPU/8GB KVM-based VM at the OSUOSL
 class role::lettuce {
   include profile::base
   include profile::sudo::osu

--- a/dist/role/manifests/okra.pp
+++ b/dist/role/manifests/okra.pp
@@ -3,4 +3,5 @@
 class role::okra {
   include profile::base
   include profile::archives
+  include profile::bind
 }

--- a/dist/role/manifests/okra.pp
+++ b/dist/role/manifests/okra.pp
@@ -1,5 +1,5 @@
 #
-# Okra is a tiny VM on Rackspace
+# Okra is a tiny VM (1vCPU/4GB RAM) on Rackspace
 class role::okra {
   include profile::base
   include profile::archives

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -66,3 +66,8 @@ node 'okra' {
 node 'cabbage' {
   include role::cabbage
 }
+
+# eggplant
+node 'eggplant.jenkins-ci.org' {
+  include role::eggplant
+}

--- a/spec/classes/profile/apache_misc_spec.rb
+++ b/spec/classes/profile/apache_misc_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
+
 describe 'profile::apache-misc' do
   shared_examples 'apache-misc' do
     it { should contain_class 'apache' }
-    it { should contain_class 'apache-logcompressor' }
+    it { should contain_class 'apachelogcompressor' }
 
     it { should contain_file '/etc/apache2/conf.d/00-reverseproxy_combined' }
     it { should contain_file '/etc/apache2/conf.d/other-vhosts-access-log' }

--- a/spec/classes/role/eggplant_spec.rb
+++ b/spec/classes/role/eggplant_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'role::eggplant' do
+  it_should_behave_like 'a standard role'
+
+  it { should contain_class 'profile::sudo::osu' }
+end

--- a/spec/classes/role/eggplant_spec.rb
+++ b/spec/classes/role/eggplant_spec.rb
@@ -3,5 +3,6 @@ require 'spec_helper'
 describe 'role::eggplant' do
   it_should_behave_like 'a standard role'
 
+  it { should contain_class 'profile::apache-misc' }
   it { should contain_class 'profile::sudo::osu' }
 end

--- a/spec/classes/role/okra_spec.rb
+++ b/spec/classes/role/okra_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'role::okra' do
+  it_should_behave_like 'a standard role'
+
+  it { should contain_class 'profile::archives' }
+  it { should contain_class 'profile::bind' }
+end

--- a/spec/server/eggplant/eggplant_spec.rb
+++ b/spec/server/eggplant/eggplant_spec.rb
@@ -1,0 +1,5 @@
+require_relative './../spec_helper'
+
+describe 'eggplant' do
+  it_behaves_like "an OSU hosted machine"
+end

--- a/spec/server/okra/okra_spec.rb
+++ b/spec/server/okra/okra_spec.rb
@@ -4,8 +4,8 @@ describe 'okra' do
   it_behaves_like "a standard Linux machine"
 
   describe service('apache2') do
-    it { should be_enabled   }
-    it { should be_running   }
+    it { should be_enabled }
+    it { should be_running }
   end
 
   describe port(80) do

--- a/spec/server/puppetmaster/puppetmaster_spec.rb
+++ b/spec/server/puppetmaster/puppetmaster_spec.rb
@@ -1,0 +1,5 @@
+require_relative './../spec_helper'
+
+describe 'puppetmaster' do
+  it_behaves_like "a standard Linux machine"
+end

--- a/spec/server/spec_helper.rb
+++ b/spec/server/spec_helper.rb
@@ -1,13 +1,9 @@
-require_relative './../spec_helper'
-
 # Server spec requirements!
 require 'serverspec'
 require 'pathname'
 require 'net/ssh'
-# Including these at a top level to make sure we have some methods for our DSL
-# that we need for server spec
-include SpecInfra::Helper::Ssh
-include SpecInfra::Helper::DetectOS
+
+set :backend, :ssh
 
 # Load all our helpful support files
 support_dir = File.expand_path(File.dirname(__FILE__) + '/support')

--- a/spec/server/support/basic_shared_contexts.rb
+++ b/spec/server/support/basic_shared_contexts.rb
@@ -33,7 +33,7 @@ shared_examples "an OSU hosted machine" do
 
   # Ensure that we have the sudoers file for `osuadmin`
   describe command('ls /etc/sudoers.d') do
-    it { should return_exit_status 0 }
+    its(:exit_status) { should eq 0 }
     its(:stdout) { should match /osuadmin/ }
   end
 end

--- a/vagrant-aws
+++ b/vagrant-aws
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-export VAGRANT_DEFAULT_PROVIDER=aws
-
-exec bundle exec vagrant $@


### PR DESCRIPTION
This deployment also has some DNS improvements:
- Enable okra.jenkins-ci.org to act as ns3.jenkins-ci.org
- Enable oak.osuosl.org to slave off our zone

This also cleans up some of the development environment
