### PR TITLE
[INFRA-1304] Improve repo-proxy http check endpoint

### DIFF
--- a/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
@@ -22,14 +22,14 @@ spec:
                   imagePullPolicy: Always
                   livenessProbe:
                       httpGet:
-                          path: /webapp/
+                          path: /api/system/ping
                           port: 80
                           scheme: HTTP
                       initialDelaySeconds: 20
                       timeoutSeconds: 5
                   readinessProbe:
                       httpGet:
-                          path: /webapp/
+                          path: /api/system/ping
                           port: 80
                           scheme: HTTP
                       initialDelaySeconds: 30


### PR DESCRIPTION
Use a lighter http check.
/webapp/ -> +- 6s to respond
/api/system/ping -> 700ms to respond