### PR TITLE
Modify the mirrorbrain role to include the update site

### DIFF
--- a/dist/profile/manifests/updatesite.pp
+++ b/dist/profile/manifests/updatesite.pp
@@ -58,6 +58,8 @@ class profile::updatesite (
     # If we're managing an ssh_authorized_key, then we should purge anything
     # else for safety's sake
     User <| title == 'www-data' |> {
+        managehome     => true,
+        home           => '/var/www',
         purge_ssh_keys => true,
     }
   }

--- a/dist/role/manifests/mirrorbrain.pp
+++ b/dist/role/manifests/mirrorbrain.pp
@@ -3,5 +3,6 @@
 class role::mirrorbrain {
   include profile::base
   include profile::mirrorbrain
+  include profile::updatesite
   include profile::pkgrepo
 }

--- a/spec/classes/role/mirrorbrain_spec.rb
+++ b/spec/classes/role/mirrorbrain_spec.rb
@@ -3,4 +3,6 @@ require 'spec_helper'
 describe 'role::mirrorbrain' do
   it { should contain_class 'profile::base' }
   it { should contain_class 'profile::mirrorbrain' }
+  it { should contain_class 'profile::pkgrepo' }
+  it { should contain_class 'profile::updatesite' }
 end


### PR DESCRIPTION
It's a pretty fat role as far as our infrastructure goes, but these three
profiles all resolve around the same /srv/jenkins/releases tree :(
