### PR TITLE
Use a better worker module for Apache when serving the static site

### DIFF
--- a/dist/profile/manifests/staticsite.pp
+++ b/dist/profile/manifests/staticsite.pp
@@ -8,7 +8,14 @@ class profile::staticsite(
   $deployer_user = 'site-deployer',
   $deployer_ssh_key = undef,
 ) {
-  include apache
+
+  # Debian defaults to the 'worker' module which doesn't handle HackerNews hugs
+  # of death as well as I would like. the mpm_event module is much less
+  # resource intensive
+  class { 'apache':
+    mpm_module => 'event',
+  }
+
   include profile::letsencrypt
   # The apache-misc profile includes a number of other important monitoring and
   # apache configuration settings

--- a/spec/classes/profile/staticsite_spec.rb
+++ b/spec/classes/profile/staticsite_spec.rb
@@ -50,6 +50,10 @@ describe 'profile::staticsite' do
       })
     end
 
+    context 'use a scalable apache worker model' do
+      it { should contain_class('apache::mod::event') }
+    end
+
     context 'in production' do
       let(:facts) do
         {


### PR DESCRIPTION
I've already made this change in production due to an active site issue (HN hug
of death). This codifies that change for posterity
