### PR TITLE
Ensure the make and build-essential packages are on all buildslaves

### DIFF
--- a/dist/profile/manifests/buildslave.pp
+++ b/dist/profile/manifests/buildslave.pp
@@ -41,6 +41,8 @@ class profile::buildslave(
       'libcurl4-openssl-dev', # for curb gem
       'libruby',              # for net/https
       'subversion',
+      'make',
+      'build-essential',
   ])
 
 

--- a/spec/classes/profile/buildslave_spec.rb
+++ b/spec/classes/profile/buildslave_spec.rb
@@ -19,6 +19,9 @@ describe 'profile::buildslave' do
     # Provided by the `git` module
     it { should contain_package 'git' }
     it { should contain_package 'subversion' }
+
+    it { should contain_package 'make' }
+    it { should contain_package 'build-essential' }
   end
 
   context 'managing a `jenkins` user' do


### PR DESCRIPTION
Contrary to my assumption these were not already present everywhere.

Fixes INFRA-544
