### PR TITLE
Pin the azure-cli repository only to amd64

### DIFF
--- a/dist/profile/manifests/azure.pp
+++ b/dist/profile/manifests/azure.pp
@@ -15,12 +15,13 @@ class profile::azure (
     }
 
     apt::source { 'azure-cli':
-        location => 'https://apt-mo.trafficmanager.net/repos/azure-cli/',
-        release  => 'wheezy',
-        repos    => 'main',
-        key      => {
-        server => 'apt-mo.trafficmanager.net',
-        id     => '417A0893',
+        architecture => 'amd64',
+        location     => 'https://apt-mo.trafficmanager.net/repos/azure-cli/',
+        release      => 'wheezy',
+        repos        => 'main',
+        key          => {
+          server => 'apt-mo.trafficmanager.net',
+          id     => '417A0893',
         },
     }
 


### PR DESCRIPTION
Azure's i386 file seems to be junk:
    W: Failed to fetch https://apt-mo.trafficmanager.net/repos/azure-cli/dists/wheezy/InRelease  Unable to find expected entry 'main/binary-i386/Packages' in Release file (Wrong sources.list entry or malformed file)

Pinning the architecture seems to work well enough