### PR TITLE
Add an additional pluginsite container

### DIFF
--- a/dist/profile/templates/kubernetes/resources/pluginsite/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/pluginsite/deployment.yaml.erb
@@ -8,7 +8,7 @@ metadata:
         type: pluginsite
         logtype: archive
 spec:
-    replicas: 1
+    replicas: 2
     template:
         metadata:
             labels:


### PR DESCRIPTION
Add a second pluginsite container.

Having multiple containers simplify rolling update as we always keep one running containers at the time.

! The only thing to keep in mind, is that each pluginsite container embed his own elasticsearch.
Which means having one container out of sync doesn't necessary affect others pluginsites