### PR TITLE
Default to using the aufs storage driver, which is not garbage

### DIFF
--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -7,6 +7,7 @@ class profile::docker {
     # kernel modules on Ubuntu 12.04 LTS and restart the host machine anyways
     manage_kernel    => false,
     extra_parameters => '--storage-driver=aufs',
+    require          => Package['linux-image-extra'],
   }
 
   include datadog_agent::integrations::docker
@@ -22,5 +23,10 @@ class profile::docker {
     # traffic within docker is OK
     iniface => 'docker0',
     action  => 'accept',
+  }
+
+  package { 'linux-image-extra':
+    ensure => present,
+    name   => "linux-image-extra-${::kernelrelease}",
   }
 }

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -2,10 +2,11 @@
 # Profile for managing basics of docker installation/configuration
 class profile::docker {
   class { '::docker':
-    version       => '1.9.1',
+    version          => '1.9.1',
     # Disabling the management of the kernel, since we have to pre-install
     # kernel modules on Ubuntu 12.04 LTS and restart the host machine anyways
-    manage_kernel => false,
+    manage_kernel    => false,
+    extra_parameters => '--storage-driver=aufs',
   }
 
   include datadog_agent::integrations::docker


### PR DESCRIPTION
Unlike devicemapper, which is total garbage. Seeing failures in newer ci.j.io
and trusted.ci.j.io nodes where `docker push` commands are failing

This requires the aufs module, which is generally provided by `linux-image-extra-$(uname -r)`. Which I'm still looking into a good approach for installing
