### PR TITLE
Wrong path name for ldap daemon

### DIFF
--- a/dist/profile/files/ldap/process_check.yaml
+++ b/dist/profile/files/ldap/process_check.yaml
@@ -1,5 +1,5 @@
   - name: LDAP
-    search_string: ['/usr/bin/slapd']
+    search_string: ['/usr/sbin/slapd']
     exact_match: false
     thresholds:
       # expect exactly 1 instance


### PR DESCRIPTION
This was preventing monitoring to kick in for `slapd`
