### PR TITLE
Prevent redundant resource names in the graph

### DIFF
--- a/dist/profile/manifests/azure.pp
+++ b/dist/profile/manifests/azure.pp
@@ -10,7 +10,6 @@ class profile::azure (
 
     package { 'azure-cli-python' :
         ensure   => absent,
-        name     => 'azure-cli',
         provider => pip,
         require  => Package['python-pip'],
     }

--- a/spec/classes/profile/azure_spec.rb
+++ b/spec/classes/profile/azure_spec.rb
@@ -17,7 +17,6 @@ describe 'profile::azure' do
     it 'should remove the azure-cli from pip' do
       expect(subject).to contain_package('azure-cli-python').with({
         :provider => :pip,
-        :name => 'azure-cli',
         :ensure => :absent,
       })
     end


### PR DESCRIPTION
rspec-puppet should have caught this, not sure why it didn't