### PR TITLE
Drop the evergreen service to only one replica to work around events …

### DIFF
--- a/dist/profile/templates/kubernetes/resources/evergreen/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/evergreen/deployment.yaml.erb
@@ -5,7 +5,7 @@ metadata:
   name: evergreen
   namespace: evergreen
 spec:
-  replicas: 3
+  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
…sharing

Once JENKINS-52858 has been implemented,
this replica count can be cranked back up again