### PR TITLE
Kubernetes/plugin site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ vagrant2014*
 d2014*
 modules/
 .kube/
+# hieradata/roles/kubernetes.yaml is used for local testing
+hieradata/roles/kubernetes.yaml

--- a/dist/profile/manifests/kubernetes/kubectl.pp
+++ b/dist/profile/manifests/kubernetes/kubectl.pp
@@ -1,7 +1,7 @@
 #   Class: profile::kubernetes::kubectl
 #
-#   This class install everything need to run kubectl command
-#   System use, directories, configuration, binary,...
+#   This class install everything needed to run kubectl command
+#   System user, directories, configuration, kubectl binary,...
 #
 #   Parameters:
 #     $user:

--- a/dist/profile/manifests/kubernetes/resources/lego.pp
+++ b/dist/profile/manifests/kubernetes/resources/lego.pp
@@ -5,9 +5,9 @@
 #
 #   Parameters:
 #     $email:
-#       Mail address used by letsencrypt to send notifications 
+#       Mail address used by letsencrypt to send notifications
 #     $url:
-#       Endpoint used by letsencrypt to get certificate 
+#       Endpoint used by letsencrypt to get certificate
 #       This value can also be set to https://acme-staging.api.letsencrypt.org/directory
 #       for staging environment
 #

--- a/dist/profile/manifests/kubernetes/resources/lego.pp
+++ b/dist/profile/manifests/kubernetes/resources/lego.pp
@@ -1,0 +1,48 @@
+#   Class: profile::kubernetes::resources::lego
+#
+#   This class install kube lego
+#   => https://github.com/jetstack/kube-lego
+#
+#   Parameters:
+#     $email:
+#       Mail address used by letsencrypt to send notifications 
+#     $url:
+#       Endpoint used by letsencrypt to get certificate 
+#       This value can also be set to https://acme-staging.api.letsencrypt.org/directory
+#       for staging environment
+#
+#
+class profile::kubernetes::resources::lego (
+    String $email = 'infra@lists.jenkins-ci.org',
+    String $url = 'https://acme-v01.api.letsencrypt.org/directory'
+  ){
+  include profile::kubernetes::params
+  require profile::kubernetes::kubectl
+
+  file { "${profile::kubernetes::params::resources}/lego":
+    ensure => 'directory',
+    owner  => $profile::kubernetes::params::user,
+  }
+
+  profile::kubernetes::apply { 'lego/namespace.yaml':}
+
+  profile::kubernetes::apply { 'lego/configmap.yaml':
+    parameters => {
+      'email' => $email,
+      'url'   => $url
+    }
+  }
+
+  profile::kubernetes::apply { 'lego/deployment.yaml':}
+
+  # As configmap changes do not trigger pods update,
+  # we must reload pods 'manually' to use the newly updated configmap
+  exec { 'Reload lego pods':
+    path        => ["${profile::kubernetes::params::bin}/"],
+    command     => 'kubectl delete pods -l app=kube-lego',
+    refreshonly => true,
+    environment => ["KUBECONFIG=${profile::kubernetes::params::home}/.kube/config"] ,
+    logoutput   => true,
+    subscribe   => Exec['apply lego/configmap.yaml']
+  }
+}

--- a/dist/profile/manifests/kubernetes/resources/nginx.pp
+++ b/dist/profile/manifests/kubernetes/resources/nginx.pp
@@ -1,0 +1,36 @@
+#   Class: profile::kubernetes::resources::nginx
+#
+#   This class deploy an nginx ingress resources
+#   from gce
+#
+# Deploy nginx-ingress resources on kubernetes cluster
+# -> https://github.com/kubernetes/ingress/blob/master/controllers/nginx/Changelog.md
+#
+class profile::kubernetes::resources::nginx (
+  ){
+  include profile::kubernetes::params
+  require profile::kubernetes::kubectl
+
+  file { "${profile::kubernetes::params::resources}/nginx":
+    ensure => 'directory',
+    owner  => $profile::kubernetes::params::user,
+  }
+
+  profile::kubernetes::apply { 'nginx/namespace.yaml':}
+  profile::kubernetes::apply { 'nginx/configmap.yaml':}
+  profile::kubernetes::apply { 'nginx/default-deployment.yaml':}
+  profile::kubernetes::apply { 'nginx/default-service.yaml':}
+  profile::kubernetes::apply { 'nginx/deployment.yaml':}
+  profile::kubernetes::apply { 'nginx/service.yaml':}
+
+  # As configmap changes do not trigger pods update,
+  # we must reload pods 'manually' to use the newly updated secret
+  exec { 'Reload nginx-ingress pods':
+    path        => ["${profile::kubernetes::params::bin}/"],
+    command     => 'kubectl delete pods -l app=nginx',
+    refreshonly => true,
+    environment => ["KUBECONFIG=${profile::kubernetes::params::home}/.kube/config"] ,
+    logoutput   => true,
+    subscribe   => Exec['apply nginx/configmap.yaml']
+  }
+}

--- a/dist/profile/manifests/kubernetes/resources/pluginsite.pp
+++ b/dist/profile/manifests/kubernetes/resources/pluginsite.pp
@@ -19,7 +19,7 @@
 class profile::kubernetes::resources::pluginsite (
     String $url = 'plugins.jenkins.io',
     String $data_file_url = 'https://ci.jenkins.io/job/Infra/job/plugin-site-api/job/generate-data/lastSuccessfulBuild/artifact/plugins.json.gzip',
-    String $image_tag = 'latest'
+    String $image_tag = ''
   ){
   include profile::kubernetes::params
   require profile::kubernetes::kubectl

--- a/dist/profile/manifests/kubernetes/resources/pluginsite.pp
+++ b/dist/profile/manifests/kubernetes/resources/pluginsite.pp
@@ -1,0 +1,63 @@
+#   Class: profile::kubernetes::resources::pluginsite
+#
+#   This class deploy plugins jenkins website
+#
+#   Parameters:
+#     $data_file_url:
+#       Set endpoint for plugins data file
+#     $url:
+#       Set frontend url
+#     $image_tag:
+#       Set plugin-site image tag
+#
+#   Remark:
+#     `kubectl get service nginx --namespace nginx-ingress` return service public ip
+#     This public ip should be used for DNS record frontend_url -> this IP
+#     In order to create letsencrypt certificates
+
+# Deploy pluginsite resources on kubernetes cluster
+class profile::kubernetes::resources::pluginsite (
+    String $url = 'plugins.jenkins.io',
+    String $data_file_url = 'https://ci.jenkins.io/job/Infra/job/plugin-site-api/job/generate-data/lastSuccessfulBuild/artifact/plugins.json.gzip',
+    String $image_tag = 'latest'
+  ){
+  include profile::kubernetes::params
+  require profile::kubernetes::kubectl
+  require profile::kubernetes::resources::nginx
+  require profile::kubernetes::resources::lego
+
+  file { "${profile::kubernetes::params::resources}/pluginsite":
+    ensure => 'directory',
+    owner  => $profile::kubernetes::params::user,
+  }
+
+  profile::kubernetes::apply { 'pluginsite/ingress-tls.yaml':
+    parameters  => {
+      'url'     => $url,
+    }
+  }
+  profile::kubernetes::apply { 'pluginsite/configmap.yaml':
+    parameters  => {
+      'url'           => "https://${url}/api",
+      'data_file_url' => $data_file_url
+    }
+  }
+  profile::kubernetes::apply { 'pluginsite/service.yaml':}
+
+  profile::kubernetes::apply { 'pluginsite/deployment.yaml':
+    parameters => {
+      'image_tag' => $image_tag
+    }
+  }
+
+  # As configmap changes do not trigger pods update,
+  # we must reload pods 'manually' to use the newly updated configmap
+  exec { 'Reload pluginsite pods':
+    path        => ["${profile::kubernetes::params::bin}/"],
+    command     => 'kubectl delete pods -l app=plugins-jenkins',
+    refreshonly => true,
+    environment => ["KUBECONFIG=${profile::kubernetes::params::home}/.kube/config"] ,
+    logoutput   => true,
+    subscribe   => Exec['apply pluginsite/configmap.yaml']
+  }
+}

--- a/dist/profile/templates/kubernetes/resources/lego/configmap.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/lego/configmap.yaml.erb
@@ -1,0 +1,8 @@
+apiVersion: v1
+metadata:
+  name: kube-lego
+  namespace: kube-lego
+data:
+  lego.email: <%= @parameters['email'] %>
+  lego.url: <%= @parameters['url'] %>
+kind: ConfigMap

--- a/dist/profile/templates/kubernetes/resources/lego/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/lego/deployment.yaml.erb
@@ -1,0 +1,47 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-lego
+  namespace: kube-lego
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kube-lego
+        configmap-kube-lego: linked
+        logtype: archive
+    spec:
+      containers:
+      - name: kube-lego
+        image: jetstack/kube-lego:0.1.3
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        env:
+        - name: LEGO_EMAIL
+          valueFrom:
+            configMapKeyRef:
+              name: kube-lego
+              key: lego.email
+        - name: LEGO_URL
+          valueFrom:
+            configMapKeyRef:
+              name: kube-lego
+              key: lego.url
+        - name: LEGO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LEGO_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: LEGO_LOG_LEVEL
+          value: debug
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 1

--- a/dist/profile/templates/kubernetes/resources/lego/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/lego/deployment.yaml.erb
@@ -9,7 +9,6 @@ spec:
     metadata:
       labels:
         app: kube-lego
-        configmap-kube-lego: linked
         logtype: archive
     spec:
       containers:

--- a/dist/profile/templates/kubernetes/resources/lego/namespace.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/lego/namespace.yaml.erb
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-lego

--- a/dist/profile/templates/kubernetes/resources/nginx/configmap.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/configmap.yaml.erb
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  proxy-connect-timeout: "15"
+  proxy-read-timeout: "600"
+  proxy-send-imeout: "600"
+  hsts-include-subdomains: "false"
+  body-size: "64m"
+  server-name-hash-bucket-size: "256"
+kind: ConfigMap
+metadata:
+  namespace: nginx-ingress
+  name: nginx

--- a/dist/profile/templates/kubernetes/resources/nginx/default-deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/default-deployment.yaml.erb
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: default-http-backend
+  namespace: nginx-ingress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: default-http-backend
+    spec:
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+            - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi

--- a/dist/profile/templates/kubernetes/resources/nginx/default-service.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/default-service.yaml.erb
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: default-http-backend
+    namespace: nginx-ingress
+spec:
+    ports:
+        - port: 80
+          targetPort: 8080
+          protocol: TCP
+    selector:
+        app: default-http-backend

--- a/dist/profile/templates/kubernetes/resources/nginx/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/deployment.yaml.erb
@@ -10,7 +10,6 @@ spec:
       labels:
         app: nginx
         logtype: archive
-        configmap-nginx-ingress: linked
     spec:
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.3

--- a/dist/profile/templates/kubernetes/resources/nginx/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/deployment.yaml.erb
@@ -1,0 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: nginx-ingress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+        logtype: archive
+        configmap-nginx-ingress: linked
+    spec:
+      containers:
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.3
+        name: nginx
+        imagePullPolicy: Always
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+        ports:
+        - containerPort: 80
+        - containerPort: 443
+        args:
+        - /nginx-ingress-controller
+        - --default-backend-service=nginx-ingress/default-http-backend
+        - --configmap=nginx-ingress/nginx

--- a/dist/profile/templates/kubernetes/resources/nginx/namespace.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/namespace.yaml.erb
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-ingress

--- a/dist/profile/templates/kubernetes/resources/nginx/service.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/service.yaml.erb
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: nginx-ingress
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    name: http
+  - port: 443
+    name: https
+  selector:
+    app: nginx

--- a/dist/profile/templates/kubernetes/resources/pluginsite/configmap.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/pluginsite/configmap.yaml.erb
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: pluginsite
+data:
+    plugin.site.api.url: <%= @parameters['url'] %>
+    plugin.site.data.file.url: <%= @parameters['data_file_url'] %>

--- a/dist/profile/templates/kubernetes/resources/pluginsite/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/pluginsite/deployment.yaml.erb
@@ -1,0 +1,54 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+    name: pluginsite
+    labels:
+        app: pluginsite
+        type: pluginsite
+        logtype: archive
+spec:
+    replicas: 1
+    template:
+        metadata:
+            labels:
+                app: pluginsite
+                type: pluginsite
+                logtype: archive
+        spec:
+            containers:
+                - name: pluginsite
+                  image: jenkinsciinfra/plugin-site:<%= @parameters['image_tag'] %>
+                  imagePullPolicy: Always
+                  livenessProbe:
+                      httpGet:
+                          path: /labels
+                          port: 8080
+                          scheme: HTTP
+                      initialDelaySeconds: 20
+                      timeoutSeconds: 5
+                  readinessProbe:
+                      httpGet:
+                          path: /labels
+                          port: 8080
+                          scheme: HTTP
+                      initialDelaySeconds: 30
+                      timeoutSeconds: 5
+                  ports:
+                      - containerPort: 5000
+                        protocol: TCP
+                      - containerPort: 8080
+                        protocol: TCP
+                  env:
+                      - name: REST_API_URL
+                        valueFrom:
+                            configMapKeyRef:
+                                name: pluginsite
+                                key: plugin.site.api.url
+                      - name: DATA_FILE_URL
+                        valueFrom:
+                            configMapKeyRef:
+                                name: pluginsite
+                                key: plugin.site.data.file.url
+
+    # It seems that this pod require quite a lot of resources, so let's wait and see before defining resource limitation

--- a/dist/profile/templates/kubernetes/resources/pluginsite/ingress-tls.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/pluginsite/ingress-tls.yaml.erb
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: pluginsite
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: "nginx"
+    ingress.kubernetes.io/rewrite-target: /
+spec:
+  tls:
+  - hosts:
+    - <%= @parameters['url'] %>
+    secretName: pluginsite-tls
+  rules:
+  - host: <%= @parameters['url'] %>
+    http:
+      paths:
+      - path: /api
+        backend:
+          serviceName: pluginsite
+          servicePort: 8080
+      - path: /
+        backend:
+          serviceName: pluginsite
+          servicePort: 5000

--- a/dist/profile/templates/kubernetes/resources/pluginsite/service.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/pluginsite/service.yaml.erb
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pluginsite
+  labels:
+    app: pluginsite
+    type: pluginsite
+    logtype: archive
+spec:
+  ports:
+  - name: frontend
+    protocol: TCP
+    targetPort: 5000
+    port: 5000
+  - name: backend
+    protocol: TCP
+    targetPort: 8080
+    port: 8080
+  selector:
+    type: pluginsite

--- a/dist/role/manifests/kubernetes.pp
+++ b/dist/role/manifests/kubernetes.pp
@@ -2,4 +2,5 @@
 class role::kubernetes{
   include profile::base
   include profile::kubernetes::resources::datadog
+  include profile::kubernetes::resources::pluginsite
 }

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -250,7 +250,10 @@ archives_mirroring_privkey: ''
 
 docker::version: '1.12.1-0~trusty'
 
+# profile::pluginsite::image_tag is deprecated as pluginsite is now deployed on kubernetes
+# you should instead update profile::kubernetes::resources:pluginsite::image_tag
 profile::pluginsite::image_tag: '50-8a166d'
+profile::kubernetes::resources:pluginsite::image_tag: '50-8a166d'
 
 # The following map to the Terraform resource "${tfPrefix}jenkinsrelease" for
 # distribution Jenkins core releases

--- a/spec/classes/profile/kubernetes/lego_spec.rb
+++ b/spec/classes/profile/kubernetes/lego_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'profile::kubernetes::resources::lego' do
+   let (:params) do 
+       {
+          :email  => 'infra@lists.jenkins-ci.org',
+          :url    => 'https://acme-v01.api.letsencrypt.org/directory'
+       }
+   end
+   it { should contain_class('profile::kubernetes::params') }
+   it { should contain_class('profile::kubernetes::kubectl') }
+   it { should contain_file("/home/k8s/resources/lego").with(
+     :ensure => 'directory',
+     :owner  => 'k8s'
+     )
+   }
+   it { should contain_profile__kubernetes__apply('lego/daemonset.yaml')}
+   it { should contain_profile__kubernetes__apply('lego/namespace.yaml')}
+   it { should contain_profile__kubernetes__apply('lego/configmap.yaml').with(
+     :parameters => { 
+        'email' => 'infra@lists.jenkins-ci.org',
+        'url'   => 'https://acme-v01.api.letsencrypt.org/directory'
+        }
+     )
+   }
+   it { should contain_exec('Reload lego pods')}
+end

--- a/spec/classes/profile/kubernetes/lego_spec.rb
+++ b/spec/classes/profile/kubernetes/lego_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'profile::kubernetes::resources::lego' do
-   let (:params) do 
+   let (:params) do
        {
           :email  => 'infra@lists.jenkins-ci.org',
           :url    => 'https://acme-v01.api.letsencrypt.org/directory'
@@ -14,10 +14,10 @@ describe 'profile::kubernetes::resources::lego' do
      :owner  => 'k8s'
      )
    }
-   it { should contain_profile__kubernetes__apply('lego/daemonset.yaml')}
+   it { should contain_profile__kubernetes__apply('lego/deployment.yaml')}
    it { should contain_profile__kubernetes__apply('lego/namespace.yaml')}
    it { should contain_profile__kubernetes__apply('lego/configmap.yaml').with(
-     :parameters => { 
+     :parameters => {
         'email' => 'infra@lists.jenkins-ci.org',
         'url'   => 'https://acme-v01.api.letsencrypt.org/directory'
         }

--- a/spec/classes/profile/kubernetes/nginx_spec.rb
+++ b/spec/classes/profile/kubernetes/nginx_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'profile::kubernetes::resources::nginx' do
+
+   it { should contain_class('profile::kubernetes::params') }
+   it { should contain_class('profile::kubernetes::kubectl') }
+   it { should contain_file("/home/k8s/resources/nginx").with(
+     :ensure => 'directory',
+     :owner  => 'k8s'
+     )
+   }
+
+   it { should contain_profile__kubernetes__apply('nginx/namespace.yaml')}
+   it { should contain_profile__kubernetes__apply('nginx/configmap.yaml')}
+   it { should contain_profile__kubernetes__apply('nginx/default-deployment.yaml')}
+   it { should contain_profile__kubernetes__apply('nginx/deployment.yaml')}
+   it { should contain_profile__kubernetes__apply('nginx/default-service.yaml')}
+   it { should contain_profile__kubernetes__apply('nginx/service.yaml')}
+   it { should contain_exec('Reload nginx-ingress pods')}
+end

--- a/spec/classes/profile/kubernetes/pluginsite_spec.rb
+++ b/spec/classes/profile/kubernetes/pluginsite_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'profile::kubernetes::resources::pluginsite' do
+  let (:params) do
+    {
+        :url           => 'plugins.jenkins.io',
+        :data_file_url => 'https://ci.jenkins.io/job/Infra/job/plugin-site-api/job/generate-data/lastSuccessfulBuild/artifact/plugins.json.gzip',
+        :image_tag     => 'latest'
+    }
+  end
+  it { should contain_class('profile::kubernetes::params') }
+  it { should contain_class('profile::kubernetes::kubectl') }
+  it { should contain_class('profile::kubernetes::resources::lego') }
+  it { should contain_class('profile::kubernetes::resources::nginx') }
+
+  it { should contain_file("/home/k8s/resources/pluginsite").with(
+    :ensure => 'directory',
+    :owner  => 'k8s'
+    )
+  }
+  it { should contain_profile__kubernetes__apply('pluginsite/service.yaml')}
+  it { should contain_profile__kubernetes__apply('pluginsite/deployment.yaml').with(
+    :parameters => {
+      'image_tag' => 'latest'
+      }
+    )
+
+  }
+  it { should contain_profile__kubernetes__apply('pluginsite/configmap.yaml').with(
+    :parameters => {
+      'url'           => 'https://plugins.jenkins.io/api',
+      'data_file_url' => 'https://ci.jenkins.io/job/Infra/job/plugin-site-api/job/generate-data/lastSuccessfulBuild/artifact/plugins.json.gzip'
+      }
+    )
+  }
+  it { should contain_profile__kubernetes__apply('pluginsite/ingress-tls.yaml').with(
+    :parameters => {
+      'url'     => 'plugins.jenkins.io'
+      }
+    )
+  }
+  it { should contain_exec('Reload pluginsite pods')}
+end

--- a/spec/classes/role/kubernetes.rb
+++ b/spec/classes/role/kubernetes.rb
@@ -2,4 +2,5 @@ require 'spec_helper'
 
 describe 'role::kubernetes' do
     it { should contain_class 'profile::kubernetes::resources::datadog'}
+    it { should contain_class 'profile::kubernetes::resources::pluginsite'}
 end

--- a/spec/server/kubernetes/lego_spec.rb
+++ b/spec/server/kubernetes/lego_spec.rb
@@ -1,0 +1,33 @@
+require_relative './../spec_helper'
+
+describe 'Resources Lego' do
+    describe file('/home/k8s/resources/lego') do
+        it { should be_directory }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+    end
+    describe file('/home/k8s/resources/lego/namespace.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'Namespace')
+        }
+    end
+    describe file('/home/k8s/resources/lego/configmap.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'ConfigMap')
+        }
+    end
+    describe file('/home/k8s/resources/lego/deployment.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'Deployment')
+        }
+    end
+end

--- a/spec/server/kubernetes/nginx_spec.rb
+++ b/spec/server/kubernetes/nginx_spec.rb
@@ -1,0 +1,57 @@
+require_relative './../spec_helper'
+
+describe 'Resources Nginx' do
+    describe file('/home/k8s/resources/nginx') do
+        it { should be_directory }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+    end
+    describe file('/home/k8s/resources/nginx/namespace.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'Namespace')
+        }
+    end
+    describe file('/home/k8s/resources/nginx/configmap.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'ConfigMap')
+        }
+    end
+    describe file('/home/k8s/resources/nginx/deployment.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'Deployment')
+        }
+    end
+    describe file('/home/k8s/resources/nginx/default-deployment.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'Deployment')
+        }
+    end
+    describe file('/home/k8s/resources/nginx/service.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'Service')
+        }
+    end
+    describe file('/home/k8s/resources/nginx/default-service.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'Service')
+        }
+    end
+end

--- a/spec/server/kubernetes/nginx_spec.rb
+++ b/spec/server/kubernetes/nginx_spec.rb
@@ -4,12 +4,12 @@ describe 'Resources Nginx' do
     describe file('/home/k8s/resources/nginx') do
         it { should be_directory }
         it { should be_owned_by 'k8s' }
-        it { should be_readable } 
+        it { should be_readable }
     end
     describe file('/home/k8s/resources/nginx/namespace.yaml') do
         it { should be_file }
         it { should be_owned_by 'k8s' }
-        it { should be_readable } 
+        it { should be_readable }
         its(:content_as_yaml){
             should include('kind' => 'Namespace')
         }
@@ -17,7 +17,7 @@ describe 'Resources Nginx' do
     describe file('/home/k8s/resources/nginx/configmap.yaml') do
         it { should be_file }
         it { should be_owned_by 'k8s' }
-        it { should be_readable } 
+        it { should be_readable }
         its(:content_as_yaml){
             should include('kind' => 'ConfigMap')
         }
@@ -25,7 +25,7 @@ describe 'Resources Nginx' do
     describe file('/home/k8s/resources/nginx/deployment.yaml') do
         it { should be_file }
         it { should be_owned_by 'k8s' }
-        it { should be_readable } 
+        it { should be_readable }
         its(:content_as_yaml){
             should include('kind' => 'Deployment')
         }
@@ -33,7 +33,7 @@ describe 'Resources Nginx' do
     describe file('/home/k8s/resources/nginx/default-deployment.yaml') do
         it { should be_file }
         it { should be_owned_by 'k8s' }
-        it { should be_readable } 
+        it { should be_readable }
         its(:content_as_yaml){
             should include('kind' => 'Deployment')
         }
@@ -41,7 +41,7 @@ describe 'Resources Nginx' do
     describe file('/home/k8s/resources/nginx/service.yaml') do
         it { should be_file }
         it { should be_owned_by 'k8s' }
-        it { should be_readable } 
+        it { should be_readable }
         its(:content_as_yaml){
             should include('kind' => 'Service')
         }
@@ -49,7 +49,7 @@ describe 'Resources Nginx' do
     describe file('/home/k8s/resources/nginx/default-service.yaml') do
         it { should be_file }
         it { should be_owned_by 'k8s' }
-        it { should be_readable } 
+        it { should be_readable }
         its(:content_as_yaml){
             should include('kind' => 'Service')
         }

--- a/spec/server/kubernetes/pluginsite_spec.rb
+++ b/spec/server/kubernetes/pluginsite_spec.rb
@@ -1,20 +1,20 @@
 require_relative './../spec_helper'
 
-describe 'Resources Lego' do
-    describe file('/home/k8s/resources/lego') do
+describe 'Resources Plugins Jenkins' do
+    describe file('/home/k8s/resources/pluginsite') do
         it { should be_directory }
         it { should be_owned_by 'k8s' }
         it { should be_readable }
     end
-    describe file('/home/k8s/resources/lego/namespace.yaml') do
+    describe file('/home/k8s/resources/pluginsite/ingress-tls.yaml') do
         it { should be_file }
         it { should be_owned_by 'k8s' }
         it { should be_readable }
         its(:content_as_yaml){
-            should include('kind' => 'Namespace')
+            should include('kind' => 'Ingress')
         }
     end
-    describe file('/home/k8s/resources/lego/configmap.yaml') do
+    describe file('/home/k8s/resources/pluginsite/configmap.yaml') do
         it { should be_file }
         it { should be_owned_by 'k8s' }
         it { should be_readable }
@@ -22,12 +22,20 @@ describe 'Resources Lego' do
             should include('kind' => 'ConfigMap')
         }
     end
-    describe file('/home/k8s/resources/lego/deployment.yaml') do
+    describe file('/home/k8s/resources/pluginsite/deployment.yaml') do
         it { should be_file }
         it { should be_owned_by 'k8s' }
         it { should be_readable }
         its(:content_as_yaml){
             should include('kind' => 'Deployment')
+        }
+    end
+    describe file('/home/k8s/resources/pluginsite/service.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable }
+        its(:content_as_yaml){
+            should include('kind' => 'Service')
         }
     end
 end


### PR DESCRIPTION
This PR deploy plugins.jenkins.io and its requirements (lego/nginx-ingress)

1) [Ingress|https://kubernetes.io/docs/user-guide/ingress/]
2) [Kube-lego| https://github.com/jetstack/kube-lego]
3) Plugin-site

Once everything is deployed, we have to setup a dns record to the ingress public ip.
Use `kubectl get service nginx --namespace nginx-ingress` to retrieve public ip used by ingress

By default plugin-site use plugins.jenkins.io
We can override it with  profile::kubernetes::resources::pluginsjenkins::url=<your_url>
