### PR TITLE
[INFRA-1252] Add various datadog http checks

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -27,7 +27,7 @@ fixtures:
       ref: '4.15.0'
     datadog_agent:
       repo: 'datadog/datadog_agent'
-      ref: '1.6.0'
+      ref: '1.10.0'
     ruby:
       repo: 'puppetlabs/ruby'
       ref: '0.5.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -68,7 +68,7 @@ mod 'nanliu/staging', '0.4.0'
 mod 'saz/ssh', '3.0.1'
 
 mod 'puppetlabs/lvm', '0.3.2'
-mod 'datadog/datadog_agent', '1.6.0'
+mod 'datadog/datadog_agent', '1.10.0'
 
 # Used for grabbing certificates for jenkins.io
 mod 'danzilio/letsencrypt', '1.0.0'

--- a/dist/profile/manifests/accountapp.pp
+++ b/dist/profile/manifests/accountapp.pp
@@ -56,6 +56,7 @@ class profile::accountapp(
   }
 
   profile::datadog_check { 'accountapp-http-check':
+    ensure  => 'absent',
     checker => 'http_check',
     source  => 'puppet:///modules/profile/accountapp/http_check.yaml',
   }

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -142,6 +142,7 @@ class profile::confluence (
   }
 
   profile::datadog_check { 'confluence-http-check':
+    ensure  => 'absent',
     checker => 'http_check',
     source  => 'puppet:///modules/profile/confluence/http_check.yaml',
   }

--- a/dist/profile/manifests/datadog_http_check.pp
+++ b/dist/profile/manifests/datadog_http_check.pp
@@ -1,0 +1,171 @@
+# Class: profile::datadog_http_check
+#
+# This class will install the necessary config to monitor jenkins infrastructure https endpoint
+# Parameters:
+#     contact
+#       Specify a list of users to notify regarding http_check alert
+#
+#     days_critical
+#     days_warning
+#        The check_certificate_expiration will instruct the check
+#        to create a service check that checks the expiration of the
+#        ssl certificate. Allow for a warning to occur when x days are
+#        left in the certificate, and alternatively raise a critical
+#        warning if the certificate is y days from the expiration date.
+#        The SSL certificate will always be validated for this additional
+#         service check regardless of the value of disable_ssl_validation
+#
+#     timeout
+#        The (optional) timeout in seconds.
+#
+#     threshold
+#     window
+#        The (optional) window and threshold parameters allow you to trigger
+#        alerts only if the check fails x times within the last y attempts
+#        where x is the threshold and y is the window.
+#
+
+class profile::datadog_http_check(
+  $contact = ['pagerduty'],
+  $days_warning = 30,
+  $days_critical = 10,
+  $timeout = 1,
+  $treshold = 3,
+  $window = 5
+){
+
+  include datadog_agent
+
+  class { 'datadog_agent::integrations::http_check':
+    instances => [{
+      'sitename'                     => 'plugins.jenkins.io',
+      'url'                          => 'https://plugins.jenkins.io',
+      'timeout'                      => $timeout,
+      'treshold'                     => $treshold,
+      'window'                       => $window,
+      'collect_response_time'        => true ,
+      'check_certificate_expiration' => true,
+      'days_warning'                 => $days_warning,
+      'days_critical'                => $days_critical,
+      'contact'                      => $contact,
+      'tags'                         => ['production','jenkins.io']
+    },
+    {
+      'sitename'                     => 'jenkins.io',
+      'url'                          => 'https://jenkins.io',
+      'timeout'                      => $timeout,
+      'treshold'                     => $treshold,
+      'window'                       => $window,
+      'collect_response_time'        => true ,
+      'check_certificate_expiration' => true,
+      'days_warning'                 => $days_warning,
+      'days_critical'                => $days_critical,
+      'contact'                      => $contact,
+      'tags'                         => ['production','jenkins.io']
+    },
+    {
+      'sitename'                     => 'accounts.jenkins.io',
+      'url'                          => 'https://accounts.jenkins.io',
+      'timeout'                      => $timeout,
+      'treshold'                     => $treshold,
+      'window'                       => $window,
+      'collect_response_time'        => true,
+      'check_certificate_expiration' => true,
+      'days_warning'                 => $days_warning,
+      'days_critical'                => $days_critical,
+      'contact'                      => $contact,
+      'tags'                         => ['production','jenkins.io']
+    },
+    {
+      'sitename'                     => 'ci.jenkins.io',
+      'url'                          => 'https://ci.jenkins.io',
+      'timeout'                      => $timeout,
+      'treshold'                     => $treshold,
+      'window'                       => $window,
+      'collect_response_time'        => true,
+      'check_certificate_expiration' => true,
+      'days_warning'                 => $days_warning,
+      'days_critical'                => $days_critical,
+      'contact'                      => $contact,
+      'tags'                         => ['production','jenkins.io']
+    },
+    {
+      'sitename'                     => 'pkg.jenkins.io',
+      'url'                          => 'https://pkg.jenkins.io',
+      'timeout'                      => $timeout,
+      'treshold'                     => $treshold,
+      'window'                       => $window,
+      'collect_response_time'        => true,
+      'check_certificate_expiration' => true,
+      'days_warning'                 => $days_warning,
+      'days_critical'                => $days_critical,
+      'contact'                      => $contact,
+      'tags'                         => ['production','jenkins.io']
+    },
+    {
+      'sitename'                     => 'usage.jenkins.io',
+      'url'                          => 'https://usage.jenkins.io',
+      'timeout'                      => $timeout,
+      'treshold'                     => $treshold,
+      'window'                       => $window,
+      'collect_response_time'        => true,
+      'check_certificate_expiration' => true,
+      'days_warning'                 => $days_warning,
+      'days_critical'                => $days_critical,
+      'contact'                      => $contact,
+      'tags'                         => ['production','jenkins.io']
+    },
+    {
+      'sitename'                     => 'updates.jenkins.io',
+      'url'                          => 'https://updates.jenkins.io',
+      'timeout'                      => $timeout,
+      'treshold'                     => $treshold,
+      'window'                       => $window,
+      'collect_response_time'        => true,
+      'check_certificate_expiration' => true,
+      'days_warning'                 => $days_warning,
+      'days_critical'                => $days_critical,
+      'contact'                      => $contact,
+      'tags'                         => ['production','jenkins.io']
+    },
+    {
+      'sitename'                     => 'confluence',
+      'url'                          => 'https://wiki.jenkins.io/display/JENKINS/Git+Plugin',
+      'timeout'                      => $timeout,
+      'treshold'                     => $treshold,
+      'window'                       => $window,
+      'collect_response_time'        => true,
+      'check_certificate_expiration' => true,
+      'days_warning'                 => $days_warning,
+      'days_critical'                => $days_critical,
+      'contact'                      => $contact,
+      'tags'                         => ['production','jenkins.io']
+    },
+    {
+      'sitename'                     => 'confluence backend',
+      'url'                          => 'https://wiki.jenkins.io/s/2015/1/1/_/download/superbatch/css/batch.css',
+      'timeout'                      => $timeout,
+      'treshold'                     => $treshold,
+      'window'                       => $window,
+      'collect_response_time'        => true,
+      'check_certificate_expiration' => true,
+      'days_warning'                 => $days_warning,
+      'days_critical'                => $days_critical,
+      'contact'                      => $contact,
+      'tags'                         => ['production','jenkins.io']
+    },
+    {
+      'sitename'                     => 'jira',
+      'url'                          => 'https://issues.jenkins-ci.org/browse/JENKINS-12345',
+      'timeout'                      => $timeout,
+      'treshold'                     => $treshold,
+      'window'                       => $window,
+      'collect_response_time'        => true,
+      'check_certificate_expiration' => true,
+      'days_warning'                 => $days_warning,
+      'days_critical'                => $days_critical,
+      'contact'                      => $contact,
+      'tags'                         => ['production','jenkins-ci.org']
+    }]
+  }
+}

--- a/dist/profile/manifests/datadog_ssl_check.pp
+++ b/dist/profile/manifests/datadog_ssl_check.pp
@@ -1,14 +1,19 @@
+#   ! This puppet class is deprecated as it is now included by datadog module
+#
 #
 # Define datadog check for ssl expiration
 # Inspired by: https://workshop.avatarnewyork.com/project/datadog-ssl-expires-check/
 #
+#
+#
 class profile::datadog_ssl_check (
   $sites = [],
+  $ensure = 'absent'
 ){
   require datadog_agent
 
   file { 'ssl_check_expire_days.py':
-    ensure => present,
+    ensure => $ensure,
     source => "puppet:///modules/${module_name}/datadog_ssl_check/ssl_check_expire_days.py",
     path   => '/etc/dd-agent/checks.d/ssl_check_expire_days.py',
     owner  => $::datadog_agent::params::dd_user,
@@ -17,7 +22,7 @@ class profile::datadog_ssl_check (
   }
 
   file { 'ssl_check_expire_days.yaml':
-    ensure  => present,
+    ensure  => $ensure,
     content => template("${module_name}/datadog_ssl_check/ssl_check_expire_days.yaml.erb"),
     owner   => $::datadog_agent::params::dd_user,
     group   => $::datadog_agent::params::dd_group,

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -9,13 +9,14 @@ class profile::docker {
     require          => Package['linux-image-extra'],
   }
 
-  include datadog_agent::integrations::docker
+  include datadog_agent::integrations::docker_daemon
 
   # Ensure that the datadog user has the right group to access docker
   user { $datadog_agent::params::dd_user:
     ensure  => present,
     groups  => ['docker'],
     require => Class['::docker'],
+    before  => Class['datadog_agent::integrations::docker_daemon']
   }
 
   firewall { '010 allow inter-docker traffic':

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -113,6 +113,7 @@ class profile::jira (
   }
 
   profile::datadog_check { 'jira-http-check':
+    ensure  => 'absent',
     checker => 'http_check',
     source  => 'puppet:///modules/profile/jira/http_check.yaml',
   }

--- a/dist/role/manifests/puppetmaster.pp
+++ b/dist/role/manifests/puppetmaster.pp
@@ -4,7 +4,7 @@ class role::puppetmaster {
   include profile::base
   include profile::puppetmaster
   include profile::sudo::osu
-  include profile::datadog_ssl_check
+  include profile::datadog_http_check
   include profile::datadog_pluginsite_check
 
   include role::kubernetes

--- a/spec/classes/profile/datadog_http_check.rb
+++ b/spec/classes/profile/datadog_http_check.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe 'profile::datadog_http_check' do
+  it { should contain_class('datadog_agent') }
+  it { should contain_class('datadog_agent::integrations::http_check') }
+end

--- a/spec/classes/profile/docker_spec.rb
+++ b/spec/classes/profile/docker_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe 'profile::docker' do
   it { should contain_class 'docker' }
-  it { should contain_class 'datadog_agent::integrations::docker' }
+  it { should contain_class 'datadog_agent::integrations::docker_daemon' }
   it { should contain_firewall('010 allow inter-docker traffic').with_action('accept').with_iniface('docker0') }
 end

--- a/spec/classes/role/puppetmaster_spec.rb
+++ b/spec/classes/role/puppetmaster_spec.rb
@@ -9,6 +9,6 @@ describe 'role::puppetmaster' do
 
   it { should contain_class 'profile::puppetmaster' }
   it { should contain_class 'profile::sudo::osu' }
-  it { should contain_class 'profile::datadog_ssl_check' }
+  it { should contain_class 'profile::datadog_http_check' }
   it { should contain_class 'profile::datadog_pluginsite_check' }
 end


### PR DESCRIPTION
    * Bump datadog module to 1.10.0
    * Rename datadog_agent::integrations::docker to datadog_agent::integrations::docker_daemon
      as it's deprecated since datadog module 1.7.0
    * Create class profile::datadog_http_check which define all http_checks
    * Remove datadog http_check from accountapp/confluence/jira
    * Remove profile::datadog_ssl_check as it's now included in http_check from datadog module