### PR TITLE
Return an empty JSON file for all api/json requests

### DIFF
--- a/spec/classes/profile/buildmaster_spec.rb
+++ b/spec/classes/profile/buildmaster_spec.rb
@@ -79,15 +79,6 @@ describe 'profile::buildmaster' do
         expect(subject).to contain_apache__vhost(fqdn).with({
           :servername => fqdn,
           :port => 443,
-          :proxy_preserve_host => true,
-          :proxy_pass => [
-            {
-              'path' => '/',
-              'url' => 'http://localhost:8080/',
-              'keywords' => ['nocanon'],
-              'reverse_urls' => ['http://localhost:8080/'],
-            },
-          ],
         })
       end
 

--- a/spec/server/jenkins_master/jenkins_master_spec.rb
+++ b/spec/server/jenkins_master/jenkins_master_spec.rb
@@ -42,8 +42,9 @@ describe 'jenkins_master' do
        'Catlight/1.8.7',
        'CheckmanJenkins (Hostname: derptown)',
       ].each do |agent|
-        describe command("curl --verbose --insecure -A \"#{agent}\" -H 'Location: https://ci.jenkins.io/' --output /dev/null https://127.0.0.1/ 2>&1 | grep '302 Found'") do
+        describe command("curl --verbose --insecure -A \"#{agent}\" -H 'Location: https://ci.jenkins.io/' https://127.0.0.1/api/json") do
           its(:exit_status) { should eql 0 }
+          its(:stdout) { should match '{}' }
         end
       end
     end


### PR DESCRIPTION
This should effectively break a lot of the abusive clients which are not
following redirects. Notably Checkman which behaves in a spectacularly dumb
fashion with regards to redirects.