### PR TITLE
Re-introduce basic r10k management into jenkins-infra

### DIFF
--- a/dist/profile/files/r10k/r10k.yaml
+++ b/dist/profile/files/r10k/r10k.yaml
@@ -1,0 +1,12 @@
+---
+#
+# THIS FILE IS MANAGED BY PUPPET
+
+sources:
+  infra:
+    remote: 'https://github.com/jenkins-infra/jenkins-infra.git'
+    basedir: '/etc/puppetlabs/code/environments'
+
+git:
+  provider: 'rugged'
+  private_key: '/var/lib/puppet/keys/r10k'

--- a/dist/profile/manifests/puppetmaster.pp
+++ b/dist/profile/manifests/puppetmaster.pp
@@ -4,6 +4,8 @@
 class profile::puppetmaster {
   # pull in all our secret stuff, and install eyaml
   include ::jenkins_keys
+
+  include profile::r10k
   # Set up our IRC reporter
   include ::irc
   include datadog_agent
@@ -17,16 +19,6 @@ class profile::puppetmaster {
     source => "puppet:///modules/${module_name}/hiera.yaml",
     notify => Service['pe-puppetserver'],
   }
-
-  ## Ensure we're setting the right SMTP server. The Puppetmaster is located in
-  # the OSUOSL datacenter which operates an internal SMTP server for projects'
-  # uses
-  #yaml_setting { 'console smtp server':
-  #  target => '/etc/puppetlabs/console-auth/config.yml',
-  #  key    => 'smtp/address',
-  #  value  => 'smtp.osuosl.org',
-  #  notify => Service['pe-puppetserver'],
-  #}
 
   ini_setting { 'update report handlers':
     ensure  => present,
@@ -77,14 +69,6 @@ class profile::puppetmaster {
   # puppet-irc module which also needs to install gems
   if $::pe_server_version {
     $gem_provider = 'puppetserver_gem'
-  }
-  elsif str2bool($::is_pe) {
-    if versioncmp($::pe_version, '3.7.0') > 0 {
-        $gem_provider = 'pe_puppetserver_gem'
-      }
-      else {
-        $gem_provider = 'pe_gem'
-    }
   }
   else {
     $gem_provider = 'gem'

--- a/dist/profile/manifests/r10k.pp
+++ b/dist/profile/manifests/r10k.pp
@@ -5,88 +5,10 @@
 # Deploying r10k is a bit of a chicken-and-egg problem, so this code exists to
 # ensure that the configuration that was manually set up is codified.
 class profile::r10k {
-  # Here we get our config for r10k from hiera.
-  # currently this hash is only used by the templates below
-  $r10k_options = hiera('r10k_options')
-
-  class { '::r10k':
-    remote            => 'https://github.com/jenkins-infra/jenkins-infra.git',
-    version           => '1.2.4',
-    modulepath        => '/etc/puppetlabs/puppet/environments/$environment/dist:/etc/puppetlabs/puppet/environments/$environment/modules:/opt/puppet/share/puppet/modules',
-    manage_modulepath => true,
-    mcollective       => true,
-  }
-
-  ini_setting { 'Update manifest in puppet.conf':
-    ensure  => present,
-    path    => '/etc/puppetlabs/puppet/puppet.conf',
-    section => 'main',
-    setting => 'manifest',
-    value   => '/etc/puppetlabs/puppet/environments/$environment/manifests/site.pp',
-  }
-
-  case $::osfamily {
-    'redhat': {
-      file { '/etc/init.d/r10k_deployhook.init':
-        ensure  => file,
-        owner   => root,
-        group   => root,
-        mode    => '0755',
-        content => template("${module_name}/r10k_deployhook.init.erb"),
-        notify  => Service['r10k_deployhook'],
-      }
-    }
-
-    'debian': {
-      file { '/etc/init/r10k_deployhook.conf':
-        ensure  => file,
-        owner   => root,
-        group   => root,
-        mode    => '0644',
-        content => template("${module_name}/r10k_deployhook.upstart.erb"),
-        alias   => 'deployhook_init',
-      }
-    }
-
-    default: { fail("${module_name} is not supported on ${::osfamily}") }
-  }
-
-  file { "${r10k_options['deployhooks_logdir']}/deployhooks":
+  file { '/etc/puppetlabs/r10k/r10k.yaml' :
     ensure => file,
-    owner  => peadmin,
-    group  => peadmin,
-    mode   => '0660',
-  }
-
-  file { "${r10k_options['deployhooks_logdir']}/mco":
-    ensure => file,
-    owner  => peadmin,
-    group  => peadmin,
-    mode   => '0660',
-  }
-
-  package { 'sinatra':
-    ensure   => present,
-    provider => pe_gem,
-  }
-
-  package { 'webrick':
-    ensure   => present,
-    provider => pe_gem,
-  }
-
-  file { '/usr/local/bin/r10k_deployhook':
-    ensure  => file,
-    owner   => root,
-    group   => root,
-    mode    => '0755',
-    content => template("${module_name}/r10k_deployhook.erb"),
-    require => [ Package['sinatra'], Package['webrick'] ],
-    notify  => Service['r10k_deployhook'],
-  }
-
-  service { 'r10k_deployhook':
-    ensure => running,
-    enable => true,
+    owner  => 'root',
+    mode   => '0744',
+    source => "puppet:///modules/${module_name}/r10k/r10k.yaml",
   }
 }

--- a/spec/classes/profile/puppetmaster_spec.rb
+++ b/spec/classes/profile/puppetmaster_spec.rb
@@ -8,6 +8,7 @@ describe 'profile::puppetmaster' do
   end
 
   it { should contain_class 'jenkins_keys' }
+  it { should contain_class 'profile::r10k' }
 
   context 'puppet.conf' do
     let(:path) { '/etc/puppetlabs/puppet/puppet.conf' }

--- a/spec/classes/profile/r10k_spec.rb
+++ b/spec/classes/profile/r10k_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'profile::r10k' do
+  context 'r10k.yaml' do
+    it { should contain_file('/etc/puppetlabs/r10k/r10k.yaml') }
+  end
+end


### PR DESCRIPTION
This is already manually set up on the PE 2016.1.1 machine, this simply ensures
that the configuration is managed and updated in the future
