### PR TITLE
Set ssl => true on the wiki.jenkins-ci.org vhost

### DIFF
--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -95,13 +95,15 @@ class profile::confluence (
   }
 
   apache::vhost { 'wiki.jenkins-ci.org':
-    # redirect non-SSL to SSL
     servername      => 'wiki.jenkins-ci.org',
+    ssl             => true,
     port            => '443',
     docroot         => '/srv/wiki/docroot',
     access_log_pipe => '/dev/null',
     redirect_status => 'permanent',
-    redirect_dest   => 'https://wiki.jenkins.io/'
+    redirect_dest   => 'https://wiki.jenkins.io/',
+    require         => Apache::Vhost['wiki.jenkins.io'],
+    notify          => Service['apache2'],
   }
 
   apache::vhost { 'wiki.jenkins-ci.org non-ssl':

--- a/spec/classes/profile/confluence_spec.rb
+++ b/spec/classes/profile/confluence_spec.rb
@@ -60,4 +60,15 @@ describe 'profile::confluence' do
   context 'datadog configuration' do
     it { should contain_file '/etc/dd-agent/conf.d/http_check.yaml' }
   end
+
+  context 'environment => production' do
+    let(:environment) { 'production' }
+
+    it 'should obtain certificates' do
+      expect(subject).to contain_letsencrypt__certonly('wiki.jenkins.io').with({
+        :plugin => 'apache',
+        :domains => ['wiki.jenkins.io', 'wiki.jenkins-ci.org'],
+      })
+    end
+  end
 end


### PR DESCRIPTION
My current hypothesis is that without SSL explicitly set to true, Puppet isn't
pulling going to bother setting the SSL certificate variables