### PR TITLE
Enable deployment to non-Azure Kubernetes environments for development

### DIFF
--- a/dist/profile/manifests/kubernetes/params.pp
+++ b/dist/profile/manifests/kubernetes/params.pp
@@ -20,6 +20,11 @@
 #     $trash:
 #       Directory that contains Kubernetes resources that need to be removed from Kubernetes
 #       clusters.
+#     $deploy_context:
+#       Describes the context in which this code is running, e.g. locally, or on Azure.
+#       This can be used, for example, to swap out Azure-specific storage volumes
+#       for ephemeral, local volumes during development with minikube or similar.
+#       Currently used values are: 'local', 'azure'.
 #     $clusters:
 #       clusters contains a list of cluster information.
 #       This variable must respect following format:
@@ -47,6 +52,7 @@ class profile::kubernetes::params (
   $backup = "${home}/backup",
   $config = "${home}/.kube",
   $trash = "${home}/trash",
-  $clusters = []
+  $deploy_context = 'azure',
+  $clusters = [],
   ){
 }

--- a/dist/profile/manifests/kubernetes/resources/accountapp.pp
+++ b/dist/profile/manifests/kubernetes/resources/accountapp.pp
@@ -51,9 +51,9 @@
 #
 # Deploy accountapp resources on kubernetes cluster
 class profile::kubernetes::resources::accountapp (
-    String $election_close = '1970-01-02',
-    String $election_open = '1970-01-01',
-    String $election_logdir= '/var/log/accountapp/elections',
+    String $election_close = '1970/01/02',
+    String $election_open = '1970/01/01',
+    String $election_logdir = '/var/log/accountapp/elections',
     String $election_candidates = 'bob,alice',
     String $image_tag = 'latest',
     String $jira_username = 'jira_username',
@@ -72,7 +72,7 @@ class profile::kubernetes::resources::accountapp (
     String $storage_account_name = '',
     String $storage_account_key = '',
     String $domain_name = 'accounts.jenkins.io',
-    Array $domain_alias = ['accounts.jenkins-ci.org']
+    Array $domain_alias = ['accounts.jenkins-ci.org'],
   ){
   include profile::kubernetes::params
   require profile::kubernetes::kubectl
@@ -120,7 +120,8 @@ class profile::kubernetes::resources::accountapp (
       'smtp_server'           => $smtp_server,
       'smtp_user'             => $smtp_user,
       'smtp_auth'             => $smtp_auth,
-      'url'                   => "https://${domain_name}/"
+      'url'                   => "https://${domain_name}/",
+      'deploy_context'        => $profile::kubernetes::params::deploy_context,
     }
   }
 

--- a/dist/profile/manifests/kubernetes/resources/fluentd.pp
+++ b/dist/profile/manifests/kubernetes/resources/fluentd.pp
@@ -26,7 +26,8 @@ class profile::kubernetes::resources::fluentd (
 
   profile::kubernetes::apply{ 'fluentd/daemonset.yaml':
     parameters => {
-      'image_tag' => $image_tag
+      'image_tag'      => $image_tag,
+      'deploy_context' => $profile::kubernetes::params::deploy_context,
     }
   }
 

--- a/dist/profile/manifests/kubernetes/resources/repo_proxy.pp
+++ b/dist/profile/manifests/kubernetes/resources/repo_proxy.pp
@@ -59,7 +59,8 @@ class profile::kubernetes::resources::repo_proxy (
   }
   profile::kubernetes::apply{ 'repo_proxy/deployment.yaml':
     parameters => {
-      'image_tag' => $image_tag
+      'image_tag'      => $image_tag,
+      'deploy_context' => $profile::kubernetes::params::deploy_context,
     }
   }
 

--- a/dist/profile/templates/kubernetes/resources/accountapp/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/accountapp/deployment.yaml.erb
@@ -81,7 +81,11 @@ spec:
               mountPath: /var/log/accountapp
       volumes:
         - name: accountapp
+          <% if @parameters['deploy_context'] == 'local' %>
+          emptyDir: {}
+          <% else %>
           azureFile:
             secretName: accountapp
             shareName: accountapp
             readOnly: false
+          <% end -%>

--- a/dist/profile/templates/kubernetes/resources/fluentd/daemonset.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/fluentd/daemonset.yaml.erb
@@ -47,10 +47,14 @@ spec:
               readOnly: true
       volumes:
         - name: logs
-          azureFile: 
+          <% if @parameters['deploy_context'] == 'local' %>
+          emptyDir: {}
+          <% else %>
+          azureFile:
             secretName: azurelogs
             shareName: logs
             readOnly: false
+          <% end -%>
 
         - name: varlibdockercontainers
           hostPath:

--- a/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
@@ -48,5 +48,9 @@ spec:
                       mountPath: /var/cache/nginx
             volumes:
               - name: repo-proxy
+                <% if @parameters['deploy_context'] == 'local' %>
+                emptyDir: {}
+                <% else %>
                 persistentVolumeClaim:
                     claimName: repo-proxy
+                <% end -%>


### PR DESCRIPTION
As I don't have an Azure account, I tried out running under a local [minikube-powered](https://github.com/kubernetes/minikube) Kubernetes cluster (with help from @olblak).

However, many containers won't start up if they're using an Azure-specific resource type, such as an `azureFile` volume.  This change lets us swap out parts of the config for alternative non-Azure implementations, based on a parameter.

In my `hieradata/roles/kubernetes.yaml`, I now just have to define:
```
profile::kubernetes::params::deploy_context: local
```

We tried a couple of approaches to swap out resource types during provisioning, and this ended up being the simplest.

I also took notes while getting started with this Vagrant- and minikube-powered setup, so we could add some documentation for people who might want to develop/test locally in this manner.