### PR TITLE
Expand the list of commands atlassian-admins can touch to /usr/bin/docker

### DIFF
--- a/dist/profile/manifests/atlassian.pp
+++ b/dist/profile/manifests/atlassian.pp
@@ -19,7 +19,7 @@ class profile::atlassian {
 
   sudo::conf { $group_name:
     priority => 10,
-    content  => "%${group_name} ALL=(ALL) NOPASSWD: /usr/sbin/service",
+    content  => "%${group_name} ALL=(ALL) NOPASSWD: /usr/sbin/service,/usr/bin/docker",
     require  => Group[$group_name],
   }
 }


### PR DESCRIPTION
This should ensure that atlassian-admins can inspect and interact with the
containers running atlassian services
