### PR TITLE
Cut over from the pluginsite to what's running in Azure on Kubernetes

### DIFF
--- a/dist/profile/files/bind/jenkins.io.zone
+++ b/dist/profile/files/bind/jenkins.io.zone
@@ -58,7 +58,7 @@ archives    3600    IN    CNAME    okra ; archives.jenkins.io for delivering old
 stats       3600    IN    CNAME    jenkins-infra.github.io. ; CNAME for stats.jenkins.io which is hosted on GH pages
 patron      3600    IN    CNAME    jenkins-infra.github.io. ; CNAME for patron.jenkins.io which is hosted on GH pages
 javadoc     3600    IN    CNAME    eggplant ; CNAME for javadoc.jenkins.io which is currently in role::eggplant
-plugins     3600    IN    CNAME    kelp ; plugins.jenkins.io runs a simple pluginsite
+plugins     3600    IN    CNAME    plugins.azure ; plugins.jenkins.io runs a simple pluginsite
 
 ; Magical CNAME for certificate validation
 D07F852F584FA592123140354D366066.ldap.jenkins.io. 3600 IN CNAME 75E741181A7ACDBE2996804B2813E09B65970718.comodoca.com.


### PR DESCRIPTION
I performed some validation using plugins.azure.jenkins.io and the site looks
operational

Fixes INFRA-1008