### PR TITLE
[INFRA-1328] Give */api/python requests the same thing as */api/json

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -364,8 +364,8 @@ ProxyPassReverse / http://localhost:8080/
         path       => "${docroot}/empty.json",
       },
       {
-        # Send all api/xml to `empty.xml` to prevent abusive clients
-        # (checkman) from receiving an invalid XML response and repeatedly attempting
+        # Send all api/xml to `empty.xml` to prevent abusive clients (like checkman over
+        # in JSON land) from receiving an invalid XML response and repeatedly attempting
         # to hammer us to get a better response.
         aliasmatch => '(.*)/api/xml(/|$)(.*)',
         path       => "${docroot}/empty.xml",

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -344,16 +344,16 @@ RewriteRule ^/cli.* https://github.com/jenkinsci-cert/SECURITY-218
 # proxy_pass_match configurations
 ProxyRequests Off
 ProxyPreserveHost On
-ProxyPassMatch (.*)/api/json(/|$)(.*)  !
+ProxyPassMatch (.*)/api/(json|python)(/|$)(.*)  !
 ProxyPass / http://localhost:8080/ nocanon
 ProxyPassReverse / http://localhost:8080/
 ",
     aliases               => [
       {
-        # Send all api/json requests to `empty.json` to prevent abusive clients
+        # Send all api/json or api/python requests to `empty.json` to prevent abusive clients
         # (checkman) from receiving an invalid JSON response and repeatedly attempting
-        # to hammer us to get a better response
-        aliasmatch => '(.*)/api/json(/|$)(.*)',
+        # to hammer us to get a better response. Works for Python API as well.
+        aliasmatch => '(.*)/api/(json|python)(/|$)(.*)',
         path       => "${docroot}/empty.json",
       },
     ],

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -307,6 +307,13 @@ class profile::buildmaster(
     require => File[$docroot],
   }
 
+  file { "${docroot}/empty.xml" :
+    ensure  => file,
+    content => '<nope/>',
+    mode    => '0644',
+    require => File[$docroot],
+  }
+
   apache::vhost { $ci_fqdn:
     serveraliases         => [
       # Give all our buildmaster profiles this server alias; it's easier than
@@ -344,7 +351,7 @@ RewriteRule ^/cli.* https://github.com/jenkinsci-cert/SECURITY-218
 # proxy_pass_match configurations
 ProxyRequests Off
 ProxyPreserveHost On
-ProxyPassMatch (.*)/api/(json|python)(/|$)(.*)  !
+ProxyPassMatch (.*)/api/(json|python|xml)(/|$)(.*)  !
 ProxyPass / http://localhost:8080/ nocanon
 ProxyPassReverse / http://localhost:8080/
 ",
@@ -355,6 +362,13 @@ ProxyPassReverse / http://localhost:8080/
         # to hammer us to get a better response. Works for Python API as well.
         aliasmatch => '(.*)/api/(json|python)(/|$)(.*)',
         path       => "${docroot}/empty.json",
+      },
+      {
+        # Send all api/xml to `empty.xml` to prevent abusive clients
+        # (checkman) from receiving an invalid XML response and repeatedly attempting
+        # to hammer us to get a better response.
+        aliasmatch => '(.*)/api/xml(/|$)(.*)',
+        path       => "${docroot}/empty.xml",
       },
     ],
   }

--- a/spec/server/jenkins_master/jenkins_master_spec.rb
+++ b/spec/server/jenkins_master/jenkins_master_spec.rb
@@ -52,6 +52,11 @@ describe 'jenkins_master' do
         its(:exit_status) { should eql 0 }
         its(:stdout) { should match '{}' }
       end
+      # And one more time but with api/xml
+      describe command("curl --verbose --insecure -A \"#{agent}\" -H 'Location: https://ci.jenkins.io/' https://127.0.0.1/api/xml") do
+        its(:exit_status) { should eql 0 }
+        its(:stdout) { should match '<nope/>' }
+      end
     end
   end
 end

--- a/spec/server/jenkins_master/jenkins_master_spec.rb
+++ b/spec/server/jenkins_master/jenkins_master_spec.rb
@@ -47,6 +47,11 @@ describe 'jenkins_master' do
           its(:stdout) { should match '{}' }
         end
       end
+      # Same trick but this time with api/python
+      describe command("curl --verbose --insecure -A \"#{agent}\" -H 'Location: https://ci.jenkins.io/' https://127.0.0.1/api/python") do
+        its(:exit_status) { should eql 0 }
+        its(:stdout) { should match '{}' }
+      end
     end
   end
 end


### PR DESCRIPTION
[INFRA-1328](https://issues.jenkins-ci.org/browse/INFRA-1328)

I *think* this is right? 