### PR TITLE
[INFRA-1324] Kuberneres Ingress: Preserver source IP

### DIFF
--- a/dist/profile/templates/kubernetes/resources/nginx/service.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/service.yaml.erb
@@ -5,6 +5,7 @@ metadata:
   namespace: nginx-ingress
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: Local
   ports:
   - port: 80
     name: http


### PR DESCRIPTION
[Documentation](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer)