### PR TITLE
AllowOverride FileInfo for jenkins.io for custom error pages

### DIFF
--- a/dist/profile/manifests/staticsite.pp
+++ b/dist/profile/manifests/staticsite.pp
@@ -118,6 +118,7 @@ class profile::staticsite(
     port          => '443',
     ssl           => true,
     docroot       => $beta_docroot,
+    override      => 'FileInfo',
     require       => File[$beta_docroot],
   }
 

--- a/spec/classes/profile/staticsite_spec.rb
+++ b/spec/classes/profile/staticsite_spec.rb
@@ -40,7 +40,7 @@ describe 'profile::staticsite' do
                 .with(:docroot => '/srv/jenkins.io/current') }
 
     it { should contain_apache__vhost('jenkins.io')
-                .with(:docroot => '/srv/jenkins.io/beta') }
+                .with( { :docroot => '/srv/jenkins.io/beta', :override  => ['FileInfo'] } ) }
 
     it 'should upgrade non-TLS to TLS' do
       expect(subject).to contain_apache__vhost('jenkins.io unsecured').with({


### PR DESCRIPTION
![i have no idea what i m doing](https://cloud.githubusercontent.com/assets/1831569/22997137/a10e584a-f3d1-11e6-8760-73d0e66239d1.jpg)

* Untested, but based on http://httpd.apache.org/docs/current/mod/core.html#allowoverride looks reasonable.
* This file is a mess as it still refers to this site as beta (AFAIU), so I'm only somewhat confident I edited the correct thing.