### PR TITLE
[INFRA-1380] Ingress pod to daemonset

### DIFF
--- a/dist/profile/manifests/kubernetes/resources/nginx.pp
+++ b/dist/profile/manifests/kubernetes/resources/nginx.pp
@@ -49,9 +49,9 @@ class profile::kubernetes::resources::nginx (
       context  => $context,
       resource => 'nginx/default-service.yaml'
     }
-    profile::kubernetes::apply { "nginx/deployment.yaml on ${context}":
+    profile::kubernetes::apply { "nginx/daemonset.yaml on ${context}":
       context  => $context,
-      resource => 'nginx/deployment.yaml'
+      resource => 'nginx/daemonset.yaml'
     }
     profile::kubernetes::apply { "nginx/service.yaml on ${context}":
       context    => $context,
@@ -59,6 +59,10 @@ class profile::kubernetes::resources::nginx (
       parameters =>  {
         'loadBalancerIp' => $public_ip
       }
+    }
+    profile::kubernetes::delete { "nginx/deployment.yaml on ${context}":
+      context  => $context,
+      resource => 'nginx/deployment.yaml',
     }
 
     # As configmap changes do not trigger pods update,

--- a/dist/profile/templates/kubernetes/resources/nginx/daemonset.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/daemonset.yaml.erb
@@ -1,0 +1,44 @@
+apiVersion: extensions/v1beta1
+kind: Daemonset
+metadata:
+  name: nginx
+  namespace: nginx-ingress
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+        logtype: archive
+    spec:
+      containers:
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.19
+        imagePullPolicy: Always
+        name: nginx
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+        ports:
+          - containerPort: 80
+          - containerPort: 443
+        args:
+          - /nginx-ingress-controller
+          - --default-backend-service=nginx-ingress/default-http-backend
+          - --configmap=nginx-ingress/nginx

--- a/spec/classes/profile/kubernetes/nginx_spec.rb
+++ b/spec/classes/profile/kubernetes/nginx_spec.rb
@@ -31,7 +31,7 @@ describe 'profile::kubernetes::resources::nginx' do
   }
 
   it {
-    should contain_profile__kubernetes__apply('nginx/deployment.yaml on minikube')
+    should contain_profile__kubernetes__apply('nginx/daemonset.yaml on minikube')
   }
 
   it {
@@ -44,5 +44,8 @@ describe 'profile::kubernetes::resources::nginx' do
 
   it {
     should contain_profile__kubernetes__reload('nginx pods on minikube')
+  }
+  it {
+    should contain_profile__kubernetes__delete('nginx/deployment.yaml on minikube')
   }
 end


### PR DESCRIPTION
 In order to preserve the source IP, loadbalancer service need to have the annotation  'service.beta.kubernetes.io/external-traffic: OnlyLocal'.
which forces nodes without Service endpoints to remove themselves from the list of nodes eligible for loadbalanced traffic by deliberately failing health checks. 
In order to keep all nodes eligible for loadbalanced traffic, each node must run one nginx endpoint.

annotation: 'onlyLocal' is already used since months but at the moment we define the number of container needed to 3 instead of using the number of nodes.
This has already leaded to have all nginx endpoint on the same node or nodes without nginx endpoints

[Doc](https://kubernetes.io/docs/tutorials/services/source-ip/)
