### PR TITLE
Remove ssh_key to avoid a circular dependency

### DIFF
--- a/dist/profile/manifests/staticsite.pp
+++ b/dist/profile/manifests/staticsite.pp
@@ -31,7 +31,6 @@ class profile::staticsite(
   account { $deployer_user:
     ensure       => absent,
     home_dir     => $site_root,
-    ssh_key      => $deployer_ssh_key,
     gid          => $deployer_group,
     create_group => false,
     shell        => $deployer_shell,

--- a/spec/classes/profile/staticsite_spec.rb
+++ b/spec/classes/profile/staticsite_spec.rb
@@ -22,7 +22,6 @@ describe 'profile::staticsite' do
 
     it 'contains a deployer account setup' do
       expect(subject).to contain_account('site-deployer').with(
-        :ssh_key => ssh_key,
         :shell   => '/usr/lib/sftp-server',
       )
     end


### PR DESCRIPTION
I believe this will work but our tests didn't catch this the first time around,
so who knows! The account defined type will not attempt to setup an
ssh_authorized_key resource if the ssh_key is undefined