### PR TITLE
Migrate opensuse and redhat repositories to redirect https to Azure

### DIFF
--- a/dist/profile/manifests/opensuse_repo.pp
+++ b/dist/profile/manifests/opensuse_repo.pp
@@ -9,4 +9,11 @@ define profile::opensuse_repo (
   file { "${docroot}/${name}/repodata":
     ensure  => directory,
   }
+
+  # Manage some redirects off-host
+  # See also: https://issues.jenkins-ci.org/browse/INFRA-967
+  file { "${docroot}/${name}/.htaccess":
+    ensure  => $ensure,
+    content => template("${module_name}/pkgrepo/redhat_htaccess.erb"),
+  }
 }

--- a/dist/profile/manifests/redhat_repo.pp
+++ b/dist/profile/manifests/redhat_repo.pp
@@ -11,6 +11,13 @@ define profile::redhat_repo (
     content => template("${module_name}/pkgrepo/jenkins.repo.erb"),
   }
 
+  # Manage some redirects off-host
+  # See also: https://issues.jenkins-ci.org/browse/INFRA-967
+  file { "${docroot}/${name}/.htaccess":
+    ensure  => $ensure,
+    content => template("${module_name}/pkgrepo/redhat_htaccess.erb"),
+  }
+
   file { "${docroot}/${name}/repodata":
     ensure  => directory,
   }

--- a/dist/profile/templates/pkgrepo/redhat_htaccess.erb
+++ b/dist/profile/templates/pkgrepo/redhat_htaccess.erb
@@ -1,0 +1,8 @@
+RewriteEngine On
+
+# If we are serving over https://pkg.jenkins.io then redirect to Azure blob
+# storage when possible
+# 
+# See also: https://issues.jenkins-ci.org/browse/INFRA-967
+RewriteCond %{HTTPS} on
+RewriteRule ^(.*)\.rpm$ https://jenkinsreleases.blob.core.windows.net/<%= @name %>/$1.rpm [R=302,L]

--- a/spec/classes/profile/pkgrepo_spec.rb
+++ b/spec/classes/profile/pkgrepo_spec.rb
@@ -50,6 +50,27 @@ describe 'profile::pkgrepo' do
       end
     end
 
+    context 'opensuse repos' do
+      variants.each do |variant|
+        platform = 'opensuse'
+        variant = "-#{variant}" unless variant.nil?
+        variant = "#{platform}#{variant}"
+        let(:variant_dir) { "#{params[:docroot]}/#{variant}" }
+
+        it "should define an .htaccess file for #{variant} redirects" do
+          expect(subject).to contain_file("#{variant_dir}/.htaccess").with({
+            :ensure => :present,
+          })
+        end
+
+        it "should define a repodata/ for #{variant}" do
+          expect(subject).to contain_file("#{variant_dir}/repodata").with({
+            :ensure => :directory,
+          })
+        end
+      end
+    end
+
     context 'redhat repos' do
       variants.each do |variant|
         platform = 'redhat'
@@ -59,6 +80,12 @@ describe 'profile::pkgrepo' do
 
         it "should define a jenkins.repo for #{variant}" do
           expect(subject).to contain_file("#{variant_dir}/jenkins.repo").with({
+            :ensure => :present,
+          })
+        end
+
+        it "should define an .htaccess file for #{variant} redirects" do
+          expect(subject).to contain_file("#{variant_dir}/.htaccess").with({
             :ensure => :present,
           })
         end

--- a/spec/server/mirrorbrain/mirrorbrain_spec.rb
+++ b/spec/server/mirrorbrain/mirrorbrain_spec.rb
@@ -47,5 +47,16 @@ describe 'mirrorbrain' do
       its(:stderr) { should match 'Location: https://jenkinsreleases.blob.core.windows.net/debian/jenkins_2.0_all.deb' }
       its(:exit_status) { should eq 0 }
     end
+
+    # see also: https://issues.jenkins-ci.org/browse/INFRA-967
+    describe command("#{cmd}/redhat/jenkins-2.0-1.1.noarch.rpm") do
+      its(:stderr) { should match 'Location: https://jenkinsreleases.blob.core.windows.net/redhat/jenkins-2.0-1.1.noarch.rpm' }
+      its(:exit_status) { should eq 0 }
+    end
+
+    describe command("#{cmd}/opensuse/jenkins-2.0-1.2.noarch.rpm") do
+      its(:stderr) { should match 'Location: https://jenkinsreleases.blob.core.windows.net/opensuse/jenkins-2.0-1.2.noarch.rpm' }
+      its(:exit_status) { should eq 0 }
+    end
   end
 end


### PR DESCRIPTION
Generally, any Linux package request we get over HTTPs will now redirect over
HTTPs to Azure blob storage.

Fixes [INFRA-967](https://issues.jenkins-ci.org/browse/INFRA-967)