### PR TITLE
Include the properly scoped "root" firewall module

### DIFF
--- a/dist/profile/manifests/ldap.pp
+++ b/dist/profile/manifests/ldap.pp
@@ -2,7 +2,13 @@
 # Manage an OpenLDAP authentication service
 #
 class profile::ldap {
-  include firewall
+  # Not including profile::firewall intentionally here to avoid introducing
+  # redundant iptables rules for the same patterns but with different names
+  # between jenkins-infra and infra-puppet.
+  #
+  # If this is to be applied on any role other than cucumber, the caller should
+  # expect to include profile::firewall themselves
+  include ::firewall
   include ::datadog_agent
 
   package { 'slapd':


### PR DESCRIPTION
Noticed this failure when running in `--noop` mode on Cucumber itself since we do not have a way to test a node using both infra-puppet and jenkins-infra at the same time
