### PR TITLE
Move usage-stats storage onto an attached volume for better resiliency

### DIFF
--- a/hieradata/clients/usage.yaml
+++ b/hieradata/clients/usage.yaml
@@ -1,0 +1,9 @@
+---
+lvm::volume_groups:
+  data:
+    physical_volumes:
+      - /dev/xvdb
+    logical_volumes:
+      usage:
+        size: 100G
+        mountpath: /srv/usage

--- a/hieradata/vagrant/clients/usage.yaml
+++ b/hieradata/vagrant/clients/usage.yaml
@@ -1,0 +1,9 @@
+---
+lvm::volume_groups:
+  data:
+    physical_volumes:
+      - /dev/loop0
+    logical_volumes:
+      usage:
+        size: 12M
+        mountpath: /srv/usage

--- a/spec/server/usage/usage_spec.rb
+++ b/spec/server/usage/usage_spec.rb
@@ -18,11 +18,27 @@ describe 'usage' do
     end
   end
 
-  context '/var/log/usage-stats' do
-    describe file('/var/log/usage-stats') do
+  context '/srv/usage' do
+    describe file('/srv/usage/usage-stats') do
       it { should be_directory }
       it { should be_owned_by 'usagestats' }
     end
+
+    describe file('/srv/usage/apache-logs') do
+      it { should be_directory }
+    end
+  end
+
+  describe file('/var/log/usage-stats') do
+    it { should be_symlink }
+  end
+
+  describe file('/var/log/apache2/usage.jenkins.io') do
+    it { should be_symlink }
+  end
+
+  describe file('/var/log/apache2/usage.jenkins-ci.org') do
+    it { should be_symlink }
   end
 
   context '/var/www/usage.jenkins.io' do


### PR DESCRIPTION
I realized after I provisioned the machine that I should have separated out the
usage volume. Currently usage.jenkins.io has a 100GB EBS volume attached

References [INFRA-559](https://issues.jenkins-ci.org/browse/INFRA-559)
