### PR TITLE
Change some defaults for the Jenkins instances to be more stable

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -65,7 +65,11 @@ class profile::buildmaster(
     # Additionally, Jenkins picks up `user.home` as "?" without the explicit
     # JAVA_OPTS override, breaking the current azure plugin:
     # https://github.com/jenkinsci/azure-slave-plugin/issues/56
-    env              => ['HOME=/var/jenkins_home', 'USER=jenkins', 'JAVA_OPTS="-Duser.home=/var/jenkins_home"'],
+    env              => [
+      'HOME=/var/jenkins_home',
+      'USER=jenkins',
+      'JAVA_OPTS="-Duser.home=/var/jenkins_home -Djenkins.model.Jenkins.slaveAgentPort=50000"',
+    ],
     ports            => ['8080:8080', '50000:50000'],
     volumes          => ['/var/lib/jenkins:/var/jenkins_home'],
     pull_on_start    => true,

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -68,7 +68,7 @@ class profile::buildmaster(
     env              => [
       'HOME=/var/jenkins_home',
       'USER=jenkins',
-      'JAVA_OPTS="-Duser.home=/var/jenkins_home -Djenkins.model.Jenkins.slaveAgentPort=50000"',
+      'JAVA_OPTS="-Duser.home=/var/jenkins_home -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2"',
     ],
     ports            => ['8080:8080', '50000:50000'],
     volumes          => ['/var/lib/jenkins:/var/jenkins_home'],


### PR DESCRIPTION
This should help keep things running more smoothly, but also ensure newly provisioned instances are operating properly.