### PR TITLE
Upload process was modified so this is no longer needed

### DIFF
--- a/dist/profile/manifests/usage.pp
+++ b/dist/profile/manifests/usage.pp
@@ -69,16 +69,6 @@ class profile::usage(
   ## where they are decrypted and then re-uploaded to this host for processing
   ############################
 
-  # This wrapper script will not be necessary after Kohsuke's scripts migrate
-  # away from using his own user
-  file { '/home/kohsuke/sudo-rsync':
-    ensure  => file,
-    mode    => '0755',
-    content => '#!/bin/sh
-exec rsync "$@"',
-    require => User['kohsuke'],
-  }
-
   group { $group :
     ensure => present,
   }
@@ -98,16 +88,6 @@ exec rsync "$@"',
     user    => $user,
     key     => hiera('usage_ssh_pubkey'),
     require => Account[$user],
-  }
-
-  exec { 'add-kohsuke-to-usage-group':
-    unless  => 'grep -q "usagestats\\S*kohsuke" /etc/group',
-    command => "usermod -aG ${group} kohsuke",
-    path    => ['/sbin', '/bin', '/usr/sbin'],
-    require => [
-      Group[$group],
-      User['kohsuke'],
-    ],
   }
   ##
 

--- a/spec/classes/profile/usage_spec.rb
+++ b/spec/classes/profile/usage_spec.rb
@@ -164,22 +164,6 @@ describe 'profile::usage' do
     end
 
     it { should contain_user('kohsuke') }
-
-    it 'should add the `kohsuke` user to the usage group' do
-      expect(subject).to contain_exec('add-kohsuke-to-usage-group').with({
-        :command => "usermod -aG #{params[:group]} kohsuke",
-      })
-    end
-
-    it "should have /home/kohsuke/sudo-rsync for kohsuke's old scripts" do
-      expect(subject).to contain_file('/home/kohsuke/sudo-rsync').with({
-        :ensure => :file,
-        :content => '#!/bin/sh
-exec rsync "$@"',
-        :mode => '0755',
-        :require => 'User[kohsuke]',
-      })
-    end
   end
 end
 


### PR DESCRIPTION
The rsync directly logs in as 'usagestats' as of now.
