### PR TITLE
Block abusive user agents who are hitting ci.jenkins.io by default

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -23,6 +23,7 @@ class profile::buildmaster(
   include ::apache
   include apache::mod::proxy
   include apache::mod::headers
+  include apache::mod::rewrite
 
   validate_string($ci_fqdn)
   validate_bool($letsencrypt)
@@ -125,6 +126,13 @@ class profile::buildmaster(
     custom_fragment       => "
 RequestHeader set X-Forwarded-Proto \"https\"
 RequestHeader set X-Forwarded-Port \"${proxy_port}\"
+
+RewriteEngine on
+# Block abusive software which is default configured to hit our Jenkins
+# instance(s). These are typically Build Notifiers that use us as a default
+# since we're public, not anymore for you!
+RewriteCond %{HTTP_USER_AGENT} YisouSpider|Catlight*|CheckmanJenkins [NC]
+RewriteRule ^.* - [F,L]
 ",
     proxy_pass            => [
       {

--- a/spec/server/jenkins_master/jenkins_master_spec.rb
+++ b/spec/server/jenkins_master/jenkins_master_spec.rb
@@ -27,5 +27,16 @@ describe 'jenkins_master' do
     describe port(443) do
       it { should be_listening }
     end
+
+    context 'Blocking bots' do
+      ['YisouSpider',
+       'Catlight/1.8.7',
+       'CheckmanJenkins (Hostname: derptown)',
+      ].each do |agent|
+        describe command("curl --verbose --insecure -A \"#{agent}\" -H 'Location: https://ci.jenkins.io/' --output /dev/null https://127.0.0.1/ 2>&1 | grep '403 Forbidden'") do
+          its(:exit_status) { should eql 0 }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes [INFRA-917](https://issues.jenkins-ci.org/browse/INFRA-917)
