### PR TITLE
accept inbound LDAPS request from accounts app on eggplant

### DIFF
--- a/dist/profile/manifests/ldap.pp
+++ b/dist/profile/manifests/ldap.pp
@@ -206,6 +206,13 @@ class profile::ldap(
     action => 'accept',
   }
 
+  firewall { '107 accept inbound LDAPS request from accounts app on eggplant':
+    proto  => 'tcp',
+    source => 'eggplant.jenkins.io',
+    port   => 636,
+    action => 'accept',
+  }
+
   firewall { '107 accept inbound LDAPS request from puppet.jenkins.io':
     proto  => 'tcp',
     source => 'puppet.jenkins.io',


### PR DESCRIPTION
Open firewall for LDAPS Request from accountapp app on eggplant so the service is not interrupted while the dns is switching.