### PR TITLE
Add lockable-resources to ci.j.io

### DIFF
--- a/hieradata/clients/ci.yaml
+++ b/hieradata/clients/ci.yaml
@@ -27,6 +27,7 @@ profile::buildmaster::plugins:
   - junit-attachments
   - junit-realtime-test-reporter
   - ldap
+  - lockable-resources
   - mailer
   - parallel-test-executor
   - pipeline-githubnotify-step


### PR DESCRIPTION
https://github.com/jenkins-infra/jenkins-infra/pull/1043 for ci.j.io so PR builds don't break.