### PR TITLE
Bump repo_proxy  version

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -258,7 +258,7 @@ profile::kubernetes::resources::pluginsite::url: plugins.jenkins.io
 profile::kubernetes::resources::pluginsite::aliases:
     - plugins.azure.jenkins.io
 
-profile::kubernetes::resources::repo_proxy::image_tag: '3-build8151ab'
+profile::kubernetes::resources::repo_proxy::image_tag: '4-build913432'
 profile::kubernetes::resources::repo_proxy::url: repo.azure.jenkins.io
 
 # The following map to the Terraform resource "${tfPrefix}jenkinsrelease" for


### PR DESCRIPTION
At the moment repo.azure.jenkins.io/ do not redirect to repo.azure.jenkins.io/webapp/
This new version fix that.