### PR TITLE
kubernetes/pluginsite: Fix typo in variable name

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -253,7 +253,7 @@ docker::version: '1.12.1-0~trusty'
 # profile::pluginsite::image_tag is deprecated as pluginsite is now deployed on kubernetes
 # you should instead update profile::kubernetes::resources:pluginsite::image_tag
 profile::pluginsite::image_tag: '50-8a166d'
-profile::kubernetes::resources:pluginsite::image_tag: '50-8a166d'
+profile::kubernetes::resources::pluginsite::image_tag: '50-8a166d'
 
 # The following map to the Terraform resource "${tfPrefix}jenkinsrelease" for
 # distribution Jenkins core releases


### PR DESCRIPTION
plugin site on kubernetes won't deploy until container tag is correctly defined.
