### PR TITLE
Allow defining custom ErrorDocuments on jenkins.io

### DIFF
--- a/dist/profile/manifests/staticsite.pp
+++ b/dist/profile/manifests/staticsite.pp
@@ -119,6 +119,11 @@ class profile::staticsite(
     ssl           => true,
     docroot       => $beta_docroot,
     require       => File[$beta_docroot],
+    directories   => [
+      { 'path'            =>  $beta_docroot,
+        'custom_fragment' => 'AllowOverrideList ErrorDocument',
+      }
+    ]
   }
 
   apache::vhost { 'jenkins.io unsecured':


### PR DESCRIPTION
This limits customization via `.htaccess` to `ErrorDocument` directives.

Appears to require Apache 2.4 even though the Apache documentation doesn't explicitly state that AFAICT.

Untested, and couldn't find other tests for `custom_fragment` to cargo-cult from (not to mention `directories`). Hoping there's useful PR build output to confirm this works as intended.

References:
https://github.com/puppetlabs/puppetlabs-apache#parameter-directories-for-apachevhost
https://github.com/puppetlabs/puppetlabs-apache#custom_fragment-1