### PR TITLE
Kubernetes/registry

### DIFF
--- a/dist/profile/manifests/kubernetes/resources/registry.pp
+++ b/dist/profile/manifests/kubernetes/resources/registry.pp
@@ -1,0 +1,28 @@
+#   Class: profile::kubernetes::registry
+#
+#   This class apply docker registry configuration
+#   to authenticate with private docker registry
+#
+#   Parameters:
+#     $dockerconfigjson:
+#       This string contain non base64 docker registry configuration in json
+#       -> https://kubernetes.io/docs/user-guide/images/#creating-a-secret-with-a-docker-config
+#
+class profile::kubernetes::resources::registry (
+    String $dockerconfigjson = '{"auths": {"https://index.docker.io/v1/": {"auth": "base64_auth"}}}'
+  ){
+  include ::stdlib
+  include profile::kubernetes::params
+  require profile::kubernetes::kubectl
+
+  file { "${profile::kubernetes::params::resources}/registry":
+    ensure => 'directory',
+    owner  => $profile::kubernetes::params::user,
+  }
+
+  profile::kubernetes::apply { 'registry/secret.yaml':
+    parameters => {
+        'dockerconfigjson' => base64('encode', $dockerconfigjson, 'strict')
+    },
+  }
+}

--- a/dist/profile/templates/kubernetes/resources/registry/secret.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/registry/secret.yaml.erb
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jenkins-registry
+type: kubernetes.io/dockerconfigjson
+data:
+    .dockerconfigjson: <%= @parameters['dockerconfigjson'] %>
+

--- a/dist/role/manifests/kubernetes.pp
+++ b/dist/role/manifests/kubernetes.pp
@@ -6,4 +6,5 @@ class role::kubernetes{
   include profile::kubernetes::resources::kube_state_metrics
   include profile::kubernetes::resources::fluentd
   include profile::kubernetes::resources::repo_proxy
+  include profile::kubernetes::resources::registry
 }

--- a/spec/classes/profile/kubernetes/registry_spec.rb
+++ b/spec/classes/profile/kubernetes/registry_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'profile::kubernetes::resources::registry' do
+   let (:params) do
+       {
+          :dockerconfigjson  => 'dockerconfigjsonsecret',
+       }
+   end
+   it { should contain_class('profile::kubernetes::params') }
+   it { should contain_class('profile::kubernetes::kubectl') }
+
+   it { should contain_file("/home/k8s/resources/registry").with(
+     :ensure => 'directory',
+     :owner  => 'k8s'
+     )
+   }
+   it { should contain_profile__kubernetes__apply('registry/secret.yaml').with(
+     :parameters => {
+        'dockerconfigjson' => 'ZG9ja2VyY29uZmlnanNvbnNlY3JldA==',
+        }
+     )
+   }
+end

--- a/spec/classes/role/kubernetes.rb
+++ b/spec/classes/role/kubernetes.rb
@@ -6,4 +6,5 @@ describe 'role::kubernetes' do
     it { should contain_class 'profile::kubernetes::resources::kube_state_metrics'}
     it { should contain_class 'profile::kubernetes::resources::fluentd'}
     it { should contain_class 'profile::kubernetes::resources::repo_proxy'}
+    it { should contain_class 'profile::kubernetes::resources::registry'}
 end

--- a/spec/server/kubernetes/registry_spec.rb
+++ b/spec/server/kubernetes/registry_spec.rb
@@ -1,0 +1,21 @@
+require_relative './../spec_helper'
+
+describe 'Resources Lego' do
+    describe file('/home/k8s/resources/registry') do
+        it { should be_directory }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable }
+    end
+    describe file('/home/k8s/resources/registry/secret.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable }
+        its(:content_as_yaml){
+            should include('kind' => 'Secret')
+            should include(
+                'metadata' => include(
+                    'name' => 'jenkins-registry'))
+            should include( 'data' => include('.dockerconfigjson'))
+        }
+    end
+end


### PR DESCRIPTION
Add docker registry configuration to kubernetes cluster in order to pull docker images from 'prodregistry.azurecr.io'.

In order to use it we need to configure following variable on jenkins-infra project
```
profile::kubernetes::resources::registry::dockerconfigjson: '{"auths":{"prodregistry.azurecr.io":{"auth":"registry_crednential"}}}'
```

-> https://kubernetes.io/docs/concepts/containers/images/
Require:
- [ ] https://github.com/jenkins-infra/jenkins-infra/pull/702 to be merged