### PR TITLE
Remove both the ldap and jenkins profiles from cucumber

### DIFF
--- a/dist/role/manifests/cucumber.pp
+++ b/dist/role/manifests/cucumber.pp
@@ -2,6 +2,4 @@
 # Cucumber is an old machine based in a Contegix datacenter
 class role::cucumber {
   include profile::diagnostics
-  include profile::ldap
-  include profile::jenkins
 }

--- a/spec/classes/role/cucumber_spec.rb
+++ b/spec/classes/role/cucumber_spec.rb
@@ -2,8 +2,5 @@ require 'spec_helper'
 
 describe 'role::cucumber' do
   it { should_not contain_class 'profile::base' }
-  it { should contain_class 'profile::ldap' }
   it { should contain_class 'profile::diagnostics' }
-
-  it { should contain_class 'profile::jenkins' }
 end


### PR DESCRIPTION
These are either already migrated or in the process of migrating elsewhere
