### PR TITLE
Redirect HTTPs downloads from pkg.jenkins.io to Azure blob storage

### DIFF
--- a/dist/profile/templates/pkgrepo/debian_htaccess.erb
+++ b/dist/profile/templates/pkgrepo/debian_htaccess.erb
@@ -6,5 +6,14 @@ RewriteCond %{HTTP_USER_AGENT}  APT.*\(0\.7\.20     [OR]
 RewriteCond %{HTTP_USER_AGENT}  APT.*\(0\.7\.1[0-9]
 RewriteRule ^binary/(.*)\.deb$  /<%= @name %>/direct/$1.deb [L]
 
+
+# If we are serving over https://pkg.jenkins.io then redirect to Azure blob
+# storage when possible
+# 
+# See also: https://issues.jenkins-ci.org/browse/INFRA-964
+RewriteCond %{HTTPS} on
+RewriteRule ^binary/(.*)\.deb$ https://jenkinsreleases.blob.core.windows.net/<%= @name %>/$1.deb [R=302,L]
+
+
 # otherwise redirect to mirror
 RewriteRule ^binary/(.*)\.deb$ http://mirrors.jenkins.io/<%= @name %>/$1.deb [R=302,L]

--- a/spec/server/mirrorbrain/mirrorbrain_spec.rb
+++ b/spec/server/mirrorbrain/mirrorbrain_spec.rb
@@ -37,4 +37,15 @@ describe 'mirrorbrain' do
       end
     end
   end
+
+  describe 'Redirects' do
+    cmd = "curl -kvIH 'Host: pkg.jenkins.io' https://127.0.0.1"
+
+    # We should redirect HTTPs requests to pkg.jenkins.io to Azure blob storage
+    # see also: https://issues.jenkins-ci.org/browse/INFRA-964
+    describe command("#{cmd}/debian/binary/jenkins_2.0_all.deb") do
+      its(:stderr) { should match 'Location: https://jenkinsreleases.blob.core.windows.net/debian/jenkins_2.0_all.deb' }
+      its(:exit_status) { should eq 0 }
+    end
+  end
 end


### PR DESCRIPTION
This is still a bit experimental at this point as releases have to be manually
pushed to Azure blob storage by me, but this will resolve INFRA-964 and give us
a good proof-of-concept for serving more traffic off Azure blob storage

Discussed this with @daniel-beck on IRC today, seems like a good step for experimenting more with Azure-sourced downloads.

Fixes [INFRA-964](https://issues.jenkins-ci.org/browse/INFRA-964)