### PR TITLE
Incorporate the DB indices that were manually added a while back to ldap

### DIFF
--- a/dist/profile/manifests/ldap.pp
+++ b/dist/profile/manifests/ldap.pp
@@ -67,6 +67,53 @@ class profile::ldap(
   }
   ###############
 
+  # Indices
+  ###############
+  $ldap_attr_indices = 'eq,pres,sub'
+
+  openldap::server::dbindex { 'cn index':
+    ensure    => present,
+    suffix    => $database,
+    attribute => 'cn',
+    indices   => $ldap_attr_indices,
+  }
+
+  openldap::server::dbindex { 'mail index':
+    ensure    => present,
+    suffix    => $database,
+    attribute => 'mail',
+    indices   => $ldap_attr_indices,
+  }
+
+  openldap::server::dbindex { 'surname index':
+    ensure    => present,
+    suffix    => $database,
+    attribute => 'surname',
+    indices   => $ldap_attr_indices,
+  }
+
+  openldap::server::dbindex { 'givenname index':
+    ensure    => present,
+    suffix    => $database,
+    attribute => 'givenname',
+    indices   => $ldap_attr_indices,
+  }
+
+  openldap::server::dbindex { 'ou index':
+    ensure    => present,
+    suffix    => $database,
+    attribute => 'ou',
+    indices   => $ldap_attr_indices,
+  }
+
+  openldap::server::dbindex { 'uniqueMember index':
+    ensure    => present,
+    suffix    => $database,
+    attribute => 'uniqueMember',
+    indices   => 'eq',
+  }
+  ###############
+  ###############
 
   # SSL Certificates
   file { $ssl_dir:

--- a/spec/classes/profile/ldap_spec.rb
+++ b/spec/classes/profile/ldap_spec.rb
@@ -82,6 +82,24 @@ describe 'profile::ldap' do
         })
       end
     end
+
+    context 'ldap indices' do
+      ['cn', 'mail', 'surname', 'givenname', 'ou'].each do |attr|
+        it "should index `#{attr}`" do
+          expect(subject).to contain_openldap__server__dbindex("#{attr} index").with({
+            :attribute => attr,
+            :indices => 'eq,pres,sub',
+          })
+        end
+      end
+
+      it 'should index `uniqueMember`' do
+        expect(subject).to contain_openldap__server__dbindex('uniqueMember index').with({
+          :attribute => 'uniqueMember',
+          :indices => 'eq',
+        })
+      end
+    end
   end
 
   context 'monitoring' do


### PR DESCRIPTION
These were added by @benwalding after we migrated ldap. It turns out that we had
enough hardware "before" that we never really needed to care about indices. We
do now though!

References INFRA-646
