### PR TITLE
Redirect abusive build notifiers to a nice dandy HTML page

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -132,7 +132,7 @@ RewriteEngine on
 # instance(s). These are typically Build Notifiers that use us as a default
 # since we're public, not anymore for you!
 RewriteCond %{HTTP_USER_AGENT} YisouSpider|Catlight*|CheckmanJenkins [NC]
-RewriteRule ^.* - [F,L]
+RewriteRule ^.* \"https://jenkins.io/infra/ci-redirects/\"  [L]
 ",
     proxy_pass            => [
       {

--- a/spec/server/jenkins_master/jenkins_master_spec.rb
+++ b/spec/server/jenkins_master/jenkins_master_spec.rb
@@ -29,11 +29,12 @@ describe 'jenkins_master' do
     end
 
     context 'Blocking bots' do
+      # Bots are being redirected, booyah
       ['YisouSpider',
        'Catlight/1.8.7',
        'CheckmanJenkins (Hostname: derptown)',
       ].each do |agent|
-        describe command("curl --verbose --insecure -A \"#{agent}\" -H 'Location: https://ci.jenkins.io/' --output /dev/null https://127.0.0.1/ 2>&1 | grep '403 Forbidden'") do
+        describe command("curl --verbose --insecure -A \"#{agent}\" -H 'Location: https://ci.jenkins.io/' --output /dev/null https://127.0.0.1/ 2>&1 | grep '302 Found'") do
           its(:exit_status) { should eql 0 }
         end
       end


### PR DESCRIPTION
According to @abayer, the 403's just caused these build notifiers to hammer
ci.jenkins.io harder. So let's give them some HTML to chew on

See jenkins-infra/jenkins.io#381
