### PR TITLE
Update daemonset rolling update strategy and kubectl exec command

### DIFF
--- a/dist/profile/manifests/kubernetes/apply.pp
+++ b/dist/profile/manifests/kubernetes/apply.pp
@@ -27,6 +27,7 @@
 define profile::kubernetes::apply (
   String $context = '',
   String $kubeconfig = $profile::kubernetes::params::kubeconfig,
+  String $home = $profile::kubernetes::params::home,
   String $resource = $title,
   String $user = $profile::kubernetes::params::user,
   Hash $parameters = {}
@@ -52,12 +53,16 @@ define profile::kubernetes::apply (
 
   exec { "update ${resource} on ${context}":
     command     => "kubectl apply ${kubectl_options}",
-    environment => ["KUBECONFIG=${kubeconfig}"] ,
+    cwd         => $home,
+    environment => [
+      "KUBECONFIG=${kubeconfig}",
+      "HOME=${home}"
+    ] ,
     path        => [$profile::kubernetes::params::bin,$::path],
     refreshonly => true,
     logoutput   => true,
     subscribe   => File["${profile::kubernetes::params::resources}/${context}/${resource}"],
-    user        => $user
+    user        => $user,
   }
 
   # Remove resource from trash directory

--- a/dist/profile/manifests/kubernetes/delete.pp
+++ b/dist/profile/manifests/kubernetes/delete.pp
@@ -27,6 +27,7 @@
 define profile::kubernetes::delete (
   String $context = '',
   String $kubeconfig = $profile::kubernetes::params::kubeconfig,
+  String $home = $profile::kubernetes::params::home,
   String $resource = $title,
   String $user = $profile::kubernetes::params::user
 ){
@@ -56,7 +57,11 @@ define profile::kubernetes::delete (
   # Only run kubectl delete if the resources is deployed.
   exec { "Remove ${resource} on ${context}":
     command     => "kubectl delete ${delete_args}",
-    environment => ["KUBECONFIG=${kubeconfig}"] ,
+    cwd         => $home,
+    environment => [
+      "KUBECONFIG=${kubeconfig}",
+      "HOME=${home}"
+    ] ,
     path        => [$profile::kubernetes::params::bin,$::path],
     onlyif      => "test \"$(kubectl apply ${apply_args} | grep configured)\"",
     user        => $user,

--- a/dist/profile/manifests/kubernetes/reload.pp
+++ b/dist/profile/manifests/kubernetes/reload.pp
@@ -30,6 +30,7 @@
 define profile::kubernetes::reload (
   String $app= undef,
   String $context = '',
+  String $home = $profile::kubernetes::params::home,
   String $kubeconfig = $profile::kubernetes::params::kubeconfig,
   String $user = $profile::kubernetes::params::user,
   String $namespace = 'default',
@@ -46,8 +47,12 @@ define profile::kubernetes::reload (
 
   exec { "reload ${app} pods on ${context}":
     command     => "kubectl delete pods --namespace ${namespace} --context ${context} -l app=${app}",
+    cwd         => $home,
     path        => [$profile::kubernetes::params::bin,$::path],
-    environment => ["KUBECONFIG=${kubeconfig}"] ,
+    environment => [
+      "KUBECONFIG=${kubeconfig}",
+      "HOME=${home}"
+    ] ,
     logoutput   => true,
     subscribe   => $subscribe,
     refreshonly => true,

--- a/dist/profile/templates/kubernetes/resources/datadog/daemonset.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/datadog/daemonset.yaml.erb
@@ -3,6 +3,8 @@ kind: DaemonSet
 metadata:
   name: datadog
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -37,7 +39,7 @@ spec:
         env:
           - name: DD_API_KEY
             valueFrom:
-                secretKeyRef: 
+                secretKeyRef:
                     name: datadog
                     key: apiKey
           - name: KUBERNETES
@@ -50,8 +52,8 @@ spec:
           exec:
             command:
               - ./probe.sh
-            initialDelaySeconds: 15
-            periodSeconds: 5
+          initialDelaySeconds: 15
+          periodSeconds: 5
         volumeMounts:
           - name: dockersocket
             mountPath: /var/run/docker.sock

--- a/dist/profile/templates/kubernetes/resources/fluentd/daemonset.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/fluentd/daemonset.yaml.erb
@@ -4,6 +4,8 @@ kind: DaemonSet
 metadata:
   name: fluentd
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/dist/profile/templates/kubernetes/resources/nginx/daemonset.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/nginx/daemonset.yaml.erb
@@ -4,6 +4,8 @@ metadata:
   name: nginx
   namespace: nginx-ingress
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/spec/defines/profile/kubernetes/apply_spec.rb
+++ b/spec/defines/profile/kubernetes/apply_spec.rb
@@ -9,9 +9,10 @@ describe 'profile::kubernetes::apply' do
   end
   let(:params) do
     {
-      'resource' => 'nginx/deployment.yaml',
-      'context' => 'minikube',
-      'user' => 'k8s',
+      'resource'   => 'nginx/deployment.yaml',
+      'context'    => 'minikube',
+      'home'       => '/home/k8s',
+      'user'       => 'k8s',
       'kubeconfig' => '/home/k8s/.kube/config'
     }
   end

--- a/spec/defines/profile/kubernetes/delete_spec.rb
+++ b/spec/defines/profile/kubernetes/delete_spec.rb
@@ -13,6 +13,7 @@ describe 'profile::kubernetes::delete' do
     {
       'context'    => 'minikube',
       'resource'   => 'nginx/deployment.yaml',
+      'home'       => '/home/k8s',
       'user'       => 'k8s',
       'kubeconfig' => '/home/k8s/.kube/config'
     }

--- a/spec/defines/profile/kubernetes/reload_spec.rb
+++ b/spec/defines/profile/kubernetes/reload_spec.rb
@@ -14,6 +14,7 @@ describe 'profile::kubernetes::reload' do
     {
       'app' => 'datadog',
       'context' => 'minikube',
+      'home' => '/home/k8s',
       'namespace' => 'default',
       'user' => 'k8s',
       'kubeconfig' => '/home/k8s/.kube/config',


### PR DESCRIPTION
This PR introduces two changes:
1. Set daemonset update strategy to 'rolling update', in order to automatically update pods, one by one, when daemonset are updated. 
2. Specify a HOME environment in puppet exec resource,  kubectl uses by default the 'HOME' env variable to locate the 'schema cache directory', which leads kubectl to fail when run from the puppet exec resources.

Ps: Keep in mind that nginx-ingress will be restarted, when the daemonset configuration is updated.