### PR TITLE
[FIXED INFRA-896]

### DIFF
--- a/dist/profile/manifests/usage.pp
+++ b/dist/profile/manifests/usage.pp
@@ -147,7 +147,7 @@ class profile::usage(
     ssl             => true,
     docroot         => $docroot,
     error_log_file  => "${usage_fqdn}/error.log",
-    access_log_pipe => "|/usr/bin/rotatelogs ${apache_log_dir}/access.log.%Y%m%d%H%M%S 604800",
+    access_log_pipe => "|/usr/bin/rotatelogs ${apache_log_dir}/access.log.%Y%m%d%H%M%S 86400",
     require         => [
         File[$docroot],
         File[$apache_log_dir],
@@ -166,7 +166,7 @@ class profile::usage(
     override        => ['All'],
     docroot         => $docroot,
     error_log_file  => "${usage_fqdn}/error_nonssl.log",
-    access_log_pipe => "|/usr/bin/rotatelogs ${apache_log_dir}/access_nonssl.log.%Y%m%d%H%M%S 604800",
+    access_log_pipe => "|/usr/bin/rotatelogs ${apache_log_dir}/access_nonssl.log.%Y%m%d%H%M%S 86400",
     require         => [
         File[$docroot],
         File[$apache_log_dir],


### PR DESCRIPTION
usage log stats should be daily to ensure timely processing and allow
easy day-by-day comparison by eyes.

The rest of the processing pipeline depends on logs being daily, too.
