### PR TITLE
Switch back to the LTS baseline (2.46.1)

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -66,7 +66,7 @@ class profile::buildmaster(
   }
 
   docker::run { 'jenkins':
-    image            => 'jenkinsci/jenkins:2.46',
+    image            => 'jenkinsci/jenkins:lts-alpine',
     # This is a "clever" hack to force the init script to pass the numeric UID
     # through on `docker run`. Since passing the string 'jenkins' doesn't
     # actually map the UIDs properly. Using the extra_parameters option because


### PR DESCRIPTION
Previously we had to jump up to a weekly release to get security updates
properly. Now that the jenkinsci/jenkins container publishes LTS tags, we can
just rely on that instead.