### PR TITLE
Puppetize the serving of javadocs for various Jenkins releases

### DIFF
--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -46,7 +46,7 @@ www         3600    IN    CNAME    @
 issues      3600    IN    CNAME    edamame
 wiki        3600    IN    CNAME    lettuce
 updates     3600    IN    CNAME    updates.jenkins.io.
-javadoc     3600    IN    CNAME    cucumber
+javadoc     3600    IN    CNAME    javadoc.jenkins.io.
 gherkin     3600    IN    CNAME    cucumber
 drupal      3600    IN    CNAME    cucumber
 downloads   3600    IN    CNAME    cucumber

--- a/dist/profile/files/bind/jenkins.io.zone
+++ b/dist/profile/files/bind/jenkins.io.zone
@@ -55,6 +55,7 @@ archives    3600    IN    CNAME    okra ; archives.jenkins.io for delivering old
 fallback    3600    IN    CNAME    spinach ; fallback.jenkins.io for acting as a fallback mirror
 stats       3600    IN    CNAME    jenkins-infra.github.io. ; CNAME for stats.jenkins.io which is hosted on GH pages
 patron      3600    IN    CNAME    jenkins-infra.github.io. ; CNAME for patron.jenkins.io which is hosted on GH pages
+javadoc     3600    IN    CNAME    eggplant ; CNAME for javadoc.jenkins.io which is currently in role::eggplant
 
 ; Magical CNAME for certificate validation
 D07F852F584FA592123140354D366066.ldap.jenkins.io. 3600 IN CNAME 75E741181A7ACDBE2996804B2813E09B65970718.comodoca.com.

--- a/dist/profile/manifests/javadoc.pp
+++ b/dist/profile/manifests/javadoc.pp
@@ -1,0 +1,49 @@
+#
+# javadoc profile for managing the basic statically hosted site for javadocs
+#
+# https://github.com/jenkins-infra/javadoc/
+class profile::javadoc(
+  $site_root = '/srv/javadoc',
+  $remote_archive = 'https://ci.jenkins.io/job/Infrastructure/job/javadoc/lastSuccessfulBuild/artifact/build/javadoc-site.tar.bz2'
+) {
+  include ::apache
+  include profile::apachemisc
+
+  $user = 'www-data'
+
+  file { $site_root:
+    ensure => directory,
+    owner  => $user,
+    group  => 'www-data',
+  }
+
+  cron { 'update javadoc.jenkins.io':
+    ensure  => present,
+    command => "cd /tmp && /usr/bin/wget ${remote_archive} && /bin/tar -C ${site_root} --strip 1 --overwrite --owner=${user} -xjf javadoc-site.tar.bz2 && rm -f javadoc-site.tar.bz2",
+    user    => $user,
+    hour    => 4,
+    minute  => 0,
+    weekday => 1,
+  }
+
+  $apache_log_dir = '/var/log/apache2/javadoc.jenkins.io'
+  file { $apache_log_dir:
+    ensure => directory,
+    owner  => $user,
+    group  => 'www-data',
+  }
+
+  apache::vhost { 'javadoc.jenkins.io':
+    serveraliases   => [
+      'javadoc.jenkins-ci.org',
+    ],
+    docroot         => $site_root,
+    port            => 80,
+    access_log_pipe => "|/usr/bin/rotatelogs ${apache_log_dir}/access.log.%Y%m%d%H%M%S 604800",
+    error_log_file  => 'javadoc.jenkins.io/error.log',
+    require         => [
+      File[$site_root],
+      File[$apache_log_dir],
+    ],
+  }
+}

--- a/dist/role/manifests/eggplant.pp
+++ b/dist/role/manifests/eggplant.pp
@@ -5,5 +5,6 @@ class role::eggplant {
   include profile::sudo::osu
   include profile::staticsite
   include profile::catchall
+  include profile::javadoc
   include profile::accountapp
 }

--- a/spec/classes/profile/javadoc_spec.rb
+++ b/spec/classes/profile/javadoc_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'profile::javadoc' do
+  let(:params) do
+    {
+      :site_root => '/tmp/rspec-javadoc-root',
+    }
+  end
+
+  it { should contain_class 'profile::javadoc' }
+  it { should contain_class 'apache' }
+
+  it { should contain_file(params[:site_root]).with_ensure(:directory) }
+
+  context 'Apache VirtualHosts' do
+    it { should contain_apache__vhost('javadoc.jenkins.io') }
+
+    context 'javadoc.jenkins.io' do
+    end
+  end
+
+  context 'updating' do
+    it 'should contain a cron to update the javadoc' do
+      expect(subject).to contain_cron('update javadoc.jenkins.io').with({
+        :user => 'www-data',
+      })
+    end
+  end
+end


### PR DESCRIPTION
The javadoc archives are generated every monday morning at 1AM by this job:
    https://github.com/jenkins-infra/javadoc/

Since the archives are rather big, and we only need to update after a regular
weekly release, this commit includes a cron to grab the latest successful build
every monday morning at 4AM

Fixes [INFRA-49](https://issues.jenkins-ci.org/browse/INFRA-49)
