### PR TITLE
Drop back to the older nginx-ingress-controller

### DIFF
--- a/dist/profile/templates/kubernetes/resources/nginx/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/deployment.yaml.erb
@@ -12,7 +12,7 @@ spec:
         logtype: archive
     spec:
       containers:
-      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.19
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.15
         name: nginx
         imagePullPolicy: Always
         env:


### PR DESCRIPTION
This upgrade may be responsible for the issues we're seeing presently between plugins.jenkins.io and its API backend

Queueing this up just in case