### PR TITLE
Allow http://ci.jenkins-ci.org to redirect to https://ci.jenkins.io/

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -157,6 +157,11 @@ RewriteRule ^.* \"https://jenkins.io/infra/ci-redirects/\"  [L]
   }
 
   apache::vhost { "${ci_fqdn} unsecured":
+    serveraliases   => [
+      # Give all our buildmaster profiles this server alias; it's easier than
+      # parameterizing it for compatibility's sake
+      'ci.jenkins-ci.org',
+    ],
     servername      => $ci_fqdn,
     port            => 80,
     docroot         => $docroot,

--- a/spec/server/jenkins_master/jenkins_master_spec.rb
+++ b/spec/server/jenkins_master/jenkins_master_spec.rb
@@ -1,7 +1,8 @@
 require_relative './../spec_helper'
 
 describe 'jenkins_master' do
-  it_behaves_like "a standard Linux machine"
+  it_behaves_like 'a standard Linux machine'
+  it_behaves_like 'an Apache webserver'
 
   context 'the jenkins service' do
     describe service('jenkins') do
@@ -26,6 +27,13 @@ describe 'jenkins_master' do
 
     describe port(443) do
       it { should be_listening }
+    end
+
+    context 'HTTP redirects' do
+      describe command("curl -kvH 'Host: ci.jenkins-ci.org' http://127.0.0.1") do
+      its(:stderr) { should match 'Location: https://ci.jenkins.io/' }
+      its(:exit_status) { should eq 0 }
+      end
     end
 
     context 'Blocking bots' do


### PR DESCRIPTION
Fixes [INFRA-918](https://issues.jenkins-ci.org/browse/INFRA-918)
