### PR TITLE
We no longer need this file

### DIFF
--- a/dist/profile/manifests/puppetmaster.pp
+++ b/dist/profile/manifests/puppetmaster.pp
@@ -92,13 +92,7 @@ class profile::puppetmaster {
     notify   => Service['pe-puppetserver'],
   }
 
-  $api_key = $::datadog_agent::api_key
   file { '/etc/dd-agent/datadog.yaml':
-    ensure  => file,
-    content => template('datadog_agent/datadog-reports.yaml.erb'),
-    owner   => 'pe-puppet',
-    group   => 'root',
-    mode    => '0640',
-    require => File['/etc/dd-agent'],
+    ensure  => absent,
   }
 }


### PR DESCRIPTION
/etc/datadog-agent/datadog.yaml is automatically generated in the new
datadog_agent module.