### PR TITLE
Domain name verification for certificate renewal

### DIFF
--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -110,10 +110,8 @@ lists      3600    IN    MX    0    smtp4.osuosl.org.
 
 ; Certificates DNS Verification, it can be removed when validated
 @          3600  IN  TXT   "nuorpib8b66b00omtejqkj76v4"   ; For certificate:  jenkins-ci.org
-cucumber   3600  IN  TXT   "nuorpib8b66b00omtejqkj76v4"   ; For certificate:  svn.jenkins-ci.org
-edamame    3600  IN  TXT   "a7p88u6si2hmbsdfsdtgbs04dt"    ; For certificate:  issues.jenkins-ci.org
-artichoke  3600  IN  TXT   "a7p88u6si2hmbsdfsdtgbs04dt"    ; For certificate:  puppet.jenkins-ci.org
-lettuce    3600  IN  TXT   "a7p88u6si2hmbsdfsdtgbs04dt"    ; For certificate:  wiki.jenkins-ci.org
+@          3600  IN  TXT   "a7p88u6si2hmbsdfsdtgbs04dt"   ; For certificate:  wiki.jenkins-ci.org
+@          3600  IN  TXT   "rffukoeejek9rl4d1b1o2bvk0q"   ; For certificate:  repo.jenkins-ci.org
 
 ; DKIM
 cucumber._domainkey     1W IN TXT ("v=DKIM1;p="


### PR DESCRIPTION
Follow up to 768b7bdeb8b409ffa99a9b2408487d92c3a03ac7

I think TXT record needs to target the domain name itself, not after
resolving CNAME.