### PR TITLE
Update the javadoc archive location to the new job location

### DIFF
--- a/dist/profile/manifests/javadoc.pp
+++ b/dist/profile/manifests/javadoc.pp
@@ -4,7 +4,7 @@
 # https://github.com/jenkins-infra/javadoc/
 class profile::javadoc(
   $site_root = '/srv/javadoc',
-  $remote_archive = 'https://ci.jenkins.io/job/Infrastructure/job/javadoc/lastSuccessfulBuild/artifact/build/javadoc-site.tar.bz2'
+  $remote_archive = 'https://ci.jenkins.io/job/Infra/job/javadoc/job/master/lastSuccessfulBuild/artifact/build/javadoc-site.tar.bz2',
 ) {
   include ::apache
   include profile::apachemisc


### PR DESCRIPTION
This job is now managed by the GitHub Organization Folder

See also [INFRA-722](https://issues.jenkins-ci.org/browse/INFRA-722)
