### PR TITLE
Upgrade Docker and switch to the aufs storage driver

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -15,9 +15,6 @@ fixtures:
     irc:
       repo: 'git://github.com/jenkins-infra/puppet-irc.git'
       ref: '4e5e437'
-    docker:
-      repo: 'git://github.com/jenkins-infra/garethr-docker.git'
-      ref: '951781fbeb06fa8142e851c5746c35b302a6f427'
     apachelogcompressor:
       repo: 'git://github.com/jenkins-infra/puppet-apachelogcompressor.git'
     mirrorbrain:
@@ -100,6 +97,9 @@ fixtures:
     postgresql:
       repo: 'puppetlabs/postgresql'
       ref: '4.7.1'
+    docker:
+      repo: 'garethr/docker'
+      ref: '5.3.0'
 
 
 

--- a/Puppetfile
+++ b/Puppetfile
@@ -36,8 +36,7 @@ mod 'reidmv/yamlfile'
 # Needed by `yamlfile`
 mod 'adrien/filemapper'
 
-mod 'docker', :git => 'git://github.com/jenkins-infra/garethr-docker.git',
-              :ref => '951781fbeb06fa8142e851c5746c35b302a6f427'
+mod 'garethr/docker', '5.3.0'
 
 # Deps for docker
 mod 'puppetlabs/apt', '2.2.2'

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -7,6 +7,7 @@ class profile::docker {
     # kernel modules on Ubuntu 12.04 LTS and restart the host machine anyways
     manage_kernel    => false,
     extra_parameters => '--storage-driver=aufs',
+    require          => Package['linux-image-extra'],
   }
 
   include datadog_agent::integrations::docker
@@ -22,5 +23,10 @@ class profile::docker {
     # traffic within docker is OK
     iniface => 'docker0',
     action  => 'accept',
+  }
+
+  package { 'linux-image-extra':
+    ensure => present,
+    name   => "linux-image-extra-${::kernelrelease}",
   }
 }

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -2,10 +2,11 @@
 # Profile for managing basics of docker installation/configuration
 class profile::docker {
   class { '::docker':
-    version       => '1.9.1',
+    version          => '1.9.1',
     # Disabling the management of the kernel, since we have to pre-install
     # kernel modules on Ubuntu 12.04 LTS and restart the host machine anyways
-    manage_kernel => false,
+    manage_kernel    => false,
+    extra_parameters => '--storage-driver=aufs',
   }
 
   include datadog_agent::integrations::docker

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -2,7 +2,6 @@
 # Profile for managing basics of docker installation/configuration
 class profile::docker {
   class { '::docker':
-    version          => '1.9.1',
     # Disabling the management of the kernel, since we have to pre-install
     # kernel modules on Ubuntu 12.04 LTS and restart the host machine anyways
     manage_kernel    => false,

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -3,7 +3,7 @@
 class profile::docker {
   class { '::docker':
     # Disabling the management of the kernel, since we have to pre-install
-    # kernel modules on Ubuntu 12.04 LTS and restart the host machine anyways
+    # kernel modules on Ubuntu 14.04 LTS and restart the host machine anyways
     manage_kernel    => false,
     extra_parameters => '--storage-driver=aufs',
     require          => Package['linux-image-extra'],

--- a/dist/profile/manifests/robobutler.pp
+++ b/dist/profile/manifests/robobutler.pp
@@ -52,19 +52,6 @@ class profile::robobutler (
     use_name => true,
   }
 
-  # 'restart docker-butlerbot' won't do because it will not reload the configuration
-  exec { 'restart-butlerbot':
-    refreshonly => true,
-    command     => '/sbin/stop docker-butlerbot; /sbin/start docker-butlerbot',
-  }
-
-  # The File[/etc/init/docker-butlerbot.conf] resource is declared by the
-  # module, but we still need to punt the container if the config changes
-  File <| title == '/etc/init/docker-butlerbot.conf' |> {
-    notify  => Exec['restart-butlerbot'],
-  }
-
-
   file { '/var/log/apache2/meetings.jenkins-ci.org':
     ensure => directory,
   }

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -241,4 +241,6 @@ usage_ssh_privkey: 'usage_ssh_privkey'
 osuosl_mirroring_privkey: ''
 archives_mirroring_privkey: ''
 
+docker::version: '1.12.1-0~trusty'
+
 # vim: ft=yaml ts=2 sw=2 nowrap et

--- a/spec/classes/profile/robobutler_spec.rb
+++ b/spec/classes/profile/robobutler_spec.rb
@@ -9,10 +9,6 @@ describe 'profile::robobutler' do
   it { should contain_docker__image 'jenkinsciinfra/butlerbot' }
   it { should contain_docker__run 'butlerbot' }
 
-  it 'should restart butlerbot when the docker conf updates' do
-    should contain_file('/etc/init/docker-butlerbot.conf').that_notifies('Exec[restart-butlerbot]')
-  end
-
   it { should contain_apache__vhost('meetings.jenkins-ci.org') }
 
   it_behaves_like 'it has webserver firewall rules'


### PR DESCRIPTION
See [INFRA-935](https://issues.jenkins-ci.org/browse/INFRA-935) for more details.

This pull request also upgrades our garethr/docker module which we have been running a forked version of, and no longer need to do so.
