### PR TITLE
[INFRA-1584] Update DNS records for ldap&accountapp

### DIFF
--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -58,7 +58,6 @@ maven2      3600    IN    CNAME    cucumber
 ci          3600    IN    CNAME    ci.jenkins.io.
 svn         3600    IN    CNAME    cucumber
 javanet2    3600    IN    CNAME    cucumber
-ldap        3600    IN    CNAME    cucumber
 l10n        3600    IN    CNAME    l10n.jenkins.io.
 mirrors     3600    IN    CNAME    mirrors.jenkins.io.
 pkg         3600    IN    CNAME    pkg.jenkins.io.

--- a/dist/profile/files/bind/jenkins.io.zone
+++ b/dist/profile/files/bind/jenkins.io.zone
@@ -34,7 +34,6 @@ radish      3600    IN    A    140.211.9.94      ; otherwise known as jenkins-ra
 
 
 ; EC2
-ldap        3600    IN    A    52.201.145.189 ; jenkins-ldap
 rating      3600    IN    A    52.23.130.110  ; jenkins-ratings
 mirrors     3600    IN    A    52.202.51.185  ; jenkins-mirrorbrain
 ci          3600    IN    A    52.71.231.250  ; jenkins-ci
@@ -43,12 +42,14 @@ census      3600    IN    A    52.202.38.86   ; jenkins-census
 usage       3600    IN    A    52.204.62.78   ; jenkins-usage
 
 ; Azure
+ldap          3600  IN    A       52.232.180.203 ; jenkins-ldap
+accounts      3600  IN    CNAME   nginx.azure    ; accountapp application
 nginx.azure   3600  IN    CNAME   @              ; kubernetes service: namespace:nginx-ingress name:nginx
+plugins       3600  IN    CNAME   nginx.azure    ; plugins.jenkins.io runs a simple pluginsite
 repo.azure    3600  IN    CNAME   nginx.azure    ; Proxy cache in front of repo.jenkins-ci.org
 www           3600  IN    CNAME   nginx.azure    ; main website
 
 ; CNAME Records
-accounts    3600    IN    CNAME    eggplant       ; accountapp application
 pkg         3600    IN    CNAME    mirrors ; pkg and mirrors run off the same host
 puppet      3600    IN    CNAME    radish
 updates     3600    IN    CNAME    mirrors ; updates.jenkins.io for delivering update center, etc
@@ -57,7 +58,6 @@ archives    3600    IN    CNAME    okra ; archives.jenkins.io for delivering old
 stats       3600    IN    CNAME    jenkins-infra.github.io. ; CNAME for stats.jenkins.io which is hosted on GH pages
 patron      3600    IN    CNAME    jenkins-infra.github.io. ; CNAME for patron.jenkins.io which is hosted on GH pages
 javadoc     3600    IN    CNAME    eggplant ; CNAME for javadoc.jenkins.io which is currently in role::eggplant
-plugins     3600    IN    CNAME    nginx.azure ; plugins.jenkins.io runs a simple pluginsite
 reports     3600    IN    CNAME    prodjenkinsreports.blob.core.windows.net. ; see INFRA-947
 wiki        3600    IN    CNAME    lettuce
 


### PR DESCRIPTION
This PR delete the dns record for 'ldap.jenkins-ci.org' which doesn't seem to be used anymore.
It also redirect ldap.jenkins.io and accounts.jenkins.io to k8s cluster on azure.

! This cannot be merged before Saturday, cfr [email](http://lists.jenkins-ci.org/pipermail/jenkins-infra/2018-April/001441.html)

