### PR TITLE
Avoid pkg.jenkins.io staging => production rsync overwrites of Puppet managed files

### DIFF
--- a/dist/profile/files/mirrorbrain/sync.sh
+++ b/dist/profile/files/mirrorbrain/sync.sh
@@ -61,7 +61,11 @@ echo ">> Triggering remote mirroring script"
 ssh $HOST "sh trigger-jenkins"
 
 echo ">> move index from staging to production"
-(cd /var/www && rsync --omit-dir-times -av pkg.jenkins.io.staging/ pkg.jenkins.io/)
+# Excluding some files which the packaging repo which are now managed by Puppet
+# see INFRA-985, INFRA-989
+(cd /var/www && rsync --omit-dir-times -av \
+    --exclude=.htaccess --exclude=\*.key --exclude=jenkins.repo \
+    pkg.jenkins.io.staging/ pkg.jenkins.io/)
 
 # This section of the script aims to ensure that at least one of our primary mirrors has the
 # "big" archives before we complete execution. This will help prevent users from unexpectedly


### PR DESCRIPTION
These files (like .htaccess) have been removed (jenkinsci/packaging#81) but seem
to keep cropping up. This makes sure they're not rsynced into production.

Fixes [INFRA-985](https://issues.jenkins-ci.org/browse/INFRA-985), [INFRA-989](https://issues.jenkins-ci.org/browse/INFRA-989)