### PR TITLE
Disable livenessprobe && readynessProbe

### DIFF
--- a/dist/profile/templates/kubernetes/resources/ldap/stateful.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/ldap/stateful.yaml.erb
@@ -46,11 +46,6 @@ spec:
                     secretKeyRef:
                       name: ldap
                       key: ldap.admin.password
-            livenessProbe:
-                tcpSocket:
-                  port: 636
-                initialDelaySeconds: 5
-                periodSeconds: 10
             readinessProbe:
                 exec:
                   command:

--- a/dist/profile/templates/kubernetes/resources/ldap/stateful.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/ldap/stateful.yaml.erb
@@ -46,12 +46,6 @@ spec:
                     secretKeyRef:
                       name: ldap
                       key: ldap.admin.password
-            readinessProbe:
-                exec:
-                  command:
-                    - /entrypoint/healthcheck
-                initialDelaySeconds: 5
-                periodSeconds: 5
             ports:
               - containerPort: 389
               - containerPort: 636


### PR DESCRIPTION
There are two kind of heal-check that we can use on Kubernetes,
ReadynessProbe, which add/remove pods from Loadbalancer
LivenessProbe, which force a container restart.

In both cases, the checks may introduce false-negative and don't bring added values.