### PR TITLE
Do not attempt to pass undefined #{agent}

### DIFF
--- a/spec/server/jenkins_master/jenkins_master_spec.rb
+++ b/spec/server/jenkins_master/jenkins_master_spec.rb
@@ -48,12 +48,12 @@ describe 'jenkins_master' do
         end
       end
       # Same trick but this time with api/python
-      describe command("curl --verbose --insecure -A \"#{agent}\" -H 'Location: https://ci.jenkins.io/' https://127.0.0.1/api/python") do
+      describe command("curl --verbose --insecure -H 'Location: https://ci.jenkins.io/' https://127.0.0.1/api/python") do
         its(:exit_status) { should eql 0 }
         its(:stdout) { should match '{}' }
       end
       # And one more time but with api/xml
-      describe command("curl --verbose --insecure -A \"#{agent}\" -H 'Location: https://ci.jenkins.io/' https://127.0.0.1/api/xml") do
+      describe command("curl --verbose --insecure -H 'Location: https://ci.jenkins.io/' https://127.0.0.1/api/xml") do
         its(:exit_status) { should eql 0 }
         its(:stdout) { should match '<nope/>' }
       end


### PR DESCRIPTION
AFAICT @abayer’s #851 mistakenly copied the use of `#{agent}` from existing tests, which made sense when we were repeating the `/api/json` test for each of three user agents, but not for the `/api/python` and `/api/xml` tests which do not do this. Maybe Ruby just silently lets this undefined variable though, or leaves it unevaluated? Not sure,

```ruby
[1, 2, 3].each do |x| puts "foo #{x}"; end; puts "bar #{x}"
```

fails for me:

```
foo 1
foo 2
foo 3
undefined local variable or method `x' for main:Object (NameError)
```