### PR TITLE
[INFRA-1324] Disable ipv6 listening on kubernetes ingress

### DIFF
--- a/dist/profile/templates/kubernetes/resources/nginx/configmap.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/configmap.yaml.erb
@@ -6,6 +6,7 @@ data:
   hsts-include-subdomains: "false"
   body-size: "64m"
   server-name-hash-bucket-size: "256"
+  disable-ipv6: "true"
 kind: ConfigMap
 metadata:
   namespace: nginx-ingress

--- a/dist/profile/templates/kubernetes/resources/nginx/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/deployment.yaml.erb
@@ -12,7 +12,7 @@ spec:
         logtype: archive
     spec:
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.3
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.12
         name: nginx
         imagePullPolicy: Always
         env:


### PR DESCRIPTION
This PR bump nginx-ingress-controller version to 0.9.0-beta.12 and disable IPv6 listening for all k8s endpoint:
- accounts.jenkins.io
- plugins.jenkins.io
- repo.azure.jenkins.io

There are two reasons why we disable ipv6 for all endpoint. 
One, It's not possible to disable ipv6 for only one endpoint (accounts.jenkins.io).
Two, K8s doesn't provide a public ipv6 IP out of the box which means that we cannot configure AAAA records