### PR TITLE
Add serveralias www.jenkins-ci.org to vhost jenkins-ci.org

### DIFF
--- a/dist/profile/manifests/catchall.pp
+++ b/dist/profile/manifests/catchall.pp
@@ -29,6 +29,9 @@ class profile::catchall(
   }
 
   apache::vhost { 'jenkins-ci.org':
+    serveraliases   => [
+      'www.jenkins-ci.org',
+    ],
     docroot         => $docroot,
     port            => 443,
     ssl             => true,


### PR DESCRIPTION
Redirect https://www.jenkins-ci.org to https://www.jenkins.io 
