### PR TITLE
Deploy fluentd on kubernetes

### DIFF
--- a/dist/profile/manifests/kubernetes/resources/azurelogs.pp
+++ b/dist/profile/manifests/kubernetes/resources/azurelogs.pp
@@ -1,0 +1,43 @@
+# Provide azure secret for everything related to logs on kubernetes
+#   Class: profile::kubernetes::resources::azurelogs
+#
+#   This class deploy secrets for azure, related to logs
+#
+#   Parameters:
+#     $storage_account_name:$loganalytics_workspace_id
+#       Define storage account name used to store logs
+#
+#     $storage_account_key:
+#       Define storage account key used to authenticate on $storage_account_name 
+#
+#     $loganalytics_workspace_id: 
+#       Define azure log analytics workspace id
+#
+#     $loganalytics_key:
+#       Define azure log analytics key related to $loganalytics_workspace_id
+
+class profile::kubernetes::resources::azurelogs (
+  String $storage_account_name = '',
+  String $storage_account_key = '',
+  String $loganalytics_key = '',
+  String $loganalytics_workspace_id = ''
+){
+
+  include ::stdlib
+  include profile::kubernetes::params
+  include profile::kubernetes::kubectl
+
+  file { "${profile::kubernetes::params::resources}/azurelogs":
+    ensure => 'directory',
+    owner  => $profile::kubernetes::params::user,
+  }
+
+  profile::kubernetes::apply { 'azurelogs/secret.yaml':
+    parameters => {
+      'storage_account_name'      => base64('encode', $storage_account_name, 'strict'),
+      'storage_account_key'       => base64('encode', $storage_account_key, 'strict'),
+      'loganalytics_key'          => base64('encode', $loganalytics_key, 'strict'),
+      'loganalytics_workspace_id' => base64('encode', $loganalytics_workspace_id, 'strict')
+    }
+  }
+}

--- a/dist/profile/manifests/kubernetes/resources/fluentd.pp
+++ b/dist/profile/manifests/kubernetes/resources/fluentd.pp
@@ -1,0 +1,49 @@
+# Deploy fluentd
+#   Class: profile::kubernetes::resources::azurelogs
+#
+#   This class ensure that one fluentd pod run on each node
+#   olblak/fluentd-k8s-azure is used to fetch logs from kubernetes\
+#   and send them on loganalytics/blob storage
+#
+#   Parameters:
+#     $image_tag:
+#       Define tag used for olblak/fluentd-k8s-azure
+#
+
+class profile::kubernetes::resources::fluentd (
+  String $image_tag = ''
+){
+
+  include ::stdlib
+  include profile::kubernetes::params
+  include profile::kubernetes::kubectl
+  include profile::kubernetes::resources::azurelogs
+
+  file { "${profile::kubernetes::params::resources}/fluentd":
+    ensure => 'directory',
+    owner  => $profile::kubernetes::params::user,
+  }
+
+  profile::kubernetes::apply{ 'fluentd/daemonset.yaml':
+    parameters => {
+      'image_tag' => $image_tag
+    }
+  }
+
+  # As secret changes do not trigger pods update,
+  # we must reload pods 'manually' to use the newly updated secret
+  # If we delete a pod defined by daemonset,
+  # this daemonset will recreate a new one
+  # Daemonset still need to be reset
+  exec { 'Reload fluentd pods':
+    path        => ["${profile::kubernetes::params::bin}/"],
+    command     => 'kubectl delete pods -l app=fluentd --grace-period=10',
+    refreshonly => true,
+    environment => ["KUBECONFIG=${profile::kubernetes::params::home}/.kube/config"] ,
+    logoutput   => true,
+    subscribe   => [
+      Exec['apply azurelogs/secret.yaml'],
+      Exec['apply fluentd/daemonset.yaml']
+    ]
+  }
+}

--- a/dist/profile/templates/kubernetes/resources/azurelogs/secret.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/azurelogs/secret.yaml.erb
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azurelogs
+type: Opaque
+data:
+    # fluent-plugin-azure-loganalytics:
+    # Used to configure fluentd plugin
+   
+  azurestorageaccountname: <%= @parameters['storage_account_name']%>
+  azurestorageaccountkey: <%= @parameters['storage_account_key'] %>
+
+    # Kubernetes: Two following key are used by kubernetes to mount shared disk storage
+    # Two next key value can be found following this documenation -> https://docs.microsoft.com/en-us/azure/log-analytics/log-analytics-get-started 
+  azurelogsstorageaccountkey: <%= @parameters['loganalytics_key'] %>
+  azurelogsanalyticsworkspace: <%= @parameters['loganalytics_workspace_id'] %>

--- a/dist/profile/templates/kubernetes/resources/fluentd/daemonset.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/fluentd/daemonset.yaml.erb
@@ -1,0 +1,61 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluentd
+spec:
+  template:
+    metadata:
+      labels:
+        app: fluentd
+        logtype: archive
+      name: fluentd
+    spec:
+      containers:
+        - name: fluentd
+          image: olblak/fluentd-k8s-azure:<%= @parameters['image_tag'] %>
+          imagePullPolicy: Always
+          # Not sure yet about cpu/memory needed
+          #resources:
+          #  requests:
+          #    memory: "700Mi"
+          #    cpu: "0.1"
+          #  limits:
+          #    memory: "1400Mi"
+          #    cpu: "0.2"
+          env:
+            - name: AZURE_WORKSPACE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: azurelogs
+                  key: azurelogsanalyticsworkspace
+            - name: AZURE_SHARED_KEY
+              valueFrom:
+                secretKeyRef: 
+                  name: azurelogs
+                  key: azurelogsstorageaccountkey
+          volumeMounts:
+            - name: logs
+              mountPath: /fluentd/log
+
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      volumes:
+        - name: logs
+          azureFile: 
+            secretName: azurelogs
+            shareName: logs
+            readOnly: false
+
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+
+        - name: varlog
+          hostPath:
+            path: /var/log

--- a/dist/role/manifests/kubernetes.pp
+++ b/dist/role/manifests/kubernetes.pp
@@ -4,4 +4,5 @@ class role::kubernetes{
   include profile::kubernetes::resources::datadog
   include profile::kubernetes::resources::pluginsite
   include profile::kubernetes::resources::kube_state_metrics
+  include profile::kubernetes::resources::fluentd
 }

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -308,6 +308,8 @@ profile::datadog_ssl_check::sites:
     - wiki.jenkins-ci.org
     - www.jenkins.io
 
+profile::kubernetes::resources::fluentd::image_tag: '0.7.2'
+
 limits:
   '*':
     nofile:

--- a/spec/classes/profile/kubernetes/azurelogs_spec.rb
+++ b/spec/classes/profile/kubernetes/azurelogs_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'profile::kubernetes::resources::azurelogs' do
+  let(:params) do
+      {
+          :storage_account_name      => 'storage_account_name',
+          :storage_account_key       => 'storage_account_key',
+          :loganalytics_key          => 'loganalytics_key',
+          :loganalytics_workspace_id => 'workspace_id'
+      }
+  end
+
+  it { should contain_class('stdlib')}
+  it { should contain_class('profile::kubernetes::params') }
+  it { should contain_class('profile::kubernetes::kubectl') }
+  it { should contain_file("/home/k8s/resources/azurelogs").with(
+    :ensure => 'directory',
+    :owner  => 'k8s'
+    )
+  }
+  it { should contain_profile__kubernetes__apply('azurelogs/secret.yaml').with({
+    :parameters => { 
+        'storage_account_name'      => 'c3RvcmFnZV9hY2NvdW50X25hbWU=',
+        'storage_account_key'       => 'c3RvcmFnZV9hY2NvdW50X2tleQ==',
+        'loganalytics_key'          => 'bG9nYW5hbHl0aWNzX2tleQ==',
+        'loganalytics_workspace_id' => 'd29ya3NwYWNlX2lk'
+      }
+    })
+  }
+end

--- a/spec/classes/profile/kubernetes/fluentd_spec.rb
+++ b/spec/classes/profile/kubernetes/fluentd_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'profile::kubernetes::resources::fluentd' do
+  let(:params) do
+      {
+          :image_tag => 'FFFFFF',
+      }
+  end
+
+  it { should contain_class('profile::kubernetes::params') }
+  it { should contain_class('profile::kubernetes::kubectl') }
+  it { should contain_file("/home/k8s/resources/fluentd").with(
+    :ensure => 'directory',
+    :owner  => 'k8s'
+    )
+  }
+  it { should contain_profile__kubernetes__apply('fluentd/daemonset.yaml').with(
+    :parameters => { 
+        'image_tag' => 'FFFFFF'
+      }
+    )
+  }
+
+  it { should contain_exec('Reload fluentd pods').with(
+      :path        => ["/home/k8s/.bin/"],
+      :command     => 'kubectl delete pods -l app=fluentd --grace-period=10',
+      :refreshonly => true,
+      :environment => ["KUBECONFIG=/home/k8s/.kube/config"] ,
+      :logoutput   => true,
+      :subscribe   => [
+          'Exec[apply azurelogs/secret.yaml]',
+          'Exec[apply fluentd/daemonset.yaml]'
+      ]
+    )
+  } 
+end

--- a/spec/classes/role/kubernetes.rb
+++ b/spec/classes/role/kubernetes.rb
@@ -4,4 +4,5 @@ describe 'role::kubernetes' do
     it { should contain_class 'profile::kubernetes::resources::datadog'}
     it { should contain_class 'profile::kubernetes::resources::pluginsite'}
     it { should contain_class 'profile::kubernetes::resources::kube_state_metrics'}
+    it { should contain_class 'profile::kubernetes::resources::fluentd'}
 end

--- a/spec/server/kubernetes/azurelogs.rb
+++ b/spec/server/kubernetes/azurelogs.rb
@@ -1,0 +1,17 @@
+require_relative './../spec_helper'
+
+describe 'Resources Azurelogs' do
+    describe file('/home/k8s/resources/azurelogs') do
+        it { should be_directory }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+    end
+    describe file('/home/k8s/resources/azurelogs/secret.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'Secret')
+        }
+    end
+end

--- a/spec/server/kubernetes/fluentd.rb
+++ b/spec/server/kubernetes/fluentd.rb
@@ -1,0 +1,17 @@
+require_relative './../spec_helper'
+
+describe 'Resources Fluentd' do
+    describe file('/home/k8s/resources/fluentd') do
+        it { should be_directory }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+    end
+    describe file('/home/k8s/resources/fluentd/daemonset.yaml') do
+        it { should be_file }
+        it { should be_owned_by 'k8s' }
+        it { should be_readable } 
+        its(:content_as_yaml){
+            should include('kind' => 'DaemonSet')
+        }
+    end
+end


### PR DESCRIPTION
This PR deploy:
1. Azurelogs which provide credentialses for logs storage account and log analytics.
2. Fluentd daemonset to analyse kubernetes logs and send them to a blob storage and/or log analytics depending on the situation

It implements logging workflow defined [here](https://github.com/jenkins-infra/iep/tree/kubernetes-004/iep-004)

In order to deploy it we need to define following variables:
``` 
profile::kubernetes::resources::azurelogs::storage_account_name: prodmgmtjenkinslogs
profile::kubernetes::resources::azurelogs::storage_account_key: $(az storage account keys list -n "prodmgmtjenkinslogs" -g "prodmgmtlogs" -o json)
profile::kubernetes::resources::azurelogs::loganalytics_workspace_id: 
profile::kubernetes::resources::azurelogs::loganalytics_key:
```