### PR TITLE
[INFRA-1650] Don't use third HTTP endpoint for repo-proxy healthcheck

### DIFF
--- a/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/repo_proxy/deployment.yaml.erb
@@ -30,17 +30,13 @@ spec:
                   image: jenkinsciinfra/repo-proxy:<%= @parameters['image_tag'] %>
                   imagePullPolicy: Always
                   livenessProbe:
-                      httpGet:
-                          path: /repo1/org/springframework/spring-tx/maven-metadata.xml
+                      tcpSocket:
                           port: 80
-                          scheme: HTTP
                       initialDelaySeconds: 20
                       timeoutSeconds: 5
                   readinessProbe:
-                      httpGet:
-                          path: /repo1/org/springframework/spring-tx/maven-metadata.xml
+                      tcpSocket:
                           port: 80
-                          scheme: HTTP
                       initialDelaySeconds: 30
                       timeoutSeconds: 5
                   volumeMounts:


### PR DESCRIPTION
Repo-proxy health-check is currently configured to query '/repo1/org/springframework/spring-tx/maven-metadata.xml' which relies on a third party endpoint (Artifactory).
This means that if artifactory takes some time to answer, the repo-proxy health-check return 1 and force the container to be restarted.
The idea now, is just to monitor if the HTTP port is open or not.