### PR TITLE
Give the pluginsite application a full HTTP timeout window (120s) to get ready

### DIFF
--- a/dist/profile/templates/kubernetes/resources/pluginsite/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/pluginsite/deployment.yaml.erb
@@ -25,14 +25,14 @@ spec:
                           path: /labels
                           port: 8080
                           scheme: HTTP
-                      initialDelaySeconds: 20
+                      initialDelaySeconds: 120
                       timeoutSeconds: 5
                   readinessProbe:
                       httpGet:
                           path: /labels
                           port: 8080
                           scheme: HTTP
-                      initialDelaySeconds: 30
+                      initialDelaySeconds: 120
                       timeoutSeconds: 5
                   ports:
                       - containerPort: 5000


### PR DESCRIPTION
Right now Kubernetes is just in a busy-loop trying to create the application, which doesn't have enough time to boot.

From `kubectl get events`:

	29m       29m       1         pluginsite-2411406400-zd5nv   Pod       spec.containers{pluginsite}   Normal    Created      {kubelet k8s-agent-84c4d4fb-0}   Created container with docker id 38bf700523b8; Security:[seccomp=unconfined]
	29m       29m       1         pluginsite-2411406400-zd5nv   Pod       spec.containers{pluginsite}   Normal    Started      {kubelet k8s-agent-84c4d4fb-0}   Started container with docker id 38bf700523b8
	28m       28m       1         pluginsite-2411406400-zd5nv   Pod       spec.containers{pluginsite}   Normal    Killing      {kubelet k8s-agent-84c4d4fb-0}   Killing container with docker id 38bf700523b8: pod "pluginsite-2411406400-zd5nv_default(eed3c632-5abc-11e7-9e22-000d3a0208c4)" container "pluginsite" is unhealthy, it will be killed and re-created.

And the relevant logs from `kubectl logs -f pluginsite`:

	k8s@jenkins-radish:~$ kubectl logs -f pluginsite-2411406400-oxuoe
	2017-06-26 23:01:45,864 CRIT Supervisor running as root (no user in config file)
	2017-06-26 23:01:45,866 INFO supervisord started with pid 5
	2017-06-26 23:01:46,867 INFO spawned: 'frontend' with pid 8
	2017-06-26 23:01:46,872 INFO spawned: 'jetty' with pid 9
	yarn server v0.23.3
	$ run-s build server:run
	2017-06-26 23:01:48,160 INFO success: frontend entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
	2017-06-26 23:01:48,160 INFO success: jetty entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
	2017-06-26 23:01:49.146:INFO::main: Logging initialized @2252ms to org.eclipse.jetty.util.log.StdErrLog
	2017-06-26 23:01:49.989:INFO:oejs.SetUIDListener:main: Setting umask=02
	2017-06-26 23:01:50.026:INFO:oejs.SetUIDListener:main: Opened ServerConnector@475530b9{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
	2017-06-26 23:01:50.031:INFO:oejs.SetUIDListener:main: Setting GID=101
	2017-06-26 23:01:50.071:INFO:oejs.SetUIDListener:main: Setting UID=100
	2017-06-26 23:01:50.087:INFO:oejs.Server:main: jetty-9.4.3.v20170317
	yarn run v0.23.3
	2017-06-26 23:01:50.190:INFO:oejdp.ScanningAppProvider:main: Deployment monitor [file:///var/lib/jetty/webapps/] at interval 1
	$ run-s clean test && run-p build:client build:server
	yarn run v0.23.3
	$ rimraf dist
	Done in 0.80s.
	yarn run v0.23.3
	$ jest --coverage
	2017-06-26 23:02:03.833:INFO:oeja.AnnotationConfiguration:main: Scanning elapsed time=12139ms
	2017-06-26 23:02:05.441:INFO:oejs.session:main: DefaultSessionIdManager workerName=node0
	2017-06-26 23:02:05.448:INFO:oejs.session:main: No SessionScavenger set, using defaults
	2017-06-26 23:02:05.449:INFO:oejs.session:main: Scavenging every 600000ms
	23:02:10.966 [main] INFO  i.j.p.d.EmbeddedElasticsearchServer - Initialize elasticsearch
	 PASS  __tests__/reducers/ui-test.js (5.612s)
	 PASS  __tests__/actions/index-test.js
	 PASS  __tests__/reducers/data-test.js
	-----------------------|----------|----------|----------|----------|----------------|
	File                   |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
	-----------------------|----------|----------|----------|----------|----------------|
	All files              |    87.65 |     97.5 |     87.5 |    87.12 |                |
	 plugins               |      100 |      100 |      100 |      100 |                |
	  setup-jasmine-env.js |      100 |      100 |      100 |      100 |                |
	 plugins/app/actions   |      100 |      100 |      100 |      100 |                |
	  index.js             |      100 |      100 |      100 |      100 |                |
	 plugins/app/commons   |    60.38 |       75 |    68.97 |    60.38 |                |
	  api.js               |    60.38 |       75 |    68.97 |    60.38 |... 135,147,148 |
	 plugins/app/reducers  |      100 |      100 |      100 |      100 |                |
	  data.js              |      100 |      100 |      100 |      100 |                |
	  ui.js                |      100 |      100 |      100 |      100 |                |
	 plugins/app/state     |      100 |      100 |      100 |      100 |                |
	  data.js              |      100 |      100 |      100 |      100 |                |
	  index.js             |      100 |      100 |      100 |      100 |                |
	  ui.js                |      100 |      100 |      100 |      100 |                |
	-----------------------|----------|----------|----------|----------|----------------|

	Test Suites: 3 passed, 3 total
	Tests:       53 passed, 53 total
	Snapshots:   0 total
	Time:        13.287s
	Ran all test suites.
	Done in 20.02s.
	yarn run v0.23.3
	yarn run v0.23.3
	$ cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.server.entry.js --colors --display-error-details
	$ cross-env NODE_ENV=production webpack --config ./webpack/webpack.config.client.entry.js --colors --display-error-details
	23:02:18.238 [main] INFO  i.j.p.d.EmbeddedElasticsearchServer - Initialized elasticsearch
	23:02:22.567 [main] INFO  i.j.p.s.i.DefaultConfigurationService - Using Last-Modified [Mon, 26 Jun 2017 22:46:45 GMT]
	23:02:22.603 [main] INFO  i.j.p.s.i.ElasticsearchPrepareDatastoreService - Alias doesn't exist
	23:02:25.383 [main] INFO  i.j.p.s.i.ElasticsearchPrepareDatastoreService - Index 'plugins_2017.06.26_22.46.44' created
	k8s@jenkins-radish:~$