### PR TITLE
Remove unneeded datadog http check for jira/confluence

### DIFF
--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -141,12 +141,6 @@ class profile::confluence (
   profile::apachemaintenance { 'wiki.jenkins.io':
   }
 
-  profile::datadog_check { 'confluence-http-check':
-    ensure  => 'absent',
-    checker => 'http_check',
-    source  => 'puppet:///modules/profile/confluence/http_check.yaml',
-  }
-
   profile::datadog_check { 'confluence-process-check':
     checker => 'process',
     source  => 'puppet:///modules/profile/confluence/process_check.yaml',

--- a/dist/profile/manifests/jira.pp
+++ b/dist/profile/manifests/jira.pp
@@ -112,12 +112,6 @@ class profile::jira (
   profile::apachemaintenance { 'issues.jenkins-ci.org':
   }
 
-  profile::datadog_check { 'jira-http-check':
-    ensure  => 'absent',
-    checker => 'http_check',
-    source  => 'puppet:///modules/profile/jira/http_check.yaml',
-  }
-
   profile::datadog_check { 'jira-process-check':
     checker => 'process',
     source  => 'puppet:///modules/profile/jira/process_check.yaml',

--- a/spec/classes/profile/confluence_spec.rb
+++ b/spec/classes/profile/confluence_spec.rb
@@ -57,10 +57,6 @@ describe 'profile::confluence' do
     )
   }
 
-  context 'datadog configuration' do
-    it { should contain_file '/etc/dd-agent/conf.d/http_check.yaml' }
-  end
-
   context 'environment => production' do
     let(:environment) { 'production' }
 

--- a/spec/classes/profile/jira_spec.rb
+++ b/spec/classes/profile/jira_spec.rb
@@ -11,7 +11,6 @@ describe 'profile::jira' do
   it { should contain_file '/etc/apache2/sites-available/issues.jenkins-ci.org.maintenance.conf' }
 
   context 'datadog configuration' do
-    it { should contain_file '/etc/dd-agent/conf.d/http_check.yaml' }
-    #it { should contain_file '/etc/dd-agent/conf.d/process_check.yaml' }
+    it { should contain_file '/etc/dd-agent/conf.d/process.yaml' }
   end
 end


### PR DESCRIPTION
Datadog configuration tests fail when we generate a configuration with no concat fragment.
If a puppet manifest only contains datadog_check sets to absent, puppet generate a file which is not a valid yaml and a wrong datadog configuration.

Each time datadog package is updated, it runs configuration tests during upgrade which lead to a failure.

.Example Puppet code
---
    profile::datadog_check { 'accountapp-http-check':
      ensure  => 'absent',
      checker => 'http_check',
      source  => 'puppet:///modules/profile/accountapp/http_check.yaml',
    }   
---

.conf.d/http_check.yaml
---
  init_config:

  instances:
---

Once puppet stop generating those files, we can delete them manually 
