### PR TITLE
Pin our ci.j.io container at 2.46 until it's adopted as the latest LTS

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -66,7 +66,7 @@ class profile::buildmaster(
   }
 
   docker::run { 'jenkins':
-    image            => 'jenkinsci/jenkins',
+    image            => 'jenkinsci/jenkins:2.46',
     # This is a "clever" hack to force the init script to pass the numeric UID
     # through on `docker run`. Since passing the string 'jenkins' doesn't
     # actually map the UIDs properly. Using the extra_parameters option because

--- a/spec/classes/profile/buildmaster_spec.rb
+++ b/spec/classes/profile/buildmaster_spec.rb
@@ -19,7 +19,6 @@ describe 'profile::buildmaster' do
 
       it 'should define a suitable docker::run' do
         expect(subject).to contain_docker__run('jenkins').with({
-          :image => 'jenkinsci/jenkins',
           :pull_on_start => true,
           :volumes => ['/var/lib/jenkins:/var/jenkins_home'],
         })


### PR DESCRIPTION
The testing has already started on 2.46.1, this is just to make sure that we
stick on the weekly 2.46 until the LTS 2.46.1 is updated. At which point we can
upgrade to the LTS line again.