### PR TITLE
Re-introduce session affinity for the evergreen backend

### DIFF
--- a/dist/profile/templates/kubernetes/resources/evergreen/service.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/evergreen/service.yaml.erb
@@ -8,6 +8,7 @@ metadata:
     app: evergreen
     type: evergreen
 spec:
+  sessionAffinity: ClientIP
   ports:
   - name: evergreen
     protocol: TCP


### PR DESCRIPTION
Without this, socket.io will not properly have its polling requests routed to
the correct pod, and likely the websockets too.

I knew I needed this @olblak :smiling_imp: