### PR TITLE
Add a catch-all virtualhost with redirects for jenkins-ci.org

### DIFF
--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -10,7 +10,7 @@ JENKINS-CI.ORG.    3600    IN    SOA    ns1.jenkins-ci.org. tyler.monkeypox.org.
                 )
 
 ; A Records
-@           3600    IN    A    199.193.196.24
+@           3600    IN    A    140.211.15.101
 
 ; Primary at Contegix
 cucumber    3600    IN    A    199.193.196.24
@@ -44,27 +44,27 @@ ns3         3600    IN    A    162.209.106.32 ; okra (Rackspace)
 ; CNAME Records
 www         3600    IN    CNAME    @
 issues      3600    IN    CNAME    edamame
-gherkin     3600    IN    CNAME    cucumber
-drupal      3600    IN    CNAME    cucumber
 wiki        3600    IN    CNAME    lettuce
 updates     3600    IN    CNAME    updates.jenkins.io.
+javadoc     3600    IN    CNAME    cucumber
+gherkin     3600    IN    CNAME    cucumber
+drupal      3600    IN    CNAME    cucumber
 downloads   3600    IN    CNAME    cucumber
 fisheye     3600    IN    CNAME    cucumber
+stacktrace  3600    IN    CNAME    cucumber
+sorcerer    3600    IN    CNAME    cucumber
+maven       3600    IN    CNAME    cucumber
+maven2      3600    IN    CNAME    cucumber
+ci          3600    IN    CNAME    ci.jenkins.io.
+svn         3600    IN    CNAME    cucumber
+javanet2    3600    IN    CNAME    cucumber
+ldap        3600    IN    CNAME    cucumber
 l10n        3600    IN    CNAME    l10n.jenkins.io.
-javadoc     3600    IN    CNAME    cucumber
 mirrors     3600    IN    CNAME    mirrors.jenkins.io.
 pkg         3600    IN    CNAME    pkg.jenkins.io.
 usage       3600    IN    CNAME    usage.jenkins.io.
-stacktrace  3600    IN    CNAME    cucumber
-sorcerer    3600    IN    CNAME    cucumber
 stats       3600    IN    CNAME    stats.jenkins.io.
-maven       3600    IN    CNAME    cucumber
-maven2      3600    IN    CNAME    cucumber
-ci          3600    IN    CNAME    cucumber
-svn         3600    IN    CNAME    cucumber
 meetings    3600    IN    CNAME    edamame
-javanet2    3600    IN    CNAME    cucumber
-ldap        3600    IN    CNAME    cucumber
 jekyll      3600    IN    CNAME    jenkinsci.github.io.
 git         3600    IN    CNAME    spinach
 boxes       3600    IN    CNAME    spinach

--- a/dist/profile/files/catchall/jenkins.jnlp
+++ b/dist/profile/files/catchall/jenkins.jnlp
@@ -1,0 +1,23 @@
+<!-- See http://java.sun.com/j2se/1.5.0/docs/guide/javaws/developersguide/syntax.html for the syntax -->
+<jnlp spec="1.0+" codebase="http://jenkins-ci.org/jenkins.jnlp">
+
+  <information>
+    <title>Jenkins</title>
+    <vendor>Jenkins project</vendor>
+    <homepage href="http://jenkins-ci.org/"/>
+    <offline-allowed/>
+  </information>
+
+  <security>
+    <all-permissions/>
+  </security>
+
+  <resources>
+    <j2se version="1.6+"/>
+    <jar href="http://mirrors.jenkins-ci.org/war/latest/jenkins.war"/>
+    <!-- create a prominent Windows service installation link --> 
+    <!--property name="hudson.lifecycle.WindowsInstallerLink.prominent" value="true" /-->
+  </resources>
+
+  <application-desc main-class="JNLPMain" />
+</jnlp>

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -104,6 +104,11 @@ class profile::buildmaster(
   }
 
   apache::vhost { $ci_fqdn:
+    serveraliases         => [
+      # Give all our buildmaster profiles this server alias; it's easier than
+      # parameterizing it for compatibility's sake
+      'ci.jenkins-ci.org',
+    ],
     require               => [
       File[$docroot],
       # We need our installation to be secure before we allow access

--- a/dist/profile/manifests/catchall.pp
+++ b/dist/profile/manifests/catchall.pp
@@ -1,0 +1,140 @@
+#
+# Catchall virtualhosts for the legacy jenkins-ci.org domain
+class profile::catchall(
+  $docroot = '/var/www/html',
+) {
+  include ::apache
+  include profile::apachemisc
+
+
+  $apache_log_dir = '/var/log/apache2/jenkins-ci.org'
+  $docroot_user = 'www-data'
+
+  file { $apache_log_dir :
+    ensure => directory,
+  }
+
+  file { $docroot :
+    ensure => directory,
+    owner  => $docroot_user,
+  }
+
+  file { "${docroot}/jenkins.jnlp" :
+    ensure  => present,
+    source  => "puppet:///modules/${module_name}/catchall/jenkins.jnlp",
+    owner   => $docroot_user,
+    mode    => '0755',
+    require => File[$docroot],
+  }
+
+  apache::vhost { 'jenkins-ci.org':
+    docroot         => $docroot,
+    port            => 443,
+    ssl             => true,
+    ssl_key         => '/etc/apache2/legacy_cert.key',
+    ssl_chain       => '/etc/apache2/legacy_chain.crt',
+    ssl_cert        => '/etc/apache2/legacy_cert.crt',
+    override        => ['All'],
+    error_log_file  => 'jenkins-ci.org/error.log',
+    access_log_pipe => "|/usr/bin/rotatelogs ${apache_log_dir}/access.log.%Y%m%d%H%M%S 604800",
+    # Using a big custom fragment here because our ordering of redirects and
+    # aliases is actually fairly important and it's difficult to ensure order
+    # in any other way
+    custom_fragment => '
+  AddType    application/x-java-jnlp-file jnlp
+
+  # compatibility with old package repository locations
+  RedirectMatch ^/redhat/(.*) https://pkg.jenkins.io/redhat/$1
+  RedirectMatch ^/opensuse/(.*) https://pkg.jenkins.io/opensuse/$1
+  RedirectMatch ^/debian/(.*) https://pkg.jenkins.io/debian/$1
+  # convenient short URLs
+  RedirectMatch /issue/(.+)          https://issues.jenkins-ci.org/browse/JENKINS-$1
+  RedirectMatch /commit/core/(.+)    https://github.com/jenkinsci/jenkins/commit/$1
+  RedirectMatch /commit/(.+)/(.+)    https://github.com/jenkinsci/$1/commit/$2
+  RedirectMatch /pull/(.+)/([0-9]+)  https://github.com/jenkinsci/$1/pull/$2
+
+  Redirect /maven-site/hudson-core /maven-site/jenkins-core
+
+  # https://issues.jenkins-ci.org/browse/INFRA-351
+  RedirectMatch ^/maven-hpi-plugin(.*) http://jenkinsci.github.io/maven-hpi-plugin/$1
+
+  # Probably not needed but, rating code moved a while ago
+  RedirectMatch ^/rate/(.*) https://rating.jenkins.io/$1
+  RedirectMatch ^/census/(.*) https://census.jenkins.io/$1
+  Redirect /jenkins-ci.org.key https://pkg.jenkins.io/redhat/jenkins.io.key
+
+  # permalinks
+  # - this one is referenced from 1.395.1 "sign post" release
+  Redirect /why            https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=53608972
+  # baked in the help file to create account on Oracle for JDK downloads
+  Redirect /oracleAccountSignup    http://www.oracle.com/webapps/redirect/signon?nexturl=http://jenkins-ci.org/
+  # to the donation page
+  Redirect /donate        https://wiki.jenkins-ci.org/display/JENKINS/Donation
+  # CLA links used in the CLA forms
+  Redirect /license        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla
+  Redirect /licenses        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla
+  # used to advertise the project meeting
+  Redirect /meetings/        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda
+  # used from friends of Jenkins plugin to link to the thank you page
+  Redirect /friend        https://wiki.jenkins-ci.org/display/JENKINS/Donation
+  # used by Gradle JPI plugin to include fragment
+  Redirect /gradle-jpi-plugin/latest    https://raw.github.com/jenkinsci/gradle-jpi-plugin/master/install
+  # used when encouraging people to subscribe to security advisories
+  Redirect /advisories        https://wiki.jenkins-ci.org/display/JENKINS/Security+Advisories
+  # used in slides and handouts to refer to survey
+  Redirect /survey        http://s.zoomerang.com/s/JenkinsSurvey
+  # used by RekeySecretAdminMonitor in Jenkins
+  Redirect /rekey            https://wiki.jenkins-ci.org/display/SECURITY/Re-keying
+  # persistent Google hangout link
+  Redirect /hangout        https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38
+# .16.203.43 repo.jenkins-ci.org
+  Redirect /pull-request-greeting    https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories
+  # Mailer plugin uses this to redirect to Javamail javadoc page
+  Redirect /javamail-properties   https://javamail.java.net/nonav/docs/api/overview-summary.html#overview_description
+  # baked in jenkins.war 1.587 / 1.580.1
+  Redirect /security-144          https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control
+  # baked in 1.600 easter egg
+  Redirect /100k                  https://jenkins.io/content/jenkins-celebration-day-february-26
+
+  RedirectMatch permanent ^/((?!patron|maven-site|jenkins.jnlp).+)$ https://jenkins.io/$1
+    ',
+    require         => [
+      File['/etc/apache2/legacy_cert.key'],
+      File[$apache_log_dir],
+    ],
+  }
+
+  apache::vhost { 'jenkins-ci.org unsecured':
+    servername      => 'jenkins-ci.org',
+    serveraliases   => [
+      'www.jenkins-ci.org',
+    ],
+    docroot         => $docroot,
+    port            => 80,
+    redirect_status => 'permanent',
+    redirect_dest   => 'https://jenkins-ci.org/',
+    override        => ['All'],
+    error_log_file  => 'jenkins-ci.org/error_nonssl.log',
+    access_log_pipe => "|/usr/bin/rotatelogs ${apache_log_dir}/access_nonssl.log.%Y%m%d%H%M%S 604800",
+  }
+
+  # Legacy update site compatibility
+  ##################################
+  file { '/etc/apache2/legacy_cert.key':
+    ensure  => present,
+    content => hiera('ssl_legacy_key'),
+    require => Package['httpd'],
+  }
+
+  file { '/etc/apache2/legacy_chain.crt':
+    ensure  => present,
+    content => hiera('ssl_legacy_chain'),
+    require => Package['httpd'],
+  }
+  file { '/etc/apache2/legacy_cert.crt':
+    ensure  => present,
+    content => hiera('ssl_legacy_cert'),
+    require => Package['httpd'],
+  }
+  ##################################
+}

--- a/dist/profile/manifests/staticsite.pp
+++ b/dist/profile/manifests/staticsite.pp
@@ -117,11 +117,6 @@ class profile::staticsite(
     ],
     port          => '443',
     ssl           => true,
-    ssl_key       => '/etc/letsencrypt/live/jenkins.io/privkey.pem',
-    # When Apache is upgraded to >= 2.4.8 this should be changed to
-    # fullchain.pem
-    ssl_cert      => '/etc/letsencrypt/live/jenkins.io/cert.pem',
-    ssl_chain     => '/etc/letsencrypt/live/jenkins.io/chain.pem',
     docroot       => $beta_docroot,
     require       => File[$beta_docroot],
   }
@@ -145,6 +140,14 @@ class profile::staticsite(
         domains     => ['jenkins.io', 'www.jenkins.io'],
         plugin      => 'apache',
         manage_cron => true,
+    }
+
+    Apache::Vhost <| title == 'jenkins.io' |> {
+      ssl_key       => '/etc/letsencrypt/live/jenkins.io/privkey.pem',
+      # When Apache is upgraded to >= 2.4.8 this should be changed to
+      # fullchain.pem
+      ssl_cert      => '/etc/letsencrypt/live/jenkins.io/cert.pem',
+      ssl_chain     => '/etc/letsencrypt/live/jenkins.io/chain.pem',
     }
   }
 }

--- a/dist/role/manifests/eggplant.pp
+++ b/dist/role/manifests/eggplant.pp
@@ -4,5 +4,6 @@ class role::eggplant {
   include profile::base
   include profile::sudo::osu
   include profile::staticsite
+  include profile::catchall
   include profile::accountapp
 }

--- a/dist/role/manifests/vhostcatchall.pp
+++ b/dist/role/manifests/vhostcatchall.pp
@@ -1,0 +1,9 @@
+#
+# This role is for a simple apache host which serves as a catch-all for legacy
+# domains under jenkins-ci.org
+#
+# <https://issues.jenkins-ci.org/browse/INFRA-639>
+class role::vhostcatchall {
+  include profile::base
+  include profile::catchall
+}

--- a/spec/classes/profile/catchall_spec.rb
+++ b/spec/classes/profile/catchall_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'profile::catchall' do
+  let(:docroot) { '/tmp/rspecdocroot' }
+  let(:params) do
+    {
+      :docroot => docroot,
+    }
+  end
+
+  it { should contain_class 'profile::catchall' }
+  it { should contain_class 'apache' }
+
+  it { should contain_file(docroot).with_ensure(:directory) }
+  # https://issues.jenkins-ci.org/browse/INFRA-639
+  it 'should install jenkins.jnlp' do
+    expect(subject).to contain_file("#{docroot}/jenkins.jnlp").with({
+      :ensure => :present,
+      :owner => 'www-data',
+      :mode => '0755',
+    })
+  end
+
+  ['legacy_cert.key', 'legacy_chain.crt', 'legacy_cert.crt'].each do |f|
+    it { should contain_file("/etc/apache2/#{f}").with_ensure(:present) }
+  end
+
+  context 'Apache VirtualHosts' do
+    context 'HTTPs VirtualHost' do
+      let(:name) { 'jenkins-ci.org' }
+      it { should contain_apache__vhost(name) }
+
+      it 'should be configured to serve over HTTPs' do
+        expect(subject).to contain_apache__vhost(name).with({
+          :port => 443,
+          :ssl => true,
+          :ssl_key   => '/etc/apache2/legacy_cert.key',
+          :ssl_chain => '/etc/apache2/legacy_chain.crt',
+          :ssl_cert  => '/etc/apache2/legacy_cert.crt',
+        })
+      end
+    end
+
+
+    context 'HTTP VirtualHost' do
+      let(:name) { 'jenkins-ci.org unsecured' }
+      it { should contain_apache__vhost(name) }
+
+      it 'should be configured to promote to a HTTPs request' do
+        expect(subject).to contain_apache__vhost(name).with({
+          :port => 80,
+          :redirect_status => 'permanent',
+          :redirect_dest => 'https://jenkins-ci.org/',
+        })
+      end
+    end
+
+    it { pending 'INFRA-868'; should contain_apache__vhost('stats.jenkins-ci.org') }
+  end
+end

--- a/spec/classes/profile/catchall_spec.rb
+++ b/spec/classes/profile/catchall_spec.rb
@@ -55,6 +55,9 @@ describe 'profile::catchall' do
       end
     end
 
-    it { pending 'INFRA-868'; should contain_apache__vhost('stats.jenkins-ci.org') }
+    # Legacy vhosts which I hope can perish at some point
+    # See INFRA-639
+    it { should contain_apache__vhost('stats.jenkins-ci.org') }
+    it { should contain_apache__vhost('maven.jenkins-ci.org') }
   end
 end

--- a/spec/classes/role/vhostcatchall_spec.rb
+++ b/spec/classes/role/vhostcatchall_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'role::vhostcatchall' do
+  it { should contain_class 'role::vhostcatchall' }
+  it { should contain_class 'profile::base' }
+  it { should contain_class 'profile::catchall' }
+end

--- a/spec/server/eggplant/eggplant_spec.rb
+++ b/spec/server/eggplant/eggplant_spec.rb
@@ -11,4 +11,36 @@ describe 'eggplant' do
       its(:content) { should match /server=ldap/ }
     end
   end
+
+
+  it_behaves_like 'an Apache webserver'
+
+  describe 'Redirects' do
+    cmd = "curl -kvH 'Host: jenkins-ci.org' https://127.0.0.1"
+
+    describe command(cmd) do
+      its(:stderr) { should match 'Location: https://jenkins.io/index.html' }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command("#{cmd}/redhat/jenkins.io.key") do
+      its(:stderr) { should match 'Location: https://pkg.jenkins.io/redhat/jenkins.io.key' }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command("#{cmd}/jenkins-ci.org.key") do
+      its(:stderr) { should match 'Location: https://pkg.jenkins.io/redhat/jenkins.io.key' }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command("#{cmd}/issue/2") do
+      its(:stderr) { should match 'Location: https://issues.jenkins-ci.org/browse/JENKINS-2' }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command("#{cmd}/rate/rate.js") do
+      its(:stderr) { should match 'Location: https://rating.jenkins.io/rate.js' }
+      its(:exit_status) { should eq 0 }
+    end
+  end
 end

--- a/spec/server/vhostcatchall/vhostcatchall_spec.rb
+++ b/spec/server/vhostcatchall/vhostcatchall_spec.rb
@@ -1,0 +1,34 @@
+require_relative './../spec_helper'
+
+describe 'vhostcatchall' do
+  it_behaves_like 'an Apache webserver'
+
+  describe 'Redirects' do
+    cmd = "curl -kvH 'Host: jenkins-ci.org' https://127.0.0.1"
+
+    describe command(cmd) do
+      its(:stderr) { should match 'Location: https://jenkins.io/index.html' }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command("#{cmd}/redhat/jenkins.io.key") do
+      its(:stderr) { should match 'Location: https://pkg.jenkins.io/redhat/jenkins.io.key' }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command("#{cmd}/jenkins-ci.org.key") do
+      its(:stderr) { should match 'Location: https://pkg.jenkins.io/redhat/jenkins.io.key' }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command("#{cmd}/issue/2") do
+      its(:stderr) { should match 'Location: https://issues.jenkins-ci.org/browse/JENKINS-2' }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command("#{cmd}/rate/rate.js") do
+      its(:stderr) { should match 'Location: https://rating.jenkins.io/rate.js' }
+      its(:exit_status) { should eq 0 }
+    end
+  end
+end


### PR DESCRIPTION
This change also includes some serverspec to validate some of the more important
redirects

References [INFRA-639](https://issues.jenkins-ci.org/browse/INFRA-639)
