### PR TITLE
Correct a warning in our jenkins-ci.org zonefile

### DIFF
--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -77,7 +77,7 @@ archives    3600    IN    CNAME    okra
 beta        3600    IN    CNAME    eggplant ; beta site for the jenkins-ci.org/jenkins.io site
 
 ; MX Records
-@          3600    IN    MX    0    gherkin
+@          3600    IN    MX    0    cucumber
 lists      3600    IN    MX    0    smtp1.osuosl.org.
 lists      3600    IN    MX    0    smtp2.osuosl.org.
 lists      3600    IN    MX    0    smtp3.osuosl.org.


### PR DESCRIPTION
non-fatal, but about time to fix it

```
docker run --rm -v $PWD:/data kohsuke/named-checkzone -k fail jenkins-ci.org dist/profile/files/bind/jenkins-ci.org.zone
zone jenkins-ci.org/IN: jenkins-ci.org/MX 'gherkin.jenkins-ci.org' is a CNAME (illegal)
zone jenkins-ci.org/IN: loaded serial 2011122901
```
