### PR TITLE
[INFRA-1] ordering between config & openldap module

### DIFF
--- a/dist/profile/manifests/ldap.pp
+++ b/dist/profile/manifests/ldap.pp
@@ -70,27 +70,31 @@ class profile::ldap(
 
   # SSL Certificates
   file { $ssl_dir:
-    ensure => directory,
-    mode   => '0700',
-    owner  => $openldap::params::server_owner,
+    ensure  => directory,
+    mode    => '0700',
+    owner   => $openldap::params::server_owner,
+    require => Class['::openldap::server::install'],
   }
   file { $ssl_key_path:
     content => $ssl_key,
     mode    => '0600',
     owner   => $openldap::params::server_owner,
     notify  => Service['slapd'],
+    before  => Class['::openldap::server::service'],
   }
   file { $ssl_cert_path:
     content => $ssl_cert,
     mode    => '0644',
     owner   => $openldap::params::server_owner,
     notify  => Service['slapd'],
+    before  => Class['::openldap::server::service'],
   }
   file { $ssl_chain_path:
     content => $ssl_chain,
     mode    => '0644',
     owner   => $openldap::params::server_owner,
     notify  => Service['slapd'],
+    before  => Class['::openldap::server::service'],
   }
 
   profile::datadog_check { 'ldap-process-check':


### PR DESCRIPTION
Directory creation requires an user, so those settings have to happen
between the installation and the service execution, IIUC.

This is way more puppet than I'm comfortable with.
