### PR TITLE
Mark machines with the trustedagent role as trusted when laying down the profile

### DIFF
--- a/hieradata/roles/trustedagent.yaml
+++ b/hieradata/roles/trustedagent.yaml
@@ -1,5 +1,6 @@
 ---
 
+profile::buildslave::trusted_agent: true
 profile::buildslave::ssh_keys:
   '/home/jenkins/.ssh/updates-rsync-key':
     for_host: 'updates.jenkins.io'


### PR DESCRIPTION
I forgot to do this previously, which is obviously why my credentials aren't
where they should be :-P
