### PR TITLE
Deploy management of slapd for cucumber

### DIFF
--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -77,7 +77,7 @@ archives    3600    IN    CNAME    okra
 beta        3600    IN    CNAME    eggplant ; beta site for the jenkins-ci.org/jenkins.io site
 
 ; MX Records
-@          3600    IN    MX    0    gherkin
+@          3600    IN    MX    0    cucumber
 lists      3600    IN    MX    0    smtp1.osuosl.org.
 lists      3600    IN    MX    0    smtp2.osuosl.org.
 lists      3600    IN    MX    0    smtp3.osuosl.org.

--- a/dist/profile/files/ldap/process_check.yaml
+++ b/dist/profile/files/ldap/process_check.yaml
@@ -1,0 +1,7 @@
+  - name: LDAP
+    search_string: ['/usr/bin/slapd']
+    exact_match: false
+    thresholds:
+      # expect exactly 1 instance
+      critical: [0, 1]
+

--- a/dist/profile/files/ldap/slapd.defaults
+++ b/dist/profile/files/ldap/slapd.defaults
@@ -1,0 +1,50 @@
+# MANAGED BY PUPPET. DO NOT MODIFY
+#-----------------------------------------------------------------------
+# Location of the slapd configuration to use.  If using the cn=config
+# backend to store configuration in LDIF, set this variable to the
+# directory containing the cn=config data; otherwise set it to the location
+# of your slapd.conf file.  If empty, use the compiled-in default
+# (/etc/ldap/slapd.d).
+SLAPD_CONF=
+
+# System account to run the slapd server under. If empty the server
+# will run as root.
+SLAPD_USER="openldap"
+
+# System group to run the slapd server under. If empty the server will
+# run in the primary group of its user.
+SLAPD_GROUP="openldap"
+
+# Path to the pid file of the slapd server. If not set the init.d script
+# will try to figure it out from $SLAPD_CONF (/etc/ldap/slapd.d by
+# default)
+SLAPD_PIDFILE=
+
+# slapd normally serves ldap only on all TCP-ports 389. slapd can also
+# service requests on TCP-port 636 (ldaps) and requests via unix
+# sockets.
+# Example usage:
+# SLAPD_SERVICES="ldap://127.0.0.1:389/ ldaps:/// ldapi:///"
+# SLAPD_SERVICES="ldap:///127.0.0.1:389/ ldapi:///"
+SLAPD_SERVICES="ldap://127.0.0.1/ ldapi:/// ldaps:///"
+
+# If SLAPD_NO_START is set, the init script will not start or restart
+# slapd (but stop will still work).  Uncomment this if you are
+# starting slapd via some other means or if you don't want slapd normally
+# started at boot.
+#SLAPD_NO_START=1
+
+# If SLAPD_SENTINEL_FILE is set to path to a file and that file exists,
+# the init script will not start or restart slapd (but stop will still
+# work).  Use this for temporarily disabling startup of slapd (when doing
+# maintenance, for example, or through a configuration management system)
+# when you don't want to edit a configuration file.
+SLAPD_SENTINEL_FILE=/etc/ldap/noslapd
+
+# For Kerberos authentication (via SASL), slapd by default uses the system
+# keytab file (/etc/krb5.keytab).  To use a different keytab file,
+# uncomment this line and change the path.
+#export KRB5_KTNAME=/etc/krb5.keytab
+
+# Additional options to pass to slapd
+SLAPD_OPTIONS=""

--- a/dist/profile/manifests/ldap.pp
+++ b/dist/profile/manifests/ldap.pp
@@ -1,6 +1,8 @@
 #
 # Manage an OpenLDAP authentication service
 class profile::ldap {
+  include ::datadog_agent
+
   package { 'slapd':
     ensure => present,
   }
@@ -12,7 +14,12 @@ class profile::ldap {
   }
 
   file { '/etc/default/slapd':
-    source => "puppet:///modules/${module_name}/slapd.defaults",
+    source => 'puppet:///modules/profile/ldap/slapd.defaults',
     notify => Service[slapd],
+  }
+
+  profile::datadog_check { 'ldap-process-check':
+    checker => 'process',
+    source  => 'puppet:///modules/profile/ldap/process_check.yaml',
   }
 }

--- a/dist/profile/manifests/ldap.pp
+++ b/dist/profile/manifests/ldap.pp
@@ -1,0 +1,18 @@
+#
+# Manage an OpenLDAP authentication service
+class profile::ldap {
+  package { 'slapd':
+    ensure => present,
+  }
+
+  service { 'slapd':
+    ensure     => running,
+    hasrestart => true,
+    enable     => true,
+  }
+
+  file { '/etc/default/slapd':
+    source => "puppet:///modules/${module_name}/slapd.defaults",
+    notify => Service[slapd],
+  }
+}

--- a/dist/profile/manifests/ldap.pp
+++ b/dist/profile/manifests/ldap.pp
@@ -2,7 +2,13 @@
 # Manage an OpenLDAP authentication service
 #
 class profile::ldap {
-  include firewall
+  # Not including profile::firewall intentionally here to avoid introducing
+  # redundant iptables rules for the same patterns but with different names
+  # between jenkins-infra and infra-puppet.
+  #
+  # If this is to be applied on any role other than cucumber, the caller should
+  # expect to include profile::firewall themselves
+  include ::firewall
   include ::datadog_agent
 
   package { 'slapd':

--- a/dist/profile/manifests/ldap.pp
+++ b/dist/profile/manifests/ldap.pp
@@ -1,6 +1,8 @@
 #
 # Manage an OpenLDAP authentication service
+#
 class profile::ldap {
+  include firewall
   include ::datadog_agent
 
   package { 'slapd':
@@ -21,5 +23,49 @@ class profile::ldap {
   profile::datadog_check { 'ldap-process-check':
     checker => 'process',
     source  => 'puppet:///modules/profile/ldap/process_check.yaml',
+  }
+
+  # Legacy firewall rules from infra-puppet which are copied and
+  # pasted here so infra-puppet and jenkins-infra are not clobbering
+  # each others' firewall declarations
+  firewall { '106 accept inbound LDAPS request from hosted Artifactory by JFrog':
+    proto  => 'tcp',
+    source => '50.19.229.208',
+    port   => 636,
+    action => 'accept',
+  }
+
+  # It appears that puppetlabs-firewall doesn't understand an Array as an
+  # option for the source argument. In fact, as far as I know, iptables can
+  # only lump multiple IPs into a single rule if they're in a contiguous
+  # range, this will have to do
+  firewall { '106 accept inbound LDAPS request from hosted Artifactory by JFrog (second IP)':
+    proto  => 'tcp',
+    source => '50.16.203.43',
+    port   => 636,
+    action => 'accept',
+  }
+
+  firewall { '106 accept inbound LDAPS request from hosted Artifactory by JFrog (third IP)':
+    proto  => 'tcp',
+    source => '54.236.124.56',
+    port   => 636,
+    action => 'accept',
+  }
+
+  firewall { '106 accept inbound LDAPS request from spambot':
+    proto  => 'tcp',
+    source => 'home.kohsuke.org',
+    port   => 636,
+    action => 'accept',
+  }
+
+  # normally nobody listens on this port, but when we need to find the
+  # source IP address JFrog is using to connect us, run 'stone -d -d
+  # localhost:636 9636' and watch the log
+  firewall { '106 debugging the LDAPS connection (necessary to report source IP address)':
+    proto  => 'tcp',
+    port   => 9636,
+    action => 'accept',
   }
 }

--- a/dist/role/manifests/cucumber.pp
+++ b/dist/role/manifests/cucumber.pp
@@ -1,4 +1,5 @@
 #
 # Cucumber is an old machine based in a Contegix datacenter
 class role::cucumber {
+  include profile::ldap
 }

--- a/dist/role/manifests/cucumber.pp
+++ b/dist/role/manifests/cucumber.pp
@@ -1,5 +1,6 @@
 #
 # Cucumber is an old machine based in a Contegix datacenter
 class role::cucumber {
+  include profile::diagnostics
   include profile::ldap
 }

--- a/spec/classes/profile/ldap_spec.rb
+++ b/spec/classes/profile/ldap_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'profile::ldap' do
+  it { should contain_package 'slapd' }
+  it { should contain_service('slapd').with_ensure(:running) }
+
+  context "slapd's configuration" do
+    it 'should add a defaults file' do
+      expect(subject).to contain_file('/etc/default/slapd').with({
+        :notify => 'Service[slapd]',
+      })
+    end
+  end
+end

--- a/spec/classes/profile/ldap_spec.rb
+++ b/spec/classes/profile/ldap_spec.rb
@@ -11,4 +11,8 @@ describe 'profile::ldap' do
       })
     end
   end
+
+  context 'monitoring' do
+    it { should contain_profile__datadog_check 'ldap-process-check' }
+  end
 end

--- a/spec/classes/role/cucumber_spec.rb
+++ b/spec/classes/role/cucumber_spec.rb
@@ -2,4 +2,5 @@ require 'spec_helper'
 
 describe 'role::cucumber' do
   it { should_not contain_class 'profile::base' }
+  it { should contain_class 'profile::ldap' }
 end

--- a/spec/classes/role/cucumber_spec.rb
+++ b/spec/classes/role/cucumber_spec.rb
@@ -3,4 +3,5 @@ require 'spec_helper'
 describe 'role::cucumber' do
   it { should_not contain_class 'profile::base' }
   it { should contain_class 'profile::ldap' }
+  it { should contain_class 'profile::diagnostics' }
 end

--- a/spec/server/cucumber/cucumber_spec.rb
+++ b/spec/server/cucumber/cucumber_spec.rb
@@ -1,4 +1,18 @@
 require_relative './../spec_helper'
 
 describe 'cucumber' do
+  context 'LDAP' do
+    describe port(389) do
+      it { should be_listening }
+    end
+
+    describe port(636) do
+      it { should be_listening }
+    end
+
+    describe service('slapd') do
+      it { should be_enabled }
+      it { should be_running }
+    end
+  end
 end


### PR DESCRIPTION
I've run this with `--noop` on cucumber already for the `staging` environment with the following results:

```
cucumber% sudo puppet agent -t --noop --verbose --environment staging
 Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for cucumber
Info: Applying configuration version '1455232470'
Notice: /Stage[main]/Datadog_agent::Ubuntu/File[/etc/apt/sources.list.d/datadog.list]/mode: current_value 0644, should be 0444 (noop)
Info: /Stage[main]/Datadog_agent::Ubuntu/File[/etc/apt/sources.list.d/datadog.list]: Scheduling refresh of Exec[datadog_apt-get_update]
Notice: /Stage[main]/Datadog_agent::Ubuntu/Exec[datadog_apt-get_update]: Would have triggered 'refresh' from 1 events
Notice: /Stage[main]/Datadog_agent::Ubuntu/Package[datadog-agent]/ensure: current_value 1:5.2.2-1, should be 1:5.6.3-1 (noop)
Notice: /Stage[main]/Datadog_agent/File[/etc/dd-agent]/owner: current_value dd-agent, should be root (noop)
Notice: /Stage[main]/Datadog_agent/File[/etc/dd-agent/datadog.conf]/content: 
--- /etc/dd-agent/datadog.conf  2015-03-24 01:00:34.209833783 -0400
+++ /tmp/puppet-file20160211-29459-5odyyf   2016-02-11 18:14:39.143414631 -0500
@@ -1,16 +1,16 @@
+#
+# MANAGED BY PUPPET
+#
 [Main]

-# The host of the Datadog intake server to send Agent data to
+# The host of the Datadog intake server to send agent data to
 dd_url: https://app.datadoghq.com

 # If you need a proxy to connect to the Internet, provide the settings here
-# proxy_host: my-proxy.com
-# proxy_port: 3128
-# proxy_user: user
-# proxy_password: password
-# To be used with some proxys that return a 302 which make curl switch from POST to GET
-# See http://stackoverflow.com/questions/8156073/curl-violate-rfc-2616-10-3-2-and-switch-from-post-to-get
-# proxy_forbid_method_switch: no 
+# proxy_host:
+# proxy_port:
+# proxy_user:
+# proxy_password:

 # If you run the agent behind haproxy, you might want to set this to yes
 # skip_ssl_validation: no
@@ -21,13 +21,13 @@
 api_key: 47cc46059e53db020a4e611e6911d4c8

 # Force the hostname to whatever you want.
-#hostname: mymachine.mydomain
+# hostname:

 # Set the host's tags
 #tags: mytag0, mytag1

 # Collect AWS EC2 custom tags as agent tags
-# collect_ec2_tags: no
+collect_ec2_tags: false

 # Collect instance metadata
 # The Agent will try to collect instance metadata for EC2 and GCE instances by
@@ -35,7 +35,7 @@
 # See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
 # and https://developers.google.com/compute/docs/metadata
 # for more information
-# collect_instance_metadata: yes
+collect_instance_metadata: true

 # Set the threshold for accepting points to allow anything
 # with recent_point_threshold seconds
@@ -43,7 +43,7 @@
 #recent_point_threshold: 30

 # Use mount points instead of volumes to track disk and fs metrics
-use_mount: no
+use_mount: false

 # Change port the Agent is listening to
 # listen_port: 17123
@@ -59,25 +59,28 @@
 # that might not have an internet connection
 # For more information, please see
 # https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration
-# non_local_traffic: no
+non_local_traffic: false

 # Select the Tornado HTTP Client in the forwarder
 # Default to the simple http client
-# use_curl_http_client: False
+use_curl_http_client: false

 # The loopback address the Forwarder and Dogstatsd will bind.
 # Optional, it is mainly used when running the agent on Openshift
 # bind_host: localhost

-# If enabled the collector will capture a metric for check run times.
-# check_timings: no
+# ========================================================================== #
+# Pup configuration
+# ========================================================================== #

-# If you want to remove the 'ww' flag from ps catching the arguments of processes
-# for instance for security reasons
-# exclude_process_args: no
+# Pup is a small server that displays metric data collected by the Agent.
+# Think of it as a fancy status page or a toe dip into the world of
+# datadog. It can be connected to on the port below.

-# histogram_aggregates: max, median, avg, count
-# histogram_percentiles: 0.95
+# use_pup: no
+# pup_port: 17125
+# pup_interface: localhost
+# pup_url: http://localhost:17125

 # ========================================================================== #
 # DogStatsd configuration                                                    #
@@ -90,7 +93,7 @@
 # usage information, check out http://api.datadoghq.com

 #  Make sure your client is sending to the same port.
-# dogstatsd_port : 8125
+dogstatsd_port : 8125

 # By default dogstatsd will post aggregate metrics to the Agent (which handles
 # errors/timeouts/retries/etc). To send directly to the datadog api, set this
@@ -104,24 +107,14 @@
 ## by the dogstatsd_interval) before being sent to the server. Defaults to 'yes'
 # dogstatsd_normalize : yes

+histogram_percentiles: 0.95
+
 # If you want to forward every packet received by the dogstatsd server
 # to another statsd server, uncomment these lines.
 # WARNING: Make sure that forwarded packets are regular statsd packets and not "dogstatsd" packets,
 # as your other statsd server might not be able to handle them.
 # statsd_forward_host: address_of_own_statsd_server
-# statsd_forward_port: 8125
-
-# you may want all statsd metrics coming from this host to be namespaced
-# in some way; if so, configure your namespace here. a metric that looks
-# like `metric.name` will instead become `namespace.metric.name`
-# statsd_metric_namespace:
-
-# By default, dogstatsd supports only plain ASCII packets. However, most
-# (dog)statsd client support UTF8 by encoding packets before sending them
-# this option enables UTF8 decoding in case you need it.
-# However, it comes with a performance overhead of ~10% in the dogstatsd
-# server. This will be taken care of properly in the new gen agent core.
-# utf8_decoding: false
+statsd_forward_port: 8125

 # ========================================================================== #
 # Service-specific configuration                                             #
@@ -147,6 +140,8 @@
 # Ganglia port where gmetad is running
 #ganglia_port: 8651

+
+
 # -------------------------------------------------------------------------- #
 #  Dogstream (log file parser)
 # -------------------------------------------------------------------------- #
@@ -197,15 +192,16 @@
 # Logging
 # ========================================================================== #

-# log_level: INFO
+log_level: INFO

 # collector_log_file: /var/log/datadog/collector.log
 # forwarder_log_file: /var/log/datadog/forwarder.log
 # dogstatsd_log_file: /var/log/datadog/dogstatsd.log
+# pup_log_file:       /var/log/datadog/pup.log

 # if syslog is enabled but a host and port are not set, a local domain socket
 # connection will be attempted
 #
-# log_to_syslog: yes
+log_to_syslog: yes
 # syslog_host:
 # syslog_port:

Notice: /Stage[main]/Datadog_agent/File[/etc/dd-agent/datadog.conf]/content: current_value {md5}2e760be03b042562d096199cb05beab2, should be {md5}88f35f78e464a1de0daeafdcaae3ee9e (noop)
Notice: /Stage[main]/Datadog_agent/File[/etc/dd-agent/datadog.conf]/owner: current_value root, should be dd-agent (noop)
Notice: /Stage[main]/Datadog_agent/File[/etc/dd-agent/datadog.conf]/mode: current_value 0644, should be 0640 (noop)
Info: /Stage[main]/Datadog_agent/File[/etc/dd-agent/datadog.conf]: Scheduling refresh of Service[datadog-agent]
Info: /Stage[main]/Datadog_agent/File[/etc/dd-agent/datadog.conf]: Scheduling refresh of Service[datadog-agent]
Info: /Stage[main]/Datadog_agent/File[/etc/dd-agent/datadog.conf]: Scheduling refresh of Service[datadog-agent]
Notice: Class[Datadog_agent]: Would have triggered 'refresh' from 4 events
Notice: /Stage[main]/Firewall::Linux::Debian/Package[iptables-persistent]/ensure: current_value purged, should be present (noop)
Error: /Stage[main]/Firewall::Linux::Debian/Service[iptables-persistent]: Could not evaluate: Could not find init script or upstart conf file for 'iptables-persistent'
Notice: Class[Firewall::Linux::Debian]: Would have triggered 'refresh' from 1 events
Notice: /Stage[main]/Concat::Setup/File[/var/opt/lib/pe-puppet/concat]/ensure: current_value absent, should be directory (noop)
Notice: /Stage[main]/Concat::Setup/File[/var/opt/lib/pe-puppet/concat/bin]/ensure: current_value absent, should be directory (noop)
Notice: /Stage[main]/Concat::Setup/File[/var/opt/lib/pe-puppet/concat/bin/concatfragments.sh]/ensure: current_value absent, should be file (noop)
Notice: Class[Concat::Setup]: Would have triggered 'refresh' from 3 events
Notice: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/File[/var/opt/lib/pe-puppet/concat/_etc_dd-agent_conf.d_process.yaml]/ensure: current_value absent, should be directory (noop)
Info: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/File[/var/opt/lib/pe-puppet/concat/_etc_dd-agent_conf.d_process.yaml]: Scheduling refresh of Exec[concat_/etc/dd-agent/conf.d/process.yaml]
Notice: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/File[/var/opt/lib/pe-puppet/concat/_etc_dd-agent_conf.d_process.yaml/fragments]/ensure: current_value absent, should be directory (noop)
Info: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/File[/var/opt/lib/pe-puppet/concat/_etc_dd-agent_conf.d_process.yaml/fragments]: Scheduling refresh of Exec[concat_/etc/dd-agent/conf.d/process.yaml]
Notice: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/File[/var/opt/lib/pe-puppet/concat/_etc_dd-agent_conf.d_process.yaml/fragments.concat]/ensure: current_value absent, should be present (noop)
Notice: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/File[/var/opt/lib/pe-puppet/concat/_etc_dd-agent_conf.d_process.yaml/fragments.concat.out]/ensure: current_value absent, should be present (noop)
Notice: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat::Fragment[/etc/dd-agent/conf.d/process.yaml-header]/File[/var/opt/lib/pe-puppet/concat/_etc_dd-agent_conf.d_process.yaml/fragments/00__etc_dd-agent_conf.d_process.yaml-header]/ensure: current_value absent, should be present (noop)
Info: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat::Fragment[/etc/dd-agent/conf.d/process.yaml-header]/File[/var/opt/lib/pe-puppet/concat/_etc_dd-agent_conf.d_process.yaml/fragments/00__etc_dd-agent_conf.d_process.yaml-header]: Scheduling refresh of Exec[concat_/etc/dd-agent/conf.d/process.yaml]
Notice: Concat::Fragment[/etc/dd-agent/conf.d/process.yaml-header]: Would have triggered 'refresh' from 1 events
Notice: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat::Fragment[ldap-process-check]/File[/var/opt/lib/pe-puppet/concat/_etc_dd-agent_conf.d_process.yaml/fragments/10_ldap-process-check]/ensure: current_value absent, should be file (noop)
Info: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat::Fragment[ldap-process-check]/File[/var/opt/lib/pe-puppet/concat/_etc_dd-agent_conf.d_process.yaml/fragments/10_ldap-process-check]: Scheduling refresh of Exec[concat_/etc/dd-agent/conf.d/process.yaml]
Notice: Concat::Fragment[ldap-process-check]: Would have triggered 'refresh' from 1 events
Error: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/Exec[concat_/etc/dd-agent/conf.d/process.yaml]: Could not evaluate: Could not find command '/var/opt/lib/pe-puppet/concat/bin/concatfragments.sh'
Notice: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/Exec[concat_/etc/dd-agent/conf.d/process.yaml]: Would have triggered 'refresh' from 4 events
Info: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/Exec[concat_/etc/dd-agent/conf.d/process.yaml]: Scheduling refresh of Service[datadog-agent]
Notice: /Stage[main]/Datadog_agent::Ubuntu/Service[datadog-agent]: Dependency Exec[concat_/etc/dd-agent/conf.d/process.yaml] has failures: true
Warning: /Stage[main]/Datadog_agent::Ubuntu/Service[datadog-agent]: Skipping because of failed dependencies
Notice: /Stage[main]/Datadog_agent::Ubuntu/Service[datadog-agent]: Would have triggered 'refresh' from 4 events
Notice: Class[Datadog_agent::Ubuntu]: Would have triggered 'refresh' from 4 events
Notice: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/File[/etc/dd-agent/conf.d/process.yaml]: Dependency Exec[concat_/etc/dd-agent/conf.d/process.yaml] has failures: true
Warning: /Stage[main]/Profile::Ldap/Profile::Datadog_check[ldap-process-check]/Concat[/etc/dd-agent/conf.d/process.yaml]/File[/etc/dd-agent/conf.d/process.yaml]: Skipping because of failed dependencies
Notice: Concat[/etc/dd-agent/conf.d/process.yaml]: Would have triggered 'refresh' from 5 events
Notice: Profile::Datadog_check[ldap-process-check]: Would have triggered 'refresh' from 3 events
Notice: Class[Profile::Ldap]: Would have triggered 'refresh' from 1 events
Notice: Stage[main]: Would have triggered 'refresh' from 5 events
Notice: Finished catalog run in 5.18 seconds
```

The files being changed on disk look benign and the errors in the no-op run have to do with the scripts on disk for puppetlabs/concat not having been installed before. This looks safe to me for production :facepunch: 
