### PR TITLE
Add the Pipeline GitHub Notify Step plugin to our CI environments

### DIFF
--- a/hieradata/clients/ci.yaml
+++ b/hieradata/clients/ci.yaml
@@ -28,6 +28,7 @@ profile::buildmaster::plugins:
   - ldap
   - mailer
   - parallel-test-executor
+  - pipeline-githubnotify-step
   - pipeline-stage-view
   - pipeline-utility-steps
   - pmd

--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -25,6 +25,7 @@ profile::buildmaster::plugins:
   - ldap
   - mailer
   - parallel-test-executor
+  - pipeline-githubnotify-step
   - pipeline-stage-view
   - pipeline-utility-steps
   - pmd


### PR DESCRIPTION
This will require some additional configuration in ci.jenkins.io to use the
appropriate @jenkins-admin tokens.

Fixes INFRA-1488