### PR TITLE
Create a new profile for managing a Jenkins master

### DIFF
--- a/dist/profile/manifests/jenkins.pp
+++ b/dist/profile/manifests/jenkins.pp
@@ -1,0 +1,31 @@
+#
+# Profile for managing a Jenkins master installation
+class profile::jenkins {
+  include firewall
+
+  # This is a legacy role imported from infra-puppet, thus the goofy numbering
+  firewall { '108 Jenkins CLI port' :
+    proto  => 'tcp',
+    port   => 47278,
+    action => 'accept',
+  }
+
+  firewall { '801 Allow Jenkins web access only on localhost':
+    proto   => 'tcp',
+    port    => 8080,
+    action  => 'accept',
+    iniface => 'lo',
+  }
+
+  firewall { '802 Block external Jenkins web access':
+    proto  => 'tcp',
+    port   => 8080,
+    action => 'drop',
+  }
+
+  firewall { '810 Jenkins CLI SSH':
+    proto  => 'tcp',
+    port   => 22222,
+    action => 'accept',
+  }
+}

--- a/dist/role/manifests/cucumber.pp
+++ b/dist/role/manifests/cucumber.pp
@@ -3,4 +3,5 @@
 class role::cucumber {
   include profile::diagnostics
   include profile::ldap
+  include profile::jenkins
 }

--- a/spec/classes/profile/jenkins_spec.rb
+++ b/spec/classes/profile/jenkins_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'profile::jenkins' do
+  context 'firewall rules' do
+    it { should contain_class 'profile::firewall' }
+
+    it 'should have a CLI port rule' do
+      expect(subject).to contain_firewall('108 Jenkins CLI port').with({
+        :port => 47278,
+        :action => :accept,
+      })
+    end
+
+    it 'should ensure nothing talks directly to Jenkins' do
+      expect(subject).to contain_firewall('801 Allow Jenkins web access only on localhost').with({
+        :port => 8080,
+        :action => :accept,
+        :iniface => 'lo',
+      })
+
+      expect(subject).to contain_firewall('802 Block external Jenkins web access').with({
+        :port => 8080,
+        :action => :drop,
+      })
+
+    end
+
+    it 'should allow CLI SSH on 22222' do
+      expect(subject).to contain_firewall('810 Jenkins CLI SSH').with({
+        :port => 22222,
+        :action => :accept,
+      })
+    end
+  end
+end

--- a/spec/classes/role/cucumber_spec.rb
+++ b/spec/classes/role/cucumber_spec.rb
@@ -4,4 +4,6 @@ describe 'role::cucumber' do
   it { should_not contain_class 'profile::base' }
   it { should contain_class 'profile::ldap' }
   it { should contain_class 'profile::diagnostics' }
+
+  it { should contain_class 'profile::jenkins' }
 end


### PR DESCRIPTION
Right now this will obviously only be applied to Cucumber, but hopefully this
allows us to get to the point where we can migrate ci.j.o off that host
entirely

Fixes [INFRA-600](https://issues.jenkins-ci.org/browse/INFRA-600)
