### PR TITLE
[INFRA-583] Add Datadog check for SSL certificate enddate monitoring

### DIFF
--- a/dist/profile/files/datadog_ssl_check/ssl_check_expire_days.py
+++ b/dist/profile/files/datadog_ssl_check/ssl_check_expire_days.py
@@ -11,6 +11,7 @@ class SSLCheckExpireDays(AgentCheck):
     def check(self, instance):
         metric = "ssl.expire_in_days"
         site = instance['site']
+        tag = "site:"+site
         p = subprocess.Popen("echo | openssl s_client -showcerts -servername " + site + " -connect " + site + ":443 2>/dev/null | openssl x509 -noout -dates | grep notAfter | cut -f 2 -d\= | xargs -0 -I arg date -d arg \"+%s\"",stdout=subprocess.PIPE, shell=True)
         (output, err) = p.communicate()
         if output:
@@ -19,8 +20,6 @@ class SSLCheckExpireDays(AgentCheck):
             d1 = int(output)
             delta = d1 - d0
             days= delta/24/60/60 # convert the timestamp to days
-            tag="site:" + site # generate the tags
-#            print "metric: " + str(metric) + ", tag: " + str(tag) + ", days: " + str(days)
             self.gauge(metric, int(days), tags=[tag])
         else:
-            self.gauge(metric, -1, tags=[site])
+            self.gauge(metric, -1, tags=[tag])

--- a/dist/profile/files/datadog_ssl_check/ssl_check_expire_days.py
+++ b/dist/profile/files/datadog_ssl_check/ssl_check_expire_days.py
@@ -1,0 +1,26 @@
+# A rewrite of https://workshop.avatarnewyork.com/project/datadog-ssl-expires-check/
+# I prefer to test the site itself instead of the ssl cert file
+
+import time
+import datetime
+import subprocess
+import sys
+from checks import AgentCheck
+
+class SSLCheckExpireDays(AgentCheck):
+    def check(self, instance):
+        metric = "ssl.expire_in_days"
+        site = instance['site']
+        p = subprocess.Popen("echo | openssl s_client -showcerts -servername " + site + " -connect " + site + ":443 2>/dev/null | openssl x509 -noout -dates | grep notAfter | cut -f 2 -d\= | xargs -0 -I arg date -d arg \"+%s\"",stdout=subprocess.PIPE, shell=True)
+        (output, err) = p.communicate()
+        if output:
+            output = output.rstrip("\n")
+            d0 = int(time.time())
+            d1 = int(output)
+            delta = d1 - d0
+            days= delta/24/60/60 # convert the timestamp to days
+            tag="site:" + site # generate the tags
+#            print "metric: " + str(metric) + ", tag: " + str(tag) + ", days: " + str(days)
+            self.gauge(metric, int(days), tags=[tag])
+        else:
+            self.gauge(metric, -1, tags=[site])

--- a/dist/profile/manifests/datadog_ssl_check.pp
+++ b/dist/profile/manifests/datadog_ssl_check.pp
@@ -4,9 +4,10 @@
 #
 
 class profile::datadog_ssl_check (
-  $sites = undef,
+  $sites = ["N/A"]
 ){
 
+  require datadog_agent
   include datadog_agent
 
   file { 'ssl_check_expire_days.py':

--- a/dist/profile/manifests/datadog_ssl_check.pp
+++ b/dist/profile/manifests/datadog_ssl_check.pp
@@ -1,0 +1,29 @@
+#
+# Define datadog check for ssl expiration
+# Inspired by: https://workshop.avatarnewyork.com/project/datadog-ssl-expires-check/
+#
+
+class profile::datadog_ssl_check (
+  $sites = undef,
+){
+
+  include datadog_agent
+
+  file { 'ssl_check_expire_days.py':
+    ensure => present,
+    source => "puppet:///modules/${module_name}/datadog_ssl_check/ssl_check_expire_days.py",
+    path   => '/etc/dd-agent/checks.d/ssl_check_expire_days.py',
+    owner  => $::datadog_agent::params::dd_user,
+    group  => $::datadog_agent::params::dd_group,
+    notify => Service['datadog-agent']
+  }
+
+  file { 'ssl_check_expire_days.yaml':
+    ensure  => present,
+    content => template("${module_name}/datadog_ssl_check/ssl_check_expire_days.yaml.erb"),
+    owner   => $::datadog_agent::params::dd_user,
+    group   => $::datadog_agent::params::dd_group,
+    path    => "${::datadog_agent::params::conf_dir}/ssl_check_expire_days.yaml",
+    notify  => Service['datadog-agent']
+  }
+}

--- a/dist/profile/templates/datadog_ssl_check/ssl_check_expire_days.yaml.erb
+++ b/dist/profile/templates/datadog_ssl_check/ssl_check_expire_days.yaml.erb
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+    <% @sites.each do |site| -%>
+   - site: <%= site %>
+    <% end %>

--- a/dist/role/manifests/puppetmaster.pp
+++ b/dist/role/manifests/puppetmaster.pp
@@ -4,4 +4,5 @@ class role::puppetmaster {
   include profile::base
   include profile::puppetmaster
   include profile::sudo::osu
+  include profile::datadog_ssl_check
 }

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -295,6 +295,13 @@ profile::datadog_ssl_check::sites:
     - wiki.jenkins-ci.org
     - jenkins.io
     - www.jenkins.io
+    - ci.jenkins.io
+    - mirrors.jenkins.io
+    - accounts.jenkins.io
+    - usage.jenkins.io
+    - pkg.jenkins.io
+    - updates.jenkins.io
+    - plugins.jenkins.io
 
 limits:
   '*':

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -290,6 +290,12 @@ azure::k8s::management_ssh_privkey: |
 azure::k8s::management_ssh_pubkey: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDvly3ZF9ntYXlvw/SS/v+8LwGten0CHvYdIjY1y1NcR2SrX3Azv/zDPStTaiRTcOWGEByn84q6VRyH4+iN+HY31tMopVGpKEUJvIkP7qpW8UGpNS5MPOhhCfOsBxGHZ6AzjLwpOsHrlEahgl7tU1JW4VnX4jRy+2mQJkqnHtPeqYZMtNZwymhp8NjvlyxtxLw5pNu5wd8unXeuLkH73zJvk8kNgjw5P2cg4UBVXXQEdyRJ0rwLw4mLVzHvY2sIz5T9AN+qz29VgN6mm1fZPe+sHLfDLBFK5AWlvTv0jvX+TyrfryG4XwnU/kwROn5KJDa1SnuAq78JloZOsg24NXaB'
 
 
+profile::datadog_ssl_check::sites:
+    - issues.jenkins-ci.org
+    - wiki.jenkins-ci.org
+    - jenkins.io
+    - www.jenkins.io
+
 limits:
   '*':
     nofile:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -291,17 +291,16 @@ azure::k8s::management_ssh_pubkey: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDvly3ZF9ntYXlv
 
 
 profile::datadog_ssl_check::sites:
-    - issues.jenkins-ci.org
-    - wiki.jenkins-ci.org
-    - jenkins.io
-    - www.jenkins.io
-    - ci.jenkins.io
-    - mirrors.jenkins.io
     - accounts.jenkins.io
-    - usage.jenkins.io
+    - ci.jenkins.io
+    - issues.jenkins-ci.org
+    - jenkins.io
     - pkg.jenkins.io
-    - updates.jenkins.io
     - plugins.jenkins.io
+    - usage.jenkins.io
+    - updates.jenkins.io
+    - wiki.jenkins-ci.org
+    - www.jenkins.io
 
 limits:
   '*':

--- a/spec/classes/profile/datadog_ssl_check.rb
+++ b/spec/classes/profile/datadog_ssl_check.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'profile::datadog_ssl_check' do
+  it { should contain_class 'datadog_agent' }
+  it { should contain_file 'ssl_check_expire_days.py' }
+  it { should contain_file 'ssl_check_expire_days.yaml' }
+end

--- a/spec/classes/role/puppetmaster_spec.rb
+++ b/spec/classes/role/puppetmaster_spec.rb
@@ -9,4 +9,5 @@ describe 'role::puppetmaster' do
 
   it { should contain_class 'profile::puppetmaster' }
   it { should contain_class 'profile::sudo::osu' }
+  it { should contain_class 'profile::datadog_ssl_check' }
 end


### PR DESCRIPTION
This PR add ssh enddate monitoring. 
It inspired by this [blogpost](https://workshop.avatarnewyork.com/project/datadog-ssl-expires-check/)

I just adapt the script to monitor https website instead of 'local' certificate
Puppetmaster is configure to run this check but we can use another role.

Just update 'profile::datadog_ssl_check::sites:' within hieradata/common.yaml with the correct list of website.