### PR TITLE
Roll the updates.jenkins.io CNAME ahead of other changes

### DIFF
--- a/dist/profile/files/bind/jenkins.io.zone
+++ b/dist/profile/files/bind/jenkins.io.zone
@@ -48,6 +48,7 @@ pkg         3600    IN    CNAME    mirrors ; pkg and mirrors run off the same ho
 beta        3600    IN    CNAME    eggplant ; beta site for the jenkins-ci.org/jenkins.io site
 puppet      3600    IN    CNAME    radish
 accounts    3600    IN    CNAME    eggplant
+updates     3600    IN    CNAME    mirrors ; updates.jenkins.io for delivering update center, etc
 
 ; Magical CNAME for certificate validation
 D07F852F584FA592123140354D366066.ldap.jenkins.io. 3600 IN CNAME 75E741181A7ACDBE2996804B2813E09B65970718.comodoca.com.


### PR DESCRIPTION
This will allow the change to propagate through the DNS system before our vhost
changes land

References INFRA-645
