### PR TITLE
[INFRA-672] Create a CNAME and vhost for wiki.jenkins.io

### DIFF
--- a/dist/profile/files/bind/jenkins.io.zone
+++ b/dist/profile/files/bind/jenkins.io.zone
@@ -2,7 +2,7 @@
 
 ; SOA Record
 @  1D  IN  SOA    ns1.jenkins-ci.org. tyler.monkeypox.org. (
-                2017030801 ; serial, todays date + todays serial #
+                2015122201 ; serial, todays date + todays serial #
                 28800      ; refresh, seconds
                 7200       ; retry, seconds
                 604800     ; expire, seconds

--- a/dist/profile/files/bind/jenkins.io.zone
+++ b/dist/profile/files/bind/jenkins.io.zone
@@ -2,7 +2,7 @@
 
 ; SOA Record
 @  1D  IN  SOA    ns1.jenkins-ci.org. tyler.monkeypox.org. (
-                2015122201 ; serial, todays date + todays serial #
+                2017030801 ; serial, todays date + todays serial #
                 28800      ; refresh, seconds
                 7200       ; retry, seconds
                 604800     ; expire, seconds
@@ -60,6 +60,7 @@ patron      3600    IN    CNAME    jenkins-infra.github.io. ; CNAME for patron.j
 javadoc     3600    IN    CNAME    eggplant ; CNAME for javadoc.jenkins.io which is currently in role::eggplant
 plugins     3600    IN    CNAME    plugins.azure ; plugins.jenkins.io runs a simple pluginsite
 reports     3600    IN    CNAME    prodjenkinsreports.blob.core.windows.net. ; see INFRA-947
+wiki        3600    IN    CNAME    lettuce
 
 ; Magical CNAME for certificate validation
 D07F852F584FA592123140354D366066.ldap.jenkins.io. 3600 IN CNAME 75E741181A7ACDBE2996804B2813E09B65970718.comodoca.com.

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -122,12 +122,12 @@ class profile::confluence (
         plugin      => 'apache',
         manage_cron => true,
     }
-    Apache::Vhost <| title == "wiki.jenkins.io" |> {
+    Apache::Vhost <| title == 'wiki.jenkins.io' |> {
     # When Apache is upgraded to >= 2.4.8 this should be changed to
     # fullchain.pem
-      ssl_key       => "/etc/letsencrypt/live/wiki.jenkins.io/privkey.pem",
-      ssl_cert      => "/etc/letsencrypt/live/wiki.jenkins.io/cert.pem",
-      ssl_chain     => "/etc/letsencrypt/live/wiki.jenkins.io/chain.pem",
+      ssl_key       => '/etc/letsencrypt/live/wiki.jenkins.io/privkey.pemr',
+      ssl_cert      => '/etc/letsencrypt/live/wiki.jenkins.io/cert.pem',
+      ssl_chain     => '/etc/letsencrypt/live/wiki.jenkins.io/chain.pem',
     }
 
   }

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -122,6 +122,14 @@ class profile::confluence (
         plugin      => 'apache',
         manage_cron => true,
     }
+    Apache::Vhost <| title == "wiki.jenkins.io" |> {
+    # When Apache is upgraded to >= 2.4.8 this should be changed to
+    # fullchain.pem
+      ssl_key       => "/etc/letsencrypt/live/wiki.jenkins.io/privkey.pem",
+      ssl_cert      => "/etc/letsencrypt/live/wiki.jenkins.io/cert.pem",
+      ssl_chain     => "/etc/letsencrypt/live/wiki.jenkins.io/chain.pem",
+    }
+
   }
 
   apache::vhost { 'wiki.jenkins-ci.org non-ssl':
@@ -137,11 +145,6 @@ class profile::confluence (
   apache::vhost { 'wiki.jenkins.io':
     port            => '443',
     ssl             => true,
-    ssl_key         => '/etc/letsencrypt/live/wiki.jenkins.io/privkey.pem',
-    # When Apache is upgraded to >= 2.4.8 this should be changed to
-    # fullchain.pem
-    ssl_cert        => '/etc/letsencrypt/live/wiki.jenkins.io/cert.pem',
-    ssl_chain       => '/etc/letsencrypt/live/wiki.jenkins.io/chain.pem',
     docroot         => '/srv/wiki/docroot',
     access_log      => false,
     error_log_file  => 'wiki.jenkins.io/error.log',


### PR DESCRIPTION
Add wiki.jenkins.io vhost and update bind configuration 
We still have to configure in confluence admin page, the vhost that we want to use (wiki.jenkins.io vs wiki.jenkins-ci.org)