### PR TITLE
Devnull redirected access logs for usage.jenkins-ci.org

### DIFF
--- a/dist/profile/manifests/usage.pp
+++ b/dist/profile/manifests/usage.pp
@@ -220,6 +220,8 @@ exec rsync "$@"',
     override        => ['All'],
     redirect_status => 'permanent',
     redirect_dest   => 'https://usage.jenkins.io/',
+    # Blackhole all these redirect logs https://issues.jenkins-ci.org/browse/INFRA-739
+    access_log_file => '/dev/null',
     require         => [
       File['/etc/apache2/legacy_cert.crt'],
       File['/etc/apache2/legacy_cert.key'],


### PR DESCRIPTION
These are unnecessary as the destination (usage.jenkins.io) will properly log
the request when it generates a 200 status response.

Fixes [INFRA-739](https://issues.jenkins-ci.org/browse/INFRA-739)
