### PR TITLE
Use the appropriate user for the reports from datadog

### DIFF
--- a/hieradata/clients/jenkins-puppet.osuosl.org.yaml
+++ b/hieradata/clients/jenkins-puppet.osuosl.org.yaml
@@ -1,2 +1,3 @@
 ---
 datadog_agent::puppet_run_reports: true
+datadog_agent::puppetmaster_user: 'pe-puppet'


### PR DESCRIPTION
`puppet` doesn't exist in a PE setup, the user is `pe-puppet` instead
