### PR TITLE
Add SessionAffinity for ingress, accountapp, repo_proxy

### DIFF
--- a/dist/profile/templates/kubernetes/resources/accountapp/service.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/accountapp/service.yaml.erb
@@ -8,6 +8,7 @@ metadata:
     type: accountapp
     logtype: archive
 spec:
+  sessionAffinity: ClientIP
   ports:
   - name: accountapp
     protocol: TCP

--- a/dist/profile/templates/kubernetes/resources/nginx/service.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/service.yaml.erb
@@ -9,6 +9,7 @@ spec:
   type: LoadBalancer
   # Require Kubernetes 1.7
   # externalTrafficPolicy: Local
+  sessionAffinity: ClientIP
   ports:
   - port: 80
     name: http

--- a/dist/profile/templates/kubernetes/resources/repo_proxy/service.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/repo_proxy/service.yaml.erb
@@ -8,6 +8,7 @@ metadata:
     type: repo-proxy
     logtype: archive
 spec:
+  sessionAffinity: ClientIP
   ports:
   - name: repo-proxy
     protocol: TCP


### PR DESCRIPTION
Some application require that all http request are send to the same container, especially the accountapp.
-> https://kubernetes.io/docs/concepts/services-networking/service/#proxy-mode-iptables