### PR TITLE
Fix build-status badge (production)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Jenkins Infra
 
-[![Build
-Status](https://jenkins.ci.cloudbees.com/buildStatus/icon?job=infra/jenkins-infra)](https://jenkins.ci.cloudbees.com/job/infra/job/jenkins-infra/)
+[![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Infra/jenkins-infra/production)](https://ci.jenkins.io/job/Infra/job/jenkins-infra/job/production/)
 
 This repository is the [r10k](https://github.com/adrienthebo/r10k) control
 repository for the [Jenkins](https://jenkins-ci.org) project's own


### PR DESCRIPTION
@rtyler r?  Since there are two builds, I defaulted here to fixing by only including production, for now (wasn't sure).