### PR TITLE
Drop the system package in favor of the `jenkins` Docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-#!groovy
+#!/usr/bin/env groovy
 
 def nodeLabel = 'docker'
 def dockerImage = 'rtyler/jenkins-infra-builder'
@@ -52,6 +52,9 @@ def runInside(String dockerImage, Closure c) {
                     'GIT_AUTHOR_NAME=Cake',
                     'GIT_AUTHOR_EMAIL=hates@cake.com',
     ]
+
+    /* clean out our workspace before we do anything */
+    deleteDir()
 
     /* This requires the Timestamper plugin to be installed on the Jenkins */
     timestamps {

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -30,6 +30,7 @@ class profile::buildmaster(
   validate_array($plugins)
 
   include profile::apachemisc
+  include profile::docker
   include profile::firewall
 
   if $letsencrypt {
@@ -42,24 +43,37 @@ class profile::buildmaster(
   $ldap_admin_password = hiera('ldap_admin_password')
 
   class { '::jenkins':
-    lts       => true,
+    # Preventing the jenkins module from managing the package for us, since
+    # we're using the Docker container, see:
+    # https://issues.jenkins-ci.org/browse/INFRA-916·
+    version        => absent,
+    repo           => false,
+    service_enable => false,
+    service_ensure => stopped,
   }
 
+  docker::run { 'jenkins':
+    image         => 'jenkins',
+    username      => 'jenkins',
+    ports         => ['8080:8080', '50000:50000'],
+    volumes       => ['/var/lib/jenkins', '/var/jenkins_home'],
+    pull_on_start => true,
+    require       => [
+        File['/var/lib/jenkins'],
+        User['jenkins'],
+    ],
+  }
 
   $script_dir = '/usr/share/jenkins'
-  exec { 'jenkins-script-mkdirp':
-    command => "/bin/mkdir -p ${script_dir}",
-    creates => $script_dir,
+  file { $script_dir:
+    ensure => directory,
   }
 
   $ssh_dir = '/var/lib/jenkins/.ssh'
   $ssh_cli_key = 'jenkins-cli-key'
-  exec { 'jenkins-ssh-mkdirp':
-    command => "/bin/mkdir -p ${ssh_dir}",
-    creates => $ssh_dir,
-  }
+
   exec { 'generate-cli-ssh-key':
-    require => Exec['jenkins-ssh-mkdirp'],
+    require => File['/var/lib/jenkins'],
     creates => "${ssh_dir}/${ssh_cli_key}",
     command => "/usr/bin/ssh-keygen -b 4096 -q -f ${ssh_dir}/${ssh_cli_key} -N ''",
   }
@@ -67,7 +81,7 @@ class profile::buildmaster(
   $cli_script = "${script_dir}/idempotent-cli"
   file { $cli_script:
     ensure  => present,
-    require => Exec['jenkins-script-mkdirp'],
+    require => File[$script_dir],
     source  => "puppet:///modules/${module_name}/buildmaster/idempotent-cli",
     mode    => '0755',
   }
@@ -76,7 +90,7 @@ class profile::buildmaster(
 
   file { $lockbox_script :
     ensure  => present,
-    require => Exec['jenkins-script-mkdirp'],
+    require => File[$script_dir],
     content =>template("${module_name}/buildmaster/lockbox.groovy.erb"),
   }
   profile::jenkinsgroovy { 'lock-down-jenkins':
@@ -123,6 +137,7 @@ class profile::buildmaster(
       'ci.jenkins-ci.org',
     ],
     require               => [
+      Docker::Run['jenkins'],
       File[$docroot],
       # We need our installation to be secure before we allow access
       Profile::Jenkinsgroovy['lock-down-jenkins'],

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -56,7 +56,7 @@ class profile::buildmaster(
     image         => 'jenkins',
     username      => 'jenkins',
     ports         => ['8080:8080', '50000:50000'],
-    volumes       => ['/var/lib/jenkins', '/var/jenkins_home'],
+    volumes       => ['/var/lib/jenkins:/var/jenkins_home'],
     pull_on_start => true,
     require       => [
         File['/var/lib/jenkins'],

--- a/dist/profile/manifests/jenkinsgroovy.pp
+++ b/dist/profile/manifests/jenkinsgroovy.pp
@@ -14,6 +14,7 @@ define profile::jenkinsgroovy (
     tries     => $::jenkins::cli_tries,
     try_sleep => $::jenkins::cli_try_sleep,
     unless    => "/usr/share/jenkins/idempotent-cli groovy ${path}",
+    require   => Docker::Run['jenkins'],
     path      => ['/bin', '/usr/bin'],
   }
 }

--- a/dist/profile/manifests/jenkinsplugin.pp
+++ b/dist/profile/manifests/jenkinsplugin.pp
@@ -14,6 +14,7 @@ define profile::jenkinsplugin (
     try_sleep => $::jenkins::cli_try_sleep,
     path      => ['/bin', '/usr/bin'],
     unless    => "/usr/bin/test -f /var/lib/jenkins/plugins/${name}.jpi",
+    require   => Docker::Run['jenkins'],
     notify    => Exec['safe-restart-jenkins'],
   }
 }

--- a/spec/classes/profile/buildmaster_spec.rb
+++ b/spec/classes/profile/buildmaster_spec.rb
@@ -23,7 +23,7 @@ describe 'profile::buildmaster' do
           :image => 'jenkins',
           :username => 'jenkins',
           :pull_on_start => true,
-          :volumes => ['/var/lib/jenkins', '/var/jenkins_home'],
+          :volumes => ['/var/lib/jenkins:/var/jenkins_home'],
         })
       end
     end

--- a/spec/classes/profile/buildmaster_spec.rb
+++ b/spec/classes/profile/buildmaster_spec.rb
@@ -8,7 +8,27 @@ describe 'profile::buildmaster' do
     }
   end
 
-  it { should contain_class 'jenkins' }
+  context 'Jenkins configuration' do
+    it { should contain_class 'jenkins' }
+    it { should contain_file('/var/lib/jenkins/hudson.plugins.git.GitSCM.xml') }
+
+    # https://issues.jenkins-ci.org/browse/INFRA-916
+    context 'as a Docker container' do
+      it { should contain_package('jenkins').with_ensure('absent') }
+      it { should contain_file('/var/lib/jenkins').with_ensure('directory') }
+      it { should contain_class 'profile::docker' }
+
+      it 'should define a suitable docker::run' do
+        expect(subject).to contain_docker__run('jenkins').with({
+          :image => 'jenkins',
+          :username => 'jenkins',
+          :pull_on_start => true,
+          :volumes => ['/var/lib/jenkins', '/var/jenkins_home'],
+        })
+      end
+    end
+  end
+
 
   context 'JNLP' do
     it 'should open the JNLP port in the firewall' do
@@ -18,10 +38,6 @@ describe 'profile::buildmaster' do
         :action => 'accept',
       })
     end
-  end
-
-  context 'system configuration' do
-    it { should contain_file('/var/lib/jenkins/hudson.plugins.git.GitSCM.xml') }
   end
 
 
@@ -90,14 +106,6 @@ describe 'profile::buildmaster' do
           :ssl_chain => "/etc/letsencrypt/live/#{fqdn}/chain.pem",
         })
       end
-    end
-  end
-
-  context 'jenkins master configuration' do
-    it 'should default to LTS' do
-      expect(subject).to contain_class('jenkins').with({
-        :lts => true,
-      })
     end
   end
 


### PR DESCRIPTION
This will make it easier for us to get the latest and greatest updates, but also
allow us to be a bit more independent when it comes to choosing the most
appropriate JRE for the Jenkins instance

Fixes [INFRA-916](https://issues.jenkins-ci.org/browse/INFRA-916)
