### PR TITLE
[INFRA-1744] Remove all apache services from eggplant (Part 2)

### DIFF
--- a/dist/profile/manifests/catchall.pp
+++ b/dist/profile/manifests/catchall.pp
@@ -12,164 +12,49 @@ class profile::catchall(
   $docroot_user = 'www-data'
 
   file { [$apache_maven_log_dir, $apache_log_dir, $apache_stats_log_dir] :
-    ensure => directory,
+    ensure => absent,
   }
 
   file { $docroot :
-    ensure => directory,
-    owner  => $docroot_user,
+    ensure => absent,
   }
 
   file { "${docroot}/jenkins.jnlp" :
-    ensure  => present,
-    source  => "puppet:///modules/${module_name}/catchall/jenkins.jnlp",
-    owner   => $docroot_user,
-    mode    => '0755',
-    require => File[$docroot],
+    ensure  => absent,
   }
 
   apache::vhost { 'jenkins-ci.org':
-    serveraliases   => [
-      'www.jenkins-ci.org',
-    ],
-    docroot         => $docroot,
-    port            => 443,
-    ssl             => true,
-    ssl_key         => '/etc/apache2/legacy_cert.key',
-    ssl_chain       => '/etc/apache2/legacy_chain.crt',
-    ssl_cert        => '/etc/apache2/legacy_cert.crt',
-    override        => ['All'],
-    error_log_file  => 'jenkins-ci.org/error.log',
-    access_log_pipe => "|/usr/bin/rotatelogs ${apache_log_dir}/access.log.%Y%m%d%H%M%S 604800",
-    # Using a big custom fragment here because our ordering of redirects and
-    # aliases is actually fairly important and it's difficult to ensure order
-    # in any other way
-    custom_fragment => '
-  AddType    application/x-java-jnlp-file jnlp
-
-  # compatibility with old package repository locations
-  RedirectMatch ^/redhat/(.*) https://pkg.jenkins.io/redhat/$1
-  RedirectMatch ^/opensuse/(.*) https://pkg.jenkins.io/opensuse/$1
-  RedirectMatch ^/debian/(.*) https://pkg.jenkins.io/debian/$1
-  # convenient short URLs
-  RedirectMatch /issue/(.+)          https://issues.jenkins-ci.org/browse/JENKINS-$1
-  RedirectMatch /commit/core/(.+)    https://github.com/jenkinsci/jenkins/commit/$1
-  RedirectMatch /commit/(.+)/(.+)    https://github.com/jenkinsci/$1/commit/$2
-  RedirectMatch /pull/(.+)/([0-9]+)  https://github.com/jenkinsci/$1/pull/$2
-
-  Redirect /maven-site/hudson-core /maven-site/jenkins-core
-
-  # https://issues.jenkins-ci.org/browse/INFRA-351
-  RedirectMatch ^/maven-hpi-plugin(.*) http://jenkinsci.github.io/maven-hpi-plugin/$1
-
-  # Probably not needed but, rating code moved a while ago
-  RedirectMatch ^/rate/(.*) https://rating.jenkins.io/$1
-  RedirectMatch ^/census/(.*) https://census.jenkins.io/$1
-  Redirect /jenkins-ci.org.key https://pkg.jenkins.io/redhat/jenkins.io.key
-
-  # permalinks
-  # - this one is referenced from 1.395.1 "sign post" release
-  Redirect /why            https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=53608972
-  # baked in the help file to create account on Oracle for JDK downloads
-  Redirect /oracleAccountSignup    http://www.oracle.com/webapps/redirect/signon?nexturl=http://jenkins-ci.org/
-  # to the donation page
-  Redirect /donate        https://wiki.jenkins-ci.org/display/JENKINS/Donation
-  # CLA links used in the CLA forms
-  Redirect /license        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla
-  Redirect /licenses        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla
-  # used to advertise the project meeting
-  Redirect /meetings/        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda
-  # used from friends of Jenkins plugin to link to the thank you page
-  Redirect /friend        https://wiki.jenkins-ci.org/display/JENKINS/Donation
-  # used by Gradle JPI plugin to include fragment
-  Redirect /gradle-jpi-plugin/latest    https://raw.github.com/jenkinsci/gradle-jpi-plugin/master/install
-  # used when encouraging people to subscribe to security advisories
-  Redirect /advisories        https://wiki.jenkins-ci.org/display/JENKINS/Security+Advisories
-  # used in slides and handouts to refer to survey
-  Redirect /survey        http://s.zoomerang.com/s/JenkinsSurvey
-  # used by RekeySecretAdminMonitor in Jenkins
-  Redirect /rekey            https://wiki.jenkins-ci.org/display/SECURITY/Re-keying
-  # persistent Google hangout link
-  Redirect /hangout        https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38
-# .16.203.43 repo.jenkins-ci.org
-  Redirect /pull-request-greeting    https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories
-  # Mailer plugin uses this to redirect to Javamail javadoc page
-  Redirect /javamail-properties   https://javamail.java.net/nonav/docs/api/overview-summary.html#overview_description
-  # baked in jenkins.war 1.587 / 1.580.1
-  Redirect /security-144          https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control
-  # baked in 1.600 easter egg
-  Redirect /100k                  https://jenkins.io/content/jenkins-celebration-day-february-26
-
-  RedirectMatch permanent ^/((?!patron|maven-site|jenkins.jnlp).+)$ https://jenkins.io/$1
-',
-    require         => [
-      File['/etc/apache2/legacy_cert.key'],
-      File[$apache_log_dir],
-    ],
+    ensure  =>  absent,
+    docroot => $docroot,
   }
 
   apache::vhost { 'jenkins-ci.org unsecured':
-    servername      => 'jenkins-ci.org',
-    serveraliases   => [
-      'www.jenkins-ci.org',
-    ],
-    docroot         => $docroot,
-    port            => 80,
-    redirect_status => 'permanent',
-    redirect_dest   => 'https://jenkins-ci.org/',
-    override        => ['All'],
-    error_log_file  => 'jenkins-ci.org/error_nonssl.log',
-    access_log_pipe => "|/usr/bin/rotatelogs ${apache_log_dir}/access_nonssl.log.%Y%m%d%H%M%S 604800",
-    require         => File[$docroot],
+    ensure  => absent,
+    docroot => $docroot,
   }
 
   apache::vhost { 'maven.jenkins-ci.org' :
-    port            => 80,
-    docroot         => $docroot,
-    custom_fragment => '
-  RedirectMatch ^/content/repositories/releases/(.*) http://repo.jenkins-ci.org/releases/$1
-  RedirectMatch ^/content/repositories/snapshots/(.*) http://repo.jenkins-ci.org/snapshots/$1
-',
-    error_log_file  => 'maven.jenkins-ci.org/error_nonssl.log',
-    access_log_pipe => "|/usr/bin/rotatelogs ${apache_maven_log_dir}/access.log.%Y%m%d%H%M%S 604800",
-    require         => [
-      File[$docroot],
-      File[$apache_maven_log_dir],
-    ],
+    ensure  => absent,
+    docroot => $docroot,
   }
 
   apache::vhost { 'stats.jenkins-ci.org' :
-    docroot         => $docroot,
-    port            => 80,
-    redirect_status => 'permanent',
-    redirect_dest   => 'http://stats.jenkins.io/',
-    override        => ['All'],
-    error_log_file  => 'stats.jenkins-ci.org/error_nonssl.log',
-    access_log_pipe => "|/usr/bin/rotatelogs ${apache_stats_log_dir}/access_nonssl.log.%Y%m%d%H%M%S 604800",
-    require         => [
-      File[$docroot],
-      File[$apache_stats_log_dir],
-    ],
+    ensure  => absent,
+    docroot => $docroot
   }
 
   # Legacy update site compatibility
   ##################################
   file { '/etc/apache2/legacy_cert.key':
-    ensure  => present,
-    content => hiera('ssl_legacy_key'),
-    require => Package['httpd'],
+    ensure  => absent,
   }
 
   file { '/etc/apache2/legacy_chain.crt':
-    ensure  => present,
-    content => hiera('ssl_legacy_chain'),
-    require => Package['httpd'],
+    ensure  => absent,
   }
 
   file { '/etc/apache2/legacy_cert.crt':
-    ensure  => present,
-    content => hiera('ssl_legacy_cert'),
-    require => Package['httpd'],
+    ensure  => absent,
   }
   ##################################
 }

--- a/dist/profile/manifests/javadoc.pp
+++ b/dist/profile/manifests/javadoc.pp
@@ -4,47 +4,25 @@
 # https://github.com/jenkins-infra/javadoc/
 class profile::javadoc(
   $site_root = '/srv/javadoc',
-  $remote_archive = 'https://ci.jenkins.io/job/Infra/job/javadoc/job/master/lastSuccessfulBuild/artifact/build/javadoc-site.tar.bz2',
 ) {
   include ::apache
   include profile::apachemisc
 
-  $user = 'www-data'
-
   file { $site_root:
-    ensure  => directory,
-    owner   => $user,
-    group   => 'www-data',
-    recurse => true
+    ensure  => 'absent',
   }
 
   cron { 'update javadoc.jenkins.io':
-    ensure  => present,
-    command => "cd /tmp && /usr/bin/wget ${remote_archive} && /bin/tar -C ${site_root} --strip 1 --overwrite --owner=${user} -xjf javadoc-site.tar.bz2 ; rm -f javadoc-site.tar.bz2",
-    user    => $user,
-    hour    => 4,
-    minute  => 0,
-    weekday => 1,
+    ensure  => 'absent',
   }
 
   $apache_log_dir = '/var/log/apache2/javadoc.jenkins.io'
   file { $apache_log_dir:
-    ensure => directory,
-    owner  => $user,
-    group  => 'www-data',
+    ensure => 'absent',
   }
 
   apache::vhost { 'javadoc.jenkins.io':
-    serveraliases   => [
-      'javadoc.jenkins-ci.org',
-    ],
-    docroot         => $site_root,
-    port            => 80,
-    access_log_pipe => "|/usr/bin/rotatelogs ${apache_log_dir}/access.log.%Y%m%d%H%M%S 604800",
-    error_log_file  => 'javadoc.jenkins.io/error.log',
-    require         => [
-      File[$site_root],
-      File[$apache_log_dir],
-    ],
+    ensure  => 'absent',
+    docroot => $site_root,
   }
 }

--- a/spec/classes/profile/accountapp_spec.rb
+++ b/spec/classes/profile/accountapp_spec.rb
@@ -7,7 +7,7 @@ describe 'profile::accountapp' do
     let(:environment) { 'production' }
     let(:vagrant) { nil }
 
-    it { should contain_letsencrypt__certonly('accounts.jenkins.io') }
+    it { should_not contain_letsencrypt__certonly('accounts.jenkins.io') }
     it { should contain_class 'Letsencrypt' }
   end
 end

--- a/spec/classes/profile/javadoc_spec.rb
+++ b/spec/classes/profile/javadoc_spec.rb
@@ -1,25 +1,30 @@
 require 'spec_helper'
 
 describe 'profile::javadoc' do
+  let(:site_root) { '/tmp/rspec-javadoc-root' }
   let(:params) do
     {
-      'site_root' => '/tmp/rspec-javadoc-root'
+      'site_root' => site_root
     }
   end
 
   it { should contain_class 'profile::javadoc' }
   it { should contain_class 'apache' }
 
-  it { should_not contain_file(params[:site_root]).with_ensure(:directory) }
+  it {
+    should contain_file(site_root).with(
+      'ensure' => 'absent'
+    )
+  }
 
   context 'Apache VirtualHosts' do
-    it { should_not contain_apache__vhost('javadoc.jenkins.io') }
+    it { should contain_apache__vhost('javadoc.jenkins.io') }
   end
 
   context 'updating' do
     it 'should contain a cron to update the javadoc' do
-      expect(subject).to_not contain_cron('update javadoc.jenkins.io').with(
-        'user' => 'www-data'
+      expect(subject).to contain_cron('update javadoc.jenkins.io').with(
+        'ensure' => 'absent'
       )
     end
   end

--- a/spec/classes/profile/javadoc_spec.rb
+++ b/spec/classes/profile/javadoc_spec.rb
@@ -3,27 +3,24 @@ require 'spec_helper'
 describe 'profile::javadoc' do
   let(:params) do
     {
-      :site_root => '/tmp/rspec-javadoc-root',
+      'site_root' => '/tmp/rspec-javadoc-root'
     }
   end
 
   it { should contain_class 'profile::javadoc' }
   it { should contain_class 'apache' }
 
-  it { should contain_file(params[:site_root]).with_ensure(:directory) }
+  it { should_not contain_file(params[:site_root]).with_ensure(:directory) }
 
   context 'Apache VirtualHosts' do
-    it { should contain_apache__vhost('javadoc.jenkins.io') }
-
-    context 'javadoc.jenkins.io' do
-    end
+    it { should_not contain_apache__vhost('javadoc.jenkins.io') }
   end
 
   context 'updating' do
     it 'should contain a cron to update the javadoc' do
-      expect(subject).to contain_cron('update javadoc.jenkins.io').with({
-        :user => 'www-data',
-      })
+      expect(subject).to_not contain_cron('update javadoc.jenkins.io').with(
+        'user' => 'www-data'
+      )
     end
   end
 end

--- a/spec/server/eggplant/eggplant_spec.rb
+++ b/spec/server/eggplant/eggplant_spec.rb
@@ -11,35 +11,6 @@ describe 'eggplant' do
     end
   end
 
-
   it_behaves_like 'an Apache webserver'
 
-  describe 'Redirects' do
-    cmd = "curl -kvH 'Host: jenkins-ci.org' https://127.0.0.1"
-
-    describe command(cmd) do
-      its(:stderr) { should match 'Location: https://jenkins.io/index.html' }
-      its(:exit_status) { should eq 0 }
-    end
-
-    describe command("#{cmd}/redhat/jenkins.io.key") do
-      its(:stderr) { should match 'Location: https://pkg.jenkins.io/redhat/jenkins.io.key' }
-      its(:exit_status) { should eq 0 }
-    end
-
-    describe command("#{cmd}/jenkins-ci.org.key") do
-      its(:stderr) { should match 'Location: https://pkg.jenkins.io/redhat/jenkins.io.key' }
-      its(:exit_status) { should eq 0 }
-    end
-
-    describe command("#{cmd}/issue/2") do
-      its(:stderr) { should match 'Location: https://issues.jenkins-ci.org/browse/JENKINS-2' }
-      its(:exit_status) { should eq 0 }
-    end
-
-    describe command("#{cmd}/rate/rate.js") do
-      its(:stderr) { should match 'Location: https://rating.jenkins.io/rate.js' }
-      its(:exit_status) { should eq 0 }
-    end
-  end
 end


### PR DESCRIPTION
WARNING: This PR must be deployed after https://github.com/jenkins-infra/jenkins-infra/pull/1077 otherwise accounts.jenkins-ci.org will not work until the dns is totally switched on k8s.

This PR remove following unused apache services from eggplant:
* javadoc
* accounts.
* maven
* jenkins-ci.org
* stats