### PR TITLE
Add a build more cross-platform support for profile::buildslave

### DIFF
--- a/dist/profile/manifests/buildslave.pp
+++ b/dist/profile/manifests/buildslave.pp
@@ -2,9 +2,9 @@
 class profile::buildslave(
   $home_dir        = '/home/jenkins',
   $ssh_private_key = undef,
+  $docker          = true,
 ) {
   include ::stdlib
-  include profile::docker
   include git
   # Make sure our Ruby class is properly contained so we can require it in a
   # Package resource
@@ -12,9 +12,18 @@ class profile::buildslave(
 
   $user = 'jenkins'
 
+  if $docker {
+    include profile::docker
+    $groups = [$user, 'docker']
+    $account_requires = Package['docker']
+  }
+  else {
+    $groups = [$user]
+  }
+
   account { $user:
     home_dir => $home_dir,
-    groups   => ['jenkins', 'docker'],
+    groups   => $groups,
     ssh_keys => {
                   'cucumber' => {
                     'key' => 'AAAAB3NzaC1yc2EAAAABIwAAAQEA1l3oZpCJlFspsf6cfa7hovv6NqMB5eAn/+z4SSiaKt9Nsm22dg9xw3Et5MczH0JxHDw4Sdcre7JItecltq0sLbxK6wMEhrp67y0lMujAbcMu7qnp5ZLv9lKSxncOow42jBlzfdYoNSthoKhBtVZ/N30Q8upQQsEXNr+a5fFdj3oLGr8LSj9aRxh0o+nLLL3LPJdY/NeeOYJopj9qNxyP/8VdF2Uh9GaOglWBx1sX3wmJDmJFYvrApE4omxmIHI2nQ0gxKqMVf6M10ImgW7Rr4GJj7i1WIKFpHiRZ6B8C/Ds1PJ2otNLnQGjlp//bCflAmC3Vs7InWcB3CTYLiGnjrw==',
@@ -23,8 +32,8 @@ class profile::buildslave(
                     'key' => 'AAAAB3NzaC1yc2EAAAADAQABAAABAQCzBrEqC3IwdKOptY4SUi/RI0+plMVRhs+xrm1ZUizC4qK7UHW3fk/412zb5dkC1FJHFUUJh/Aa7P/OFLxfaf/nVPQ4Nv5ZIMC8g3b7yAWLHrZb7qLpPA8viG1dXXrHMdPLz2uFa2OKtrzlLe4jtyqRtnN8W+dTAWPorkZ9ia1wpD/wdPoKdDtzktBv7gXHpA/jb2arxYWkd560KtQnUbr+LDzrCkeWj2z3BtEGqKxdOtjJMWbLRU9tIkv809VaQJowEs/acwAno/5O7ejYdRzsIicX6GaiHksS6W6vBV4eEn0mA/cX0qFeo1rcGgnXbn4IyglJiwlqm3YSGpKGVJZn',
                   },
                 },
-    comment  => 'Jenkins build slave user',
-    require  => Package['docker'],
+    comment  => 'Jenkins build node user',
+    require  => $account_requires,
   }
 
   file { "${home_dir}/.ssh/id_rsa":
@@ -33,17 +42,20 @@ class profile::buildslave(
     require => Account[$user],
   }
 
-  file { "${home_dir}/.docker":
-    ensure  => directory,
-    owner   => $user,
-    require => Account[$user],
-  }
 
-  file { "${home_dir}/.docker/config.json":
-    ensure  => file,
-    content => hiera('docker_hub_key'),
-    owner   => $user,
-    require => File["${home_dir}/.docker"],
+  if $docker {
+    file { "${home_dir}/.docker":
+      ensure  => directory,
+      owner   => $user,
+      require => Account[$user],
+    }
+
+    file { "${home_dir}/.docker/config.json":
+      ensure  => file,
+      content => hiera('docker_hub_key'),
+      owner   => $user,
+      require => File["${home_dir}/.docker"],
+    }
   }
 
   package { 'bundler':

--- a/dist/role/manifests/buildnode.pp
+++ b/dist/role/manifests/buildnode.pp
@@ -1,0 +1,4 @@
+#
+#
+class role::buildnode {
+}

--- a/dist/role/manifests/buildnode/mac.pp
+++ b/dist/role/manifests/buildnode/mac.pp
@@ -5,5 +5,6 @@ class role::buildnode::mac {
 
   class { 'profile::buildslave':
     docker => false,
+    ruby   => false,
   }
 }

--- a/dist/role/manifests/buildnode/mac.pp
+++ b/dist/role/manifests/buildnode/mac.pp
@@ -1,0 +1,9 @@
+#
+# Provision a simple, SSH-able Mac OS X based Jenkins build node
+class role::buildnode::mac {
+  include profile::base
+
+  class { 'profile::buildslave':
+    docker => false,
+  }
+}

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -81,3 +81,8 @@ node 'eggplant' {
 node 'cucumber' {
   include role::cucumber
 }
+
+# tomato (Mac OS X 10.10 build node)
+node 'tomato' {
+  include role::buildnode::mac
+}

--- a/spec/classes/profile/buildslave_spec.rb
+++ b/spec/classes/profile/buildslave_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe 'profile::buildslave' do
-  it { should contain_class 'ruby' }
-
   context 'SSH host keys' do
     it "should include GitHub's host keys" do
       properties = {
@@ -13,15 +11,8 @@ describe 'profile::buildslave' do
     end
   end
 
-  context 'build slave tooling' do
-    it { should contain_package 'bundler' }
-    # Provided by the `git` module
-    it { should contain_package 'git' }
-    it { should contain_package 'subversion' }
-
-    it { should contain_package 'make' }
-    it { should contain_package 'build-essential' }
-  end
+  # Provided by the `git` module
+  it { should contain_package 'git' }
 
   context 'managing a `jenkins` user' do
     it 'should provision the "jenkins" account properly' do
@@ -46,7 +37,7 @@ describe 'profile::buildslave' do
     end
   end
 
-  context 'docker support' do
+  context 'with docker => true' do
     it { should contain_class 'docker' }
     it { should contain_package 'docker' }
 
@@ -89,5 +80,40 @@ describe 'profile::buildslave' do
       #   not set to "Package[docker]" but it is set to nil
       expect(subject).to contain_account('jenkins').with_require(nil)
     end
+  end
+
+  context 'with ruby => true' do
+    it { should contain_class 'ruby' }
+    it { should contain_package 'bundler' }
+    it { should contain_package 'libruby' }
+  end
+
+  context 'with ruby => false' do
+    let(:params) do
+      {
+        :ruby => false,
+      }
+    end
+
+    it { should_not contain_class 'ruby' }
+    it { should_not contain_package 'bundler' }
+    it { should_not contain_package 'libruby' }
+  end
+
+
+  context 'on Linux' do
+    it { should contain_package 'subversion' }
+    it { should contain_package 'make' }
+    it { should contain_package 'build-essential' }
+  end
+
+  context 'on Darwin' do
+    let(:facts) do
+      {
+        :kernel => 'Darwin',
+      }
+    end
+
+    it { should_not contain_package 'build-essential' }
   end
 end

--- a/spec/classes/role/buildnode/mac_spec.rb
+++ b/spec/classes/role/buildnode/mac_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe 'role::buildnode::mac' do
+  it { should contain_class 'profile::base' }
+
+  it 'should be a docker-less build node' do
+    expect(subject).to contain_class('profile::buildslave').with_docker(false)
+  end
+end

--- a/spec/classes/role/buildnode/mac_spec.rb
+++ b/spec/classes/role/buildnode/mac_spec.rb
@@ -4,6 +4,9 @@ describe 'role::buildnode::mac' do
   it { should contain_class 'profile::base' }
 
   it 'should be a docker-less build node' do
-    expect(subject).to contain_class('profile::buildslave').with_docker(false)
+    expect(subject).to contain_class('profile::buildslave').with({
+      :docker => false,
+      :ruby => false,
+    })
   end
 end

--- a/spec/classes/role/buildnode_spec.rb
+++ b/spec/classes/role/buildnode_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'role::buildnode' do
+  it { should compile }
+end


### PR DESCRIPTION
This isn't complete for addressing [INFRA-601](https://issues.jenkins-ci.org/browse/INFRA-601) (Mac node support) but lays some ground-work that I want to build off of for #331 
