### PR TITLE
Prevent all these bloody crawlers from trying to perform secured actions

### DIFF
--- a/dist/profile/files/jira/robots.txt
+++ b/dist/profile/files/jira/robots.txt
@@ -1,0 +1,2 @@
+user-agent: *
+disallow: /secure

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -43,6 +43,7 @@ class profile::confluence (
   file { '/srv/wiki/docroot/robots.txt':
     ensure => directory,
     owner  => 'wiki',
+    mode   => '0755',
     group  => $profile::atlassian::group_name,
     source => 'puppet:///modules/profile/confluence/robots.txt',
   }

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -38,6 +38,14 @@ class profile::jira (
     group   => $profile::atlassian::group_name,
   }
 
+  file { '/srv/jira/docroot/robots.txt':
+    ensure => directory,
+    owner  => 'jira',
+    mode   => '0755',
+    group  => $profile::atlassian::group_name,
+    source => 'puppet:///modules/profile/jira/robots.txt',
+  }
+
   # JIRA stores LDAP access information in database, not in file
   file { '/srv/jira/container.env':
     content => join([


### PR DESCRIPTION
Our logs are filled with garbage like this:

    2017-04-07 18:54:14,054 http-nio-8080-exec-2 INFO anonymous 1134x6461x1 - 40.77.167.133,172.17.0.1 /secure/VoteOrWatchIssue.jspa [c.a.j.web.action.XsrfErrorAction] The security token is missing for 'anonymous'. User-Agent : 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'
    2017-04-07 18:54:14,538 http-nio-8080-exec-105 INFO anonymous 1134x6463x1 - 40.77.167.133,172.17.0.1 /secure/VoteOrWatchIssue.jspa [c.a.j.web.action.XsrfErrorAction] The security token is missing for 'anonymous'. User-Agent : 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)'
    2017-04-07 18:54:14,580 http-nio-8080-exec-94 INFO anonymous 1134x6464x2 - 141.8.143.166,172.17.0.1 /secure/VoteOrWatchIssue.jspa [c.a.j.web.action.XsrfErrorAction] The security token is missing for 'anonymous'. User-Agent : 'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)'
    2017-04-07 18:54:15,658 http-nio-8080-exec-53 INFO anonymous 1134x6471x1 - 77.88.47.25,172.17.0.1 /secure/VoteOrWatchIssue.jspa [c.a.j.web.action.XsrfErrorAction] The security token is mi