### PR TITLE
Apparently 100GB on AWS is not 100GB.

### DIFF
--- a/hieradata/clients/usage.yaml
+++ b/hieradata/clients/usage.yaml
@@ -5,5 +5,5 @@ lvm::volume_groups:
       - /dev/xvdf
     logical_volumes:
       usage:
-        size: 100G
+        size: 99G
         mountpath: /srv/usage


### PR DESCRIPTION
```
Execution of '/sbin/lvcreate -n usage --size 100G data' returned 5: Volume group "data" has insufficient free space (25599 extents): 25600 required.
```

:fire:
