### PR TITLE
[INFRA-1730] Define a different fallblack mirror for /plugins

### DIFF
--- a/dist/profile/manifests/mirrorbrain.pp
+++ b/dist/profile/manifests/mirrorbrain.pp
@@ -401,7 +401,7 @@ date \"+%s\" > /srv/releases/jenkins/TIME
 
             # we serve most files from mirrors, but as a fallback,
             # this slow server has everything.
-            MirrorBrainFallback na us https://updates.azure.jenkins.io/
+            MirrorBrainFallback na us http://updates.azure.jenkins.io/
 
             # Do not redirect for files smaller than 4096 bytes
             MirrorBrainMinSize 4096

--- a/dist/profile/manifests/mirrorbrain.pp
+++ b/dist/profile/manifests/mirrorbrain.pp
@@ -390,6 +390,30 @@ date \"+%s\" > /srv/releases/jenkins/TIME
     ],
     directories       => [
       {
+        path            => "${docroot}/plugins",
+        options         => 'FollowSymLinks Indexes',
+        allow_override  => ['All'],
+        custom_fragment => '
+            MirrorBrainEngine On
+            MirrorBrainDebug Off
+            FormGET On
+            MirrorBrainHandleHEADRequestLocally Off
+
+            # we serve most files from mirrors, but as a fallback,
+            # this slow server has everything.
+            MirrorBrainFallback na us https://updates.azure.jenkins.io/
+
+            # Do not redirect for files smaller than 4096 bytes
+            MirrorBrainMinSize 4096
+            ## NOTE: Re-enabling these exclude rules will kill our bandwidth allocation.
+            #MirrorBrainExcludeUserAgent rpm/4.4.2*
+            #MirrorBrainExcludeUserAgent *APT-HTTP*
+
+            MirrorBrainExcludeMimeType application/pgp-keys
+            MirrorBrainExcludeMimeType text/html
+        ',
+      },
+      {
         path            => $docroot,
         options         => 'FollowSymLinks Indexes',
         allow_override  => ['All'],


### PR DESCRIPTION
This PR define a different fallback mirror than archives.jenkins-ci.org for mirrors.jenkins.io/plugins
I can't test this PR but I based my configuration on this [documentation](http://svn.mirrorbrain.org/viewvc/mirrorbrain/trunk/mod_mirrorbrain/mod_mirrorbrain.conf?view=markup). 
Search for 'MirrorBrainFallback'
