### PR TITLE
Add missing trailing slash to non-TLS plugin site redirect.

### DIFF
--- a/dist/profile/manifests/pluginsite.pp
+++ b/dist/profile/manifests/pluginsite.pp
@@ -65,7 +65,7 @@ class profile::pluginsite(
     port            => '80',
     docroot         => $docroot,
     redirect_status => 'permanent',
-    redirect_dest   => "https://${pluginsite_fqdn}",
+    redirect_dest   => "https://${pluginsite_fqdn}/",
   }
 
 

--- a/spec/classes/profile/pluginsite_spec.rb
+++ b/spec/classes/profile/pluginsite_spec.rb
@@ -32,8 +32,20 @@ describe 'profile::pluginsite' do
     it { should contain_file('/srv/pluginsite').with_ensure(:directory) }
 
     context 'plugins.jenkins.io virtual host' do
-      it { should contain_apache__vhost 'plugins.jenkins.io' }
-      it { should contain_apache__vhost 'plugins.jenkins.io unsecured' }
+      it 'should have a vhost' do
+        expect(subject).to contain_apache__vhost('plugins.jenkins.io').with({
+          :port => 443,
+          :ssl  => true,
+        })
+      end
+
+      it 'should have a non-TLS vhost that redirects' do
+        expect(subject).to contain_apache__vhost('plugins.jenkins.io unsecured').with({
+          :port => 80,
+          :redirect_status => 'permanent',
+          :redirect_dest => 'https://plugins.jenkins.io/'
+        })
+      end
     end
   end
 


### PR DESCRIPTION
Otherwise, the redirect to port 443 goes awry:

    $ curl -sI http://plugins.jenkins.io/git | grep Location
    Location: https://plugins.jenkins.iogit

Added an rspec test, similar to other vhosts, but not sure whether adding an integration test is possible…