### PR TITLE
[INFRA-1470] Display Custom 404 error page on Kubernetes

### DIFF
--- a/dist/profile/templates/kubernetes/resources/nginx/default-deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/default-deployment.yaml.erb
@@ -14,17 +14,17 @@ spec:
       - name: default-http-backend
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
-        # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.0
+        # 2. It serves 200 on a / endpoint
+        image: olblak/jenkins404:3519ac
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: 8080
+            path: /
+            port: 80
             scheme: HTTP
           initialDelaySeconds: 30
           timeoutSeconds: 5
         ports:
-            - containerPort: 8080
+            - containerPort: 80
         resources:
           limits:
             cpu: 10m

--- a/dist/profile/templates/kubernetes/resources/nginx/default-deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/default-deployment.yaml.erb
@@ -15,7 +15,7 @@ spec:
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a / endpoint
-        image: olblak/jenkins404:3519ac
+        image: jenkinsciinfra/404:2-buildb403fe
         livenessProbe:
           httpGet:
             path: /

--- a/dist/profile/templates/kubernetes/resources/nginx/default-service.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/default-service.yaml.erb
@@ -7,7 +7,7 @@ metadata:
 spec:
     ports:
         - port: 80
-          targetPort: 8080
+          targetPort: 80
           protocol: TCP
     selector:
         app: default-http-backend


### PR DESCRIPTION
In order to compare the difference

docker run -i -t --rm -p 8080:8080 gcr.io/google_containers/defaultbackend:1.0
docker run -i -t --rm -p 80:80 olblak/jenkins404:3519ac 