### PR TITLE
Bump libssl version to 1.0.1f-1ubuntu2.25

### DIFF
--- a/dist/profile/manifests/compliance.pp
+++ b/dist/profile/manifests/compliance.pp
@@ -9,7 +9,7 @@ class profile::compliance {
   # http://www.ubuntu.com/usn/usn-2959-1/
   if $::lsbdistid == 'Ubuntu' and $::lsbdistrelease == '14.04' {
     package { 'libssl1.0.0':
-      ensure => '1.0.1f-1ubuntu2.24',
+      ensure => '1.0.1f-1ubuntu2.25',
     }
   }
 }

--- a/spec/classes/profile/compliance_spec.rb
+++ b/spec/classes/profile/compliance_spec.rb
@@ -4,9 +4,9 @@ describe 'profile::compliance' do
   it { should contain_class 'profile::compliance' }
 
   context 'libssl1.0.0.' do
-    it 'should comply with USN-2959-1' do
+    it 'should comply with USN-3628-1' do
       expect(subject).to contain_package('libssl1.0.0').with({
-        :ensure => '1.0.1f-1ubuntu2.24',
+        :ensure => '1.0.1f-1ubuntu2.25',
       })
     end
   end


### PR DESCRIPTION
~~~~
change from 1.0.1f-1ubuntu2.25 to 1.0.1f-1ubuntu2.24 failed: Could not update: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold --force-yes install libssl1.0.0=1.0.1f-1ubuntu2.24' returned 100: Reading package lists... Building dependency tree... Reading state information... E: Version '1.0.1f-1ubuntu2.24' for 'libssl1.0.0' was not found
~~~~