### PR TITLE
Grow the conntrack_max again after some excess load took mirrors.jenkins.io offline

### DIFF
--- a/dist/profile/manifests/mirrorbrain.pp
+++ b/dist/profile/manifests/mirrorbrain.pp
@@ -201,7 +201,7 @@ wget -O release-blob-sync https://raw.githubusercontent.com/jenkins-infra/azure/
   ##########################
 
 
-  $conntrack_max = '131072'
+  $conntrack_max = '262144'
   # Double conntrack to ensure we can handle lots of connections
   file { '/etc/sysctl.d/30-conntrack.conf':
     ensure  => present,


### PR DESCRIPTION
 have made this change manually already on mirrors.jenkins.io. This codifies it
however. We have plenty of memory to allow a higher conntrack. There's an
unfortunate cascading failure affect if mirrorbrain takes too long to serve
requests insofar that it fills up the connections table and can exacerbate an
existing load issue.