### PR TITLE
Rsync wants these directories to be 0755, let's just leave them 0755

### DIFF
--- a/dist/profile/manifests/usage.pp
+++ b/dist/profile/manifests/usage.pp
@@ -57,7 +57,7 @@ class profile::usage(
     ensure  => directory,
     owner   => $user,
     group   => $group,
-    mode    => '0775',
+    mode    => '0755',
     require => Mount[$home_dir],
   }
   ############################


### PR DESCRIPTION
Puppet and rsync(1) processes have been bickering for months about what the
right permissions for these directories are. rsync(1) wins, there's no benefit
to 0775 AFAICT