### PR TITLE
Allow trusted agents to act as census::agents

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -146,6 +146,7 @@ node /^trusted-agent-\d+$/ {
   notice('This agent is trusted!')
   $hiera_role = 'trustedagent'
   include role::jenkins::agent
+  include role::census::agent
 }
 
 node 'bounce' {


### PR DESCRIPTION
This will allow those machines to access usage. and census.jenkins.io