### PR TITLE
Install the debian repository key under jenkins.io.key and jenkins-ci.org.key

### DIFF
--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -62,6 +62,12 @@ class profile::pkgrepo (
     require => File[$docroot],
   }
 
+  file { suffix($repos, '/jenkins.io.key'):
+    ensure  => present,
+    source  => "puppet:///modules/${module_name}/pkgrepo/jenkins-ci.org.key",
+    require => File[$docroot],
+  }
+
   profile::redhat_repo { ['redhat', 'redhat-stable', 'redhat-rc', 'redhat-stable-rc']:
     ensure    => present,
     docroot   => $docroot,

--- a/spec/server/mirrorbrain/mirrorbrain_spec.rb
+++ b/spec/server/mirrorbrain/mirrorbrain_spec.rb
@@ -23,4 +23,18 @@ describe 'mirrorbrain' do
   describe file('/etc/apache2/mods-enabled/geoip.conf') do
     it { should be_symlink }
   end
+
+  context 'pkgrepo' do
+    describe file('/srv/releases/jenkins') do
+      it { should be_directory }
+    end
+
+    ['jenkins.io.key', 'jenkins-ci.org.key'].each do |key|
+      ['debian', 'debian-stable'].each do |repo|
+        describe file("/var/www/pkg.jenkins.io/#{repo}/#{key}") do
+          it { should be_file }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
At some point in the future, hopefully this calendar year, we deprecate the old
keys entirely

Fixes [INFRA-811](https://issues.jenkins-ci.org/browse/INFRA-811)
