### PR TITLE
Update our relationship for repo directories

### DIFF
--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -50,7 +50,7 @@ class profile::pkgrepo (
     ensure      => present,
     docroot     => $docroot,
     mirror_fqdn => $mirror_fqdn,
-    require     => File["${docroot}/${title}"],
+    require     => File[$repos],
   }
 
   profile::debian_repo { ['debian', 'debian-stable', 'debian-rc', 'debian-stable-rc']:
@@ -58,14 +58,14 @@ class profile::pkgrepo (
     docroot     => $docroot,
     direct_root => $release_root,
     mirror_fqdn => $mirror_fqdn,
-    require     => File["${docroot}/${title}"],
+    require     => File[$repos],
   }
 
   profile::opensuse_repo { ['opensuse', 'opensuse-stable', 'opensuse-rc', 'opensuse-stable-rc']:
     ensure      => present,
     docroot     => $docroot,
     mirror_fqdn => $mirror_fqdn,
-    require     => File["${docroot}/${title}"],
+    require     => File[$repos],
   }
 
   apache::vhost { 'pkg.jenkins.io':

--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -42,7 +42,7 @@ class profile::pkgrepo (
 
   file { suffix($repos, '/jenkins-ci.org.key'):
     ensure  => present,
-    content => "puppet:///modules/${module_name}/pkgrepo/jenkins-ci.org.key",
+    source  => "puppet:///modules/${module_name}/pkgrepo/jenkins-ci.org.key",
     require => File[$docroot],
   }
 

--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -3,7 +3,8 @@
 class profile::pkgrepo (
   $docroot      = '/var/www/pkg.jenkins.io',
   $release_root = '/srv/releases/jenkins',
-  $mirror_fqdn  = 'mirrors.jenkins.io'
+  $repo_fqdn    = 'pkg.jenkins.io',
+  $mirror_fqdn  = 'mirrors.jenkins.io',
 ) {
   include ::stdlib
   include ::apache
@@ -47,10 +48,10 @@ class profile::pkgrepo (
   }
 
   profile::redhat_repo { ['redhat', 'redhat-stable', 'redhat-rc', 'redhat-stable-rc']:
-    ensure      => present,
-    docroot     => $docroot,
-    mirror_fqdn => $mirror_fqdn,
-    require     => File[$repos],
+    ensure    => present,
+    docroot   => $docroot,
+    repo_fqdn => $repo_fqdn,
+    require   => File[$repos],
   }
 
   profile::debian_repo { ['debian', 'debian-stable', 'debian-rc', 'debian-stable-rc']:

--- a/dist/profile/manifests/redhat_repo.pp
+++ b/dist/profile/manifests/redhat_repo.pp
@@ -4,7 +4,7 @@
 define profile::redhat_repo (
   $ensure,
   $docroot,
-  $mirror_fqdn) {
+  $repo_fqdn) {
 
   file { "${docroot}/${name}/jenkins.repo":
     ensure  => $ensure,

--- a/dist/profile/templates/pkgrepo/jenkins.repo.erb
+++ b/dist/profile/templates/pkgrepo/jenkins.repo.erb
@@ -1,5 +1,5 @@
 [jenkins]
 name=Jenkins
-baseurl=http://<%= @mirror_fqdn %>/<%= @name %>
+baseurl=http://<%= @repo_fqdn %>/<%= @name %>
 gpgcheck=1
 


### PR DESCRIPTION
Apparently rspec-puppet wasn't complaining about an invalid relationship, but
the puppet master sure did!

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid relationship: Profile::Redhat_repo[redhat] { require => File[/var/www/pkg.jenkins.io/profile::pkgrepo] }, because File[/var/www/pkg.jenkins.io/profile::pkgrepo] doesn't seem to be in the catalog
```
