### PR TITLE
Remove deprecated use_name parameters from docker::run

### DIFF
--- a/dist/profile/manifests/accountapp.pp
+++ b/dist/profile/manifests/accountapp.pp
@@ -53,7 +53,6 @@ class profile::accountapp(
       "JIRA_PASSWORD=${jira_password}",
     ],
     extra_parameters => ['--net=host'],
-    use_name         => true,
   }
 
   profile::datadog_check { 'accountapp-http-check':

--- a/dist/profile/manifests/bind.pp
+++ b/dist/profile/manifests/bind.pp
@@ -49,14 +49,13 @@ class profile::bind (
   }
 
   docker::run { 'bind':
-    command  => undef,
-    ports    => ['53:53', '53:53/udp'],
-    image    => "jenkinsciinfra/bind:${image_tag}",
-    volumes  => ['/etc/bind/local:/etc/bind/local'],
-    require  => [File["${conf_dir}/named.conf.local"],
+    command => undef,
+    ports   => ['53:53', '53:53/udp'],
+    image   => "jenkinsciinfra/bind:${image_tag}",
+    volumes => ['/etc/bind/local:/etc/bind/local'],
+    require => [File["${conf_dir}/named.conf.local"],
       File["${conf_dir}/jenkins-ci.org.zone"],
     ],
-    use_name => true,
   }
 
   exec { 'sighup-named':

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -67,7 +67,6 @@ class profile::confluence (
     volumes         => ['/srv/wiki/home:/srv/wiki/home', '/srv/wiki/cache:/srv/wiki/cache'],
     env_file        => '/srv/wiki/container.env',
     restart_service => true,
-    use_name        => true,
     require         => File['/srv/wiki/container.env'],
   }
 
@@ -85,16 +84,6 @@ class profile::confluence (
     # to the docker run command
     env             => ['TARGET=http://confluence:8080'],
     restart_service => true,
-    use_name        => true,
-  }
-
-  # If the configuration changes, containers have to be kicked & restarted
-  # due to the dependency between those two, change in confluence forces restart of both
-  File <| title == '/etc/init/docker-confluence.conf' |> {
-    notify  => [Service['docker-confluence'],Service['docker-confluence-cache']]
-  }
-  File <| title == '/etc/init/docker-confluence-cache.conf' |> {
-    notify  => Service['docker-confluence-cache'],
   }
 
   ### to put maintenance screen up, comment out the following and comment in the apache::vhost for https://jenkins-ci.org

--- a/dist/profile/manifests/demo.pp
+++ b/dist/profile/manifests/demo.pp
@@ -21,19 +21,12 @@ $image_tag = '2.23'
     image           => "${image}:${image_tag}",
     ports           => ['8080:8080'],
     restart_service => true,
-    use_name        => true,
     require         => [
       Class['::docker'],
       Docker::Image[$image],
       File['/srv/demo/passwd'],
       User[$user],
     ],
-  }
-
-  # The File[/etc/init/docker-demo.conf] resource is declared by the
-  # module, but we still need to punt the container if the config changes
-  File <| title == '/etc/init/docker-demo.conf' |> {
-    notify  => Service['docker-demo'],
   }
 
   account { $user:

--- a/dist/profile/manifests/jenkinsadmin.pp
+++ b/dist/profile/manifests/jenkinsadmin.pp
@@ -34,13 +34,6 @@ class profile::jenkinsadmin (
                 File['/home/ircbot/.github'],
                 File['/home/ircbot/.jenkins-ci.org'],
     ],
-    use_name => true,
-  }
-
-  # The File[/etc/init/docker-ircbot.conf] resource is declared by the
-  # module, but we still need to punt the container if the config changes
-  File <| title == '/etc/init/docker-ircbot.conf' |> {
-    notify  => Service['docker-ircbot'],
   }
 
   user { $user:

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -51,7 +51,6 @@ class profile::jira (
       image           => 'mariadb',
       env             => ['MYSQL_ROOT_PASSWORD=s3cr3t','MYSQL_USER=jira','MYSQL_PASSWORD=raji','MYSQL_DATABASE=jiradb'],
       restart_service => true,
-      use_name        => true,
       command         => undef,
     }
     $jira_links = ['jiradb:db']
@@ -70,7 +69,6 @@ class profile::jira (
     volumes         => ['/srv/jira/home:/srv/jira/home'],
     env_file        => '/srv/jira/container.env',
     restart_service => true,
-    use_name        => true,
     require         => File['/srv/jira/container.env'],
     links           => $jira_links,
   }

--- a/dist/profile/manifests/l10n_server.pp
+++ b/dist/profile/manifests/l10n_server.pp
@@ -26,13 +26,6 @@ class profile::l10n_server (
     image    => "${image}:${image_tag}",
     require  => [Docker::Image[$image],
     ],
-    use_name => true,
-  }
-
-  # The File[/etc/init/docker-ircbot.conf] resource is declared by the
-  # module, but we still need to punt the container if the config changes
-  File <| title == '/etc/init/docker-l10n.conf' |> {
-    notify  => Service['docker-l10n'],
   }
 
   user { $user:

--- a/dist/profile/manifests/rating.pp
+++ b/dist/profile/manifests/rating.pp
@@ -18,20 +18,13 @@ class profile::rating (
   }
 
   docker::run { 'rating':
-    image    => "${image}:${image_tag}",
-    volumes  => ["${config}:/config/dbconfig.php"
+    image   => "${image}:${image_tag}",
+    volumes => ["${config}:/config/dbconfig.php"
     ],
-    ports    => ['8083:80'],
-    require  => [Docker::Image[$image],
+    ports   => ['8083:80'],
+    require => [Docker::Image[$image],
                 File[$config],
     ],
-    use_name => true,
-  }
-
-  # The File[/etc/init/docker-ircbot.conf] resource is declared by the
-  # module, but we still need to punt the container if the config changes
-  File <| title == '/etc/init/docker-rating.conf' |> {
-    notify  => Service['docker-rating'],
   }
 
   file { $config:

--- a/dist/profile/manifests/robobutler.pp
+++ b/dist/profile/manifests/robobutler.pp
@@ -45,11 +45,10 @@ class profile::robobutler (
   }
 
   docker::run { 'butlerbot':
-    command  => undef,
-    image    => "jenkinsciinfra/butlerbot:${tag}",
-    volumes  => ["${logdir}:${logdir}", '/etc/butlerbot:/etc/butlerbot'],
-    require  => File['/etc/butlerbot/main.conf'],
-    use_name => true,
+    command => undef,
+    image   => "jenkinsciinfra/butlerbot:${tag}",
+    volumes => ["${logdir}:${logdir}", '/etc/butlerbot:/etc/butlerbot'],
+    require => File['/etc/butlerbot/main.conf'],
   }
 
   file { '/var/log/apache2/meetings.jenkins-ci.org':


### PR DESCRIPTION
This commit also removes the legacy hack around upstart configurations, since
the newer garethr/docker no longer uses upstart (because it's a POS)
