### PR TITLE
Add checkstyle and findbugs plugins to ci

### DIFF
--- a/hieradata/clients/ci.yaml
+++ b/hieradata/clients/ci.yaml
@@ -9,11 +9,13 @@ profile::buildmaster::plugins:
   - blueocean
   - build-timeout
   - buildtriggerbadge
+  - checkstyle
   - cloudbees-folder
   - credentials
   - credentials-binding
   - docker-workflow
   - embeddable-build-status
+  - findbugs
   - git-client
   - git
   - github


### PR DESCRIPTION
Add checkstyle and findbugs

It seems like dependencies are not needed in this list, so I skipped adding those. But this would then also add matrix and maven unfortunately.