### PR TITLE
Properly provision the keepalive setting for Apache

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -64,7 +64,7 @@ ntp::autoupdate: true
 ntp::servers:
   - pool.ntp.org iburst
 
-apache::keepalive: On
+apache::keepalive: 'On'
 apache::keepalive_timeout: 3
 
 ### Stuff for IRC jenkins-admin bot


### PR DESCRIPTION
This has been causing eggplant provisioning to fail because it's using a newer
version of Apache, which properly fails `apachectl configtest` on an invalid
value for KeepAlive (2.4) whereas the previous version (2.2) gleefully ignored
it.

```
tyler@eggplant:~$ apachectl -v
Server version: Apache/2.4.7 (Ubuntu)
Server built:   Oct 14 2015 14:20:21
tyler@eggplant:~$ ^C
tyler@eggplant:~$ apachectl -v
Server version: Apache/2.4.7 (Ubuntu)
Server built:   Oct 14 2015 14:20:21
tyler@eggplant:~$ apachectl configtest
AH00526: Syntax error on line 10 of /etc/apache2/apache2.conf:
KeepAlive must be On or Off
Action 'configtest' failed.
The Apache error log may have more information.

tyler@edamame:~$ apachectl -v
/usr/sbin/apachectl: 87: ulimit: error setting limit (Operation not permitted)
Server version: Apache/2.2.22 (Ubuntu)
Server built:   Mar 19 2014 21:11:15
tyler@edamame:~$ apachectl configtest
/usr/sbin/apachectl: 87: ulimit: error setting limit (Operation not permitted)
Warning: DocumentRoot [/srv/jira/docroot] does not exist
Warning: DocumentRoot [/srv/jira/docroot] does not exist
Syntax OK
```

Turns out this is a subtle, cute, behavior from hiera detailed in https://tickets.puppetlabs.com/browse/MODULES-2147

```
This is because when Hieradata gets interpolated, it interprets the words
'on', 'yes', 'no', 'off' into booleans.
```
