### PR TITLE
Update plugin site to new UI message

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -243,7 +243,7 @@ archives_mirroring_privkey: ''
 
 docker::version: '1.12.1-0~trusty'
 
-profile::pluginsite::image_tag: '12-1a342b'
+profile::pluginsite::image_tag: '13-1a342b'
 
 
 


### PR DESCRIPTION
Builds are only identified by number and `plugin-site-api` revision, not `plugin-site` revision; so changes to UI only don't show in commit ID.