### PR TITLE
Allow override for /srv/releases/jenkins on mirrorbrains

### DIFF
--- a/dist/profile/manifests/mirrorbrain.pp
+++ b/dist/profile/manifests/mirrorbrain.pp
@@ -184,6 +184,7 @@ perl -e 'printf \"%s\n\", time' > ${docroot}/TIME'
       {
         path            => $docroot,
         options         => 'FollowSymLinks Indexes',
+        override        => 'All',
         custom_fragment => '
             MirrorBrainEngine On
             MirrorBrainDebug Off


### PR DESCRIPTION
Turns out we generated .htaccess files in order to serve up URLs like
/osx/latest which redirect to the latest package
