### PR TITLE
Ensure that the Jenkins buildslave can actually access docker

### DIFF
--- a/dist/profile/manifests/buildslave.pp
+++ b/dist/profile/manifests/buildslave.pp
@@ -12,7 +12,7 @@ class profile::buildslave(
 
   account { 'jenkins':
     home_dir => $home_dir,
-    groups   => ['jenkins'],
+    groups   => ['jenkins', 'docker'],
     ssh_keys => {
                   'cucumber' => {
                     'key' => 'AAAAB3NzaC1yc2EAAAABIwAAAQEA1l3oZpCJlFspsf6cfa7hovv6NqMB5eAn/+z4SSiaKt9Nsm22dg9xw3Et5MczH0JxHDw4Sdcre7JItecltq0sLbxK6wMEhrp67y0lMujAbcMu7qnp5ZLv9lKSxncOow42jBlzfdYoNSthoKhBtVZ/N30Q8upQQsEXNr+a5fFdj3oLGr8LSj9aRxh0o+nLLL3LPJdY/NeeOYJopj9qNxyP/8VdF2Uh9GaOglWBx1sX3wmJDmJFYvrApE4omxmIHI2nQ0gxKqMVf6M10ImgW7Rr4GJj7i1WIKFpHiRZ6B8C/Ds1PJ2otNLnQGjlp//bCflAmC3Vs7InWcB3CTYLiGnjrw==',


### PR DESCRIPTION
This is related to INFRA-544 but doesn't resolve that particular issue. When I
added `profile::docker` to the buildslave profile, I should have ensured that
the Jenkins user could actually interact with the running docker daemon
