### PR TITLE
Ensure we're setting configuration down in the right, new, directory

### DIFF
--- a/dist/profile/manifests/datadog_check.pp
+++ b/dist/profile/manifests/datadog_check.pp
@@ -6,7 +6,7 @@ define profile::datadog_check(
   $source    = undef,
   $content   = undef,
 ) {
-  $target ="${datadog_agent::params::conf_dir}/${checker}.yaml"
+  $target ="${datadog_agent::params::conf6_dir}/${checker}.yaml"
 
   include datadog_agent
 

--- a/dist/profile/manifests/datadog_pluginsite_check.pp
+++ b/dist/profile/manifests/datadog_pluginsite_check.pp
@@ -21,7 +21,7 @@ class profile::datadog_pluginsite_check (
     content => template("${module_name}/datadog_pluginsite_check/plugins_api_check.yaml.erb"),
     owner   => $::datadog_agent::params::dd_user,
     group   => $::datadog_agent::params::dd_group,
-    path    => "${::datadog_agent::params::conf_dir}/plugins_api_check.yaml",
+    path    => "${::datadog_agent::params::conf6_dir}/plugins_api_check.yaml",
     notify  => Service[$datadog_agent::params::service_name]
   }
 }

--- a/dist/profile/manifests/datadog_ssl_check.pp
+++ b/dist/profile/manifests/datadog_ssl_check.pp
@@ -26,7 +26,7 @@ class profile::datadog_ssl_check (
     content => template("${module_name}/datadog_ssl_check/ssl_check_expire_days.yaml.erb"),
     owner   => $::datadog_agent::params::dd_user,
     group   => $::datadog_agent::params::dd_group,
-    path    => "${::datadog_agent::params::conf_dir}/ssl_check_expire_days.yaml",
+    path    => "${::datadog_agent::params::conf6_dir}/ssl_check_expire_days.yaml",
     notify  => Service['datadog-agent']
   }
 }

--- a/spec/classes/profile/jira_spec.rb
+++ b/spec/classes/profile/jira_spec.rb
@@ -11,6 +11,6 @@ describe 'profile::jira' do
   it { should contain_file '/etc/apache2/sites-available/issues.jenkins-ci.org.maintenance.conf' }
 
   context 'datadog configuration' do
-    it { should contain_file '/etc/dd-agent/conf.d/process.yaml' }
+    it { should contain_file '/etc/datadog-agent/conf.d/process.yaml' }
   end
 end


### PR DESCRIPTION
The agent v6 uses a different directory for configuration. If this doesn't jive,
we can always just switch back to the v5 agent, though v6 looks much better.