### PR TITLE
Upgrade puppetlabs/stdlib which has a versioncmp function that actually works

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -4,12 +4,7 @@ forge "http://forge.puppetlabs.com"
 mod "puppet/r10k", '6.0.0'
 
 # Deps for zack/r10k
-# We are tracking stdlib from git because the puppet module tool
-# is getting in the way when we want to upgrade newer than the
-# supported module version
-mod "stdlib",
-        :git => 'git@github.com:puppetlabs/puppetlabs-stdlib.git',
-        :ref => '4.15.0'
+mod "stdlib", '4.17.0'
 
 mod 'puppetlabs/ruby', '0.5.0'
 mod "puppetlabs/gcc", '0.3.0'


### PR DESCRIPTION
When the agent on the puppetmaster was upgraded, its version became '4.10.1'
which, with the older version of puppetlabs/stdlib, resulted in a conditional
inside the webhook template to think that the agent was *NOT* in a Puppet
Enterprise environment

See <https://github.com/voxpupuli/puppet-r10k/blob/master/templates/webhook.bin.erb#L3>

This resulted in the shebang for the /usr/local/bin/webhook script being
/usr/bin/ruby, which is incorrect, leading to this frustrating error:

	tyler@jenkins-radish:~$ sudo service webhook start
	sudo: unable to resolve host jenkins-radish

	Starting webhook: start-stop-daemon: unable to start /usr/local/bin/webhook (No such file or directory)
	tyler@jenkins-radish:~$ head -n 1 `which webhook`
	#!/usr/bin/ruby
	tyler@jenkins-radish:~$

In stdlib 4.16.0 this bug
(https://github.com/voxpupuli/puppet-r10k/blob/master/templates/webhook.bin.erb#L3)
was fixed, so versioncmp() compares versions correctly.

:frowning: