### PR TITLE
Add a role for cucumber which will allow it to run the puppet agent

### DIFF
--- a/dist/role/manifests/cucumber.pp
+++ b/dist/role/manifests/cucumber.pp
@@ -1,0 +1,4 @@
+#
+# Cucumber is an old machine based in a Contegix datacenter
+class role::cucumber {
+}

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -71,3 +71,8 @@ node 'cabbage' {
 node 'eggplant.jenkins-ci.org' {
   include role::eggplant
 }
+
+# cucumber (legacy host)
+node 'cucumber' {
+  include role::cucumber
+}

--- a/spec/classes/role/cucumber_spec.rb
+++ b/spec/classes/role/cucumber_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'role::cucumber' do
+  it { should_not contain_class 'profile::base' }
+end

--- a/spec/server/cucumber/cucumber_spec.rb
+++ b/spec/server/cucumber/cucumber_spec.rb
@@ -1,0 +1,4 @@
+require_relative './../spec_helper'
+
+describe 'cucumber' do
+end


### PR DESCRIPTION
I'm intentionally excluding the `base` profile since that will include accounts
and all sorts of other stuff which may conflict with the old "infra-puppet"

By excluding profile::base for now, I can start to test the agent properly with
infra-puppet and all that jazz running side-by-side

References INFRA-176
