### PR TITLE
Upgrade the demo instance to 2.10

### DIFF
--- a/dist/profile/manifests/demo.pp
+++ b/dist/profile/manifests/demo.pp
@@ -1,7 +1,7 @@
 #
 # Run a demo instance of Jenkins in a Docker container
 class profile::demo(
-$image_tag = '2.1'
+$image_tag = '2.10'
 ) {
   include profile::docker
   include profile::apachemisc


### PR DESCRIPTION
For deployment, the old image needs to be removed from the host. This currently
isn't handled by Puppet, so the post-provisioning steps are required:

```
# docker stop demo && docker rm demo
```

This will ensure the new image with the new label is restarted by Upstart
