### PR TITLE
Tidy up the idempotent CLI a bit

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,9 +20,6 @@ fixtures:
     mirrorbrain:
       repo: 'git://github.com/jenkins-infra/puppet-mirrorbrain.git'
       ref: '78ec0b0'
-    jenkins:
-      repo: 'git://github.com/jenkinsci/puppet-jenkins.git'
-      ref: 'd70fd6f'
     r10k:
       repo: 'git://github.com/acidprime/r10k.git'
       ref: 'f270781'
@@ -100,6 +97,12 @@ fixtures:
     docker:
       repo: 'garethr/docker'
       ref: '5.3.0'
+    jenkins:
+      repo: 'rtyler/jenkins'
+      ref: '1.7.0'
+    archive:
+      repo: 'puppet/archive'
+      ref: '1.1.2'
 
 
 

--- a/Puppetfile
+++ b/Puppetfile
@@ -91,11 +91,10 @@ mod 'mirrorbrain',
     :ref => '78ec0b0'
 
 # For managing Jenkins itself
-mod 'rtyler/jenkins',
-  :git => 'git://github.com/jenkinsci/puppet-jenkins.git',
-  :ref => 'd70fd6f'
+mod 'rtyler/jenkins', '1.7.0'
 # Needed for the Jenkins module
 mod 'puppetlabs/java', '1.5.0'
+mod 'puppet/archive', '1.1.2'
 
 
 # Needed for managing pgsql behind Mirrorbrain

--- a/dist/profile/files/buildmaster/idempotent-cli
+++ b/dist/profile/files/buildmaster/idempotent-cli
@@ -3,7 +3,7 @@
 AUTH_ARGS=""
 SSH_KEY="/var/lib/jenkins/.ssh/jenkins-cli-key"
 
-if [[ (-f $SSH_KEY) && ( ! -f '/var/lib/jenkins/config.xml') ]]; then
+if [ -f $SSH_KEY ] && [ ! -f '/var/lib/jenkins/config.xml' ]; then
     mkdir -p /var/lib/jenkins/users/jenkins
     cat > /var/lib/jenkins/users/jenkins/config.xml <<EOF
 <?xml version='1.0' encoding='UTF-8'?>
@@ -17,6 +17,7 @@ if [[ (-f $SSH_KEY) && ( ! -f '/var/lib/jenkins/config.xml') ]]; then
 </user>
 EOF
 
+    chown -R jenkins:jenkins /var/lib/jenkins/users
     AUTH_ARGS="-i ${SSH_KEY}"
 fi;
 


### PR DESCRIPTION
Through some twist of fate, the previous shell syntax was working just fine when I provisioned machines via Vagrant, but not in production.

Using a less silly conditional syntax seems to do the trick
