### PR TITLE
Execute the sync.sh in a crontab for the mirrorbrain user

### DIFF
--- a/dist/profile/manifests/mirrorbrain.pp
+++ b/dist/profile/manifests/mirrorbrain.pp
@@ -201,6 +201,15 @@ date \"+%s\" > /srv/releases/jenkins/TIME
     hour    => '4',
     require => File[$mirrorbrain_conf],
   }
+
+  # Sync all our Jenkins releases to our dependent mirrors
+  # See <https://issues.jenkins-ci.org/browse/INFRA-694>
+  cron { 'mirrorbrain-sync-releases':
+    command => "cd ${home_dir} && ./sync.sh",
+    minute  => '0',
+    user    => $user,
+    require => File["${home_dir}/sync.sh"],
+  }
   #############
 
   # dbd-pgsql is required to allow mod_dbd to communicate with PostgreSQL

--- a/spec/classes/profile/mirrorbrain_spec.rb
+++ b/spec/classes/profile/mirrorbrain_spec.rb
@@ -208,4 +208,20 @@ EOF
       it { should contain_apache__vhost 'mirrors.jenkins.io' }
     end
   end
+
+  context 'crontabs' do
+    it { should contain_cron 'mirrorbrain-time-update' }
+    it { should contain_cron 'mirmon-status-page' }
+    it { should contain_cron 'mirrorbrain-ping-mirrors' }
+    it { should contain_cron 'mirrorbrain-scan' }
+    it { should contain_cron 'mirrorbrain-db-cleanup' }
+    it { should contain_cron 'mirmon-update-mirror-list' }
+
+    it 'should install a `./sync.sh` crontab entry for `mirrorbrain`' do
+      expect(subject).to contain_cron('mirrorbrain-sync-releases').with({
+        :user => params[:user],
+        :minute => '0',
+      })
+    end
+  end
 end


### PR DESCRIPTION
This is already in the crontab (manually inserted) and will need to come out
when this change goes to production.

Fixes INFRA-694
