### PR TITLE
[INFRA-977] --times fails mysteriously

### DIFF
--- a/dist/profile/files/mirrorbrain/sync.sh
+++ b/dist/profile/files/mirrorbrain/sync.sh
@@ -3,11 +3,11 @@ HOST=jenkins@ftp-osl.osuosl.org
 BASE_DIR=/srv/releases/jenkins
 UPDATES_DIR=/var/www/updates.jenkins.io
 REMOTE_BASE_DIR=data/
-RSYNC_ARGS="-rlpgoDvz --times"
+RSYNC_ARGS="-rlpgoDvz"
 SCRIPT_DIR=$PWD
 
 pushd $BASE_DIR
-  rsync ${RSYNC_ARGS} --delete-during --delete-excluded --prune-empty-dirs --include-from=<(
+  rsync ${RSYNC_ARGS} --times --delete-during --delete-excluded --prune-empty-dirs --include-from=<(
     # keep all the plugins
     echo '+ plugins/**'
     echo '+ updates/**'


### PR DESCRIPTION
In trying to copy update centers, --times fails mysteriously, even
though seemingly it has the right permissions. See
https://gist.github.com/kohsuke/40f450a380e9daeb9cfffe4487cbb3ab for
more.

Moving --times to the one rsync that's very slow, keeping others as it
was before.