### PR TITLE
Increase Jenkins HTTP keepalive timeout

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -69,6 +69,7 @@ class profile::buildmaster(
       'HOME=/var/jenkins_home',
       'USER=jenkins',
       'JAVA_OPTS="-Duser.home=/var/jenkins_home -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2"',
+      'JENKINS_OPTS="--httpKeepAliveTimeout=60000"',
     ],
     ports            => ['8080:8080', '50000:50000'],
     volumes          => ['/var/lib/jenkins:/var/jenkins_home'],


### PR DESCRIPTION
Untested, but https://github.com/jenkinsci/docker/blob/3cf0212a1a795902cabbd67b2920f4bedeb762fc/jenkins.sh#L22 looks like this should work.

People with slower connections hit the overly aggressive timeout in [JENKINS-39909](https://issues.jenkins-ci.org/browse/JENKINS-39909)

Reference:
https://botbot.me/freenode/jenkins/2017-01-04/?msg=78825222&page=5

CC @jimklimov