### PR TITLE
Ensure that Class[Letsencrypt] is in the catalogue for the account app

### DIFF
--- a/dist/profile/manifests/accountapp.pp
+++ b/dist/profile/manifests/accountapp.pp
@@ -30,6 +30,7 @@ class profile::accountapp(
 ) {
   include profile::docker
   include profile::apachemisc
+  include profile::letsencrypt
 
   $docroot = '/var/www/html'
 

--- a/spec/classes/profile/accountapp_spec.rb
+++ b/spec/classes/profile/accountapp_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'profile::accountapp' do
+  it { should contain_class 'profile::accountapp' }
+
+  context 'letsencrypt setup' do
+    let(:environment) { 'production' }
+    let(:vagrant) { nil }
+
+    it { should contain_letsencrypt__certonly('accounts.jenkins.io') }
+    it { should contain_class 'Letsencrypt' }
+  end
+end


### PR DESCRIPTION
Turns out this was previously being pulled in by profile::staticsite and I
could not get the catalogue compilation error below to reproduce in the testing
environment unless I explicitly tested the expectation in rspec-puppet

    Error: Could not retrieve catalog from remote server: Error 500 on SERVER: {"message":"Server Error: Invalid relationship: Exec[letsencrypt certonly accounts.jenkins.io] { require => Class[Letsencrypt] }, because Class[Letsencrypt] doesn't seem to be in the catalog","issue_kind":"RUNTIME_ERROR","stacktrace":["Warning: The 'stacktrace' property is deprecated and will be removed in a future version of Puppet. For security reasons, stacktraces are not returned with Puppet HTTP Error responses."]}
    Warning: Not using cache on failed catalog
    Error: Could not retrieve catalog; skipping run