### PR TITLE
[Infra-1398] Use volume hostPath for repo-proxy

### DIFF
--- a/dist/profile/manifests/kubernetes/resources/repo_proxy.pp
+++ b/dist/profile/manifests/kubernetes/resources/repo_proxy.pp
@@ -44,6 +44,13 @@ class profile::kubernetes::resources::repo_proxy (
   }
   profile::kubernetes::apply{ 'repo_proxy/service.yaml':
   }
+
+  profile::kubernetes::apply{ 'repo_proxy/persistentVolume.yaml':
+  }
+
+  profile::kubernetes::apply{ 'repo_proxy/persistentVolumeClaim.yaml':
+  }
+
   profile::kubernetes::apply{ 'repo_proxy/ingress-tls.yaml':
     parameters => {
       'url'     => $url,

--- a/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
@@ -16,30 +16,36 @@ spec:
                 type: repo-proxy
                 logtype: archive
         spec:
+            # Nginx user need write permission on /var/cache/nginx
+            initContainers:
+                - name: volume-mount-hack
+                  image: busybox
+                  command: ["sh", "-c", "chown -R 101:101 /var/cache/nginx"]
+                  volumeMounts:
+                      - name: repo-proxy
+                        mountPath: /var/cache/nginx
             containers:
                 - name: repo-proxy
                   image: jenkinsciinfra/repo-proxy:<%= @parameters['image_tag'] %>
                   imagePullPolicy: Always
                   livenessProbe:
                       httpGet:
-                          path: /api/system/ping
+                          path: /repo1-cache/org/springframework/spring-tx/maven-metadata.xml
                           port: 80
                           scheme: HTTP
                       initialDelaySeconds: 20
                       timeoutSeconds: 5
                   readinessProbe:
                       httpGet:
-                          path: /api/system/ping
+                          path: /repo1-cache/org/springframework/spring-tx/maven-metadata.xml
                           port: 80
                           scheme: HTTP
                       initialDelaySeconds: 30
                       timeoutSeconds: 5
                   volumeMounts:
-                    - name: cache
+                    - name: repo-proxy
                       mountPath: /var/cache/nginx
             volumes:
-                - name: cache
-                  azureFile: 
-                      secretName: repo-proxy
-                      shareName: repo-proxy
-                      readOnly: false
+              - name: repo-proxy
+                persistentVolumeClaim:
+                    claimName: repo-proxy

--- a/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
@@ -20,7 +20,7 @@ spec:
             initContainers:
                 - name: volume-mount-hack
                   image: busybox
-                  command: ["sh", "-c", "chown -R 101:101 /var/cache/nginx"]
+                  command: ["sh", "-c", "chown -R $(id -u nginx):$(id -g nginx) /var/cache/nginx"]
                   volumeMounts:
                       - name: repo-proxy
                         mountPath: /var/cache/nginx

--- a/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
@@ -30,14 +30,14 @@ spec:
                   imagePullPolicy: Always
                   livenessProbe:
                       httpGet:
-                          path: /releases/com/perfectomobile/jenkins/2.20.0.19/jenkins-2.20.0.19.pom
+                          path: /repo1/org/springframework/spring-tx/maven-metadata.xml
                           port: 80
                           scheme: HTTP
                       initialDelaySeconds: 20
                       timeoutSeconds: 5
                   readinessProbe:
                       httpGet:
-                          path: /releases/com/perfectomobile/jenkins/2.20.0.19/jenkins-2.20.0.19.pom
+                          path: /repo1/org/springframework/spring-tx/maven-metadata.xml
                           port: 80
                           scheme: HTTP
                       initialDelaySeconds: 30

--- a/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
@@ -30,14 +30,14 @@ spec:
                   imagePullPolicy: Always
                   livenessProbe:
                       httpGet:
-                          path: /repo1-cache/org/springframework/spring-tx/maven-metadata.xml
+                          path: /releases/com/perfectomobile/jenkins/2.20.0.19/jenkins-2.20.0.19.pom
                           port: 80
                           scheme: HTTP
                       initialDelaySeconds: 20
                       timeoutSeconds: 5
                   readinessProbe:
                       httpGet:
-                          path: /repo1-cache/org/springframework/spring-tx/maven-metadata.xml
+                          path: /releases/com/perfectomobile/jenkins/2.20.0.19/jenkins-2.20.0.19.pom
                           port: 80
                           scheme: HTTP
                       initialDelaySeconds: 30

--- a/dist/profile/templates/kubernetes/resources/repo_proxy/persistentVolume.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/repo_proxy/persistentVolume.yaml.erb
@@ -1,0 +1,16 @@
+---
+  apiVersion: v1
+  kind: PersistentVolume
+  metadata:
+    name: repo-proxy
+    labels:
+        app: repo-proxy
+  spec:
+    capacity:
+      storage: 20Gi
+    accessModes:
+      - ReadWriteOnce
+    persistentVolumeReclaimPolicy: Retain
+    hostPath:
+        path: /mnt/repo-proxy/nginx-cache
+

--- a/dist/profile/templates/kubernetes/resources/repo_proxy/persistentVolumeClaim.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/repo_proxy/persistentVolumeClaim.yaml.erb
@@ -1,0 +1,14 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: repo-proxy
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  selector:
+      matchLabels:
+          app: repo-proxy

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -280,7 +280,7 @@ profile::kubernetes::resources::pluginsite::url: plugins.jenkins.io
 profile::kubernetes::resources::pluginsite::aliases:
     - plugins.azure.jenkins.io
 
-profile::kubernetes::resources::repo_proxy::image_tag: '4-build913432'
+profile::kubernetes::resources::repo_proxy::image_tag: '19-build1bc066'
 profile::kubernetes::resources::repo_proxy::url: repo.azure.jenkins.io
 
 # The following map to the Terraform resource "${tfPrefix}jenkinsrelease" for


### PR DESCRIPTION
The PR change the mounted volume used by repo-proxy container.
Instead of using azure files which rely on the network, we use hostPath that mount local node directory inside a container.
This means that instead of having one directory shared across containers (Azure file), we now have one caching directory per node per container.
Remark: If for some reason a container has to move on another nodes, it lose/changes his cache directory.