### PR TITLE
[INFRA-1669] Simplify repo.jenkins-ci.org monitoring endpoint

### DIFF
--- a/dist/profile/manifests/datadog_http_check.pp
+++ b/dist/profile/manifests/datadog_http_check.pp
@@ -130,7 +130,7 @@ class profile::datadog_http_check(
     },
     {
       'sitename'                     => 'repo.jenkins-ci.org',
-      'url'                          => 'https://repo.jenkins-ci.org/repo1-cache/org/springframework/spring-tx/maven-metadata.xml',
+      'url'                          => 'https://repo.jenkins-ci.org/api/system/ping',
       'timeout'                      => $timeout,
       'threshold'                    => $threshold,
       'window'                       => $window,
@@ -143,7 +143,7 @@ class profile::datadog_http_check(
     },
     {
       'sitename'                     => 'repo.azure.jenkins.io',
-      'url'                          => 'https://repo.azure.jenkins.io/repo1-cache/org/springframework/spring-tx/maven-metadata.xml',
+      'url'                          => 'https://repo.azure.jenkins.io/api/system/ping',
       'timeout'                      => $timeout,
       'threshold'                    => $threshold,
       'window'                       => $window,


### PR DESCRIPTION
It appears that sometimes previous [url](https://repo.jenkins-ci.org/repo1-cache/org/springframework/spring-tx/maven-metadata.xml) fails because of 'resource has expired' 