### PR TITLE
Express the proper relationship to the Package[httpd] resource

### DIFF
--- a/dist/profile/manifests/apachemisc.pp
+++ b/dist/profile/manifests/apachemisc.pp
@@ -4,7 +4,7 @@
 class profile::apachemisc(
   $ssh_enabled = false,
 ) {
-  include apache
+  include ::apache
   # log rotation setting lives in another module
   include apachelogcompressor
 

--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -2,7 +2,7 @@
 # Defines an archive server for serving all the archived historical releases
 #
 class profile::archives {
-  include stdlib
+  include ::stdlib
   # volume configuration is in hiera
   include ::lvm
   include profile::apachemisc
@@ -32,7 +32,7 @@ class profile::archives {
   file { $archives_dir:
     ensure  => directory,
     owner   => 'www-data',
-    require => [Package['apache2'],
+    require => [Package['httpd'],
                 Mount[$archives_dir]],
   }
 

--- a/spec/classes/profile/archives_spec.rb
+++ b/spec/classes/profile/archives_spec.rb
@@ -9,6 +9,7 @@ describe 'profile::archives' do
   it { should contain_class 'profile::apachemisc' }
   it { should contain_class 'lvm' }
   it { should contain_class 'apache' }
+
   it_behaves_like 'it has webserver firewall rules'
 
   it { should contain_filesystem '/dev/archives/releases' }


### PR DESCRIPTION
The 'apache2' package is installed on Ubuntu by puppetlabs/apache but the resource
in the catalogue is actually Package[httpd]. Likely for convenience-sake inside
of the apache module.
