### PR TITLE
(Re)Bump ingress controller version to 0.9-beta.19

### DIFF
--- a/dist/profile/templates/kubernetes/resources/accountapp/ingress-tls.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/accountapp/ingress-tls.yaml.erb
@@ -6,10 +6,10 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/rewrite-target: /
-    ingress.kubernetes.io/affinity: cookie
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/affinity: cookie
     nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 
 spec:
   tls:

--- a/dist/profile/templates/kubernetes/resources/nginx/configmap.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/configmap.yaml.erb
@@ -5,7 +5,7 @@ data:
   proxy-send-imeout: "600"
   body-size: "64m"
   server-name-hash-bucket-size: "256"
-  hsts: false
+  hsts: "false"
   ssl-redirect: "false"
 kind: ConfigMap
 metadata:

--- a/dist/profile/templates/kubernetes/resources/nginx/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/deployment.yaml.erb
@@ -12,7 +12,7 @@ spec:
         logtype: archive
     spec:
       containers:
-      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.15
+      - image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.19
         name: nginx
         imagePullPolicy: Always
         env:

--- a/dist/profile/templates/kubernetes/resources/pluginsite/ingress-tls.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/pluginsite/ingress-tls.yaml.erb
@@ -5,9 +5,9 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     kubernetes.io/ingress.class: "nginx"
-    ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
Version 0.9-beta.18 introduced a breaking change in ingress annotation 
`ingress.kubernetes.io/rewrite-target: /` became `nginx.ingress.kubernetes.io/rewrite-target: /`
