### PR TITLE
Migrate pkg.jenkins-ci.org over to the new pkg.jenkins.io host

### DIFF
--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -52,7 +52,7 @@ fisheye     3600    IN    CNAME    cucumber
 l10n        3600    IN    CNAME    l10n.jenkins.io.
 javadoc     3600    IN    CNAME    cucumber
 mirrors     3600    IN    CNAME    mirrors.jenkins.io.
-pkg         3600    IN    CNAME    cucumber
+pkg         3600    IN    CNAME    pkg.jenkins.io.
 usage       3600    IN    CNAME    cucumber
 stacktrace  3600    IN    CNAME    cucumber
 sorcerer    3600    IN    CNAME    cucumber


### PR DESCRIPTION
Fixes INFRA-644
