### PR TITLE
[Infra-1781] Create cn.jenkins.io and jenkins.io/cn 

### DIFF
--- a/dist/profile/files/bind/jenkins.io.zone
+++ b/dist/profile/files/bind/jenkins.io.zone
@@ -41,6 +41,9 @@ l10n        3600    IN    A    52.71.7.244    ; jenkins-l10n
 census      3600    IN    A    52.202.38.86   ; jenkins-census
 usage       3600    IN    A    52.204.62.78   ; jenkins-usage
 
+; Chinese Version
+cn            3600  IN    A    122.112.226.199 ; Hosted at Huawei China
+
 ; Azure
 ldap          3600  IN    A       52.232.180.203 ; jenkins-ldap
 accounts      3600  IN    CNAME   nginx.azure    ; accountapp application

--- a/dist/profile/manifests/kubernetes/resources/jenkinsio.pp
+++ b/dist/profile/manifests/kubernetes/resources/jenkinsio.pp
@@ -30,7 +30,8 @@ class profile::kubernetes::resources::jenkinsio (
     'www.jenkins-ci.org'
     ],
   Array $clusters = $profile::kubernetes::params::clusters,
-  String $image_tag = 'alpine',
+  String $image_tag = 'latest',
+  String $cn_endpoint_ip = '122.112.226.199',
   String $storage_account_name = '',
   String $storage_account_key = '',
   String $url = 'www.jenkins.io'
@@ -62,6 +63,20 @@ class profile::kubernetes::resources::jenkinsio (
       context  => $context,
       resource => 'jenkinsio/service.yaml'
     }
+
+    profile::kubernetes::apply{ "jenkinsio/cn-service.yaml on ${context}":
+      context  => $context,
+      resource => 'jenkinsio/cn-service.yaml'
+    }
+
+    profile::kubernetes::apply{ "jenkinsio/cn-endpoint.yaml on ${context}":
+      context    => $context,
+      resource   => 'jenkinsio/cn-endpoint.yaml',
+      parameters => {
+        'cn_endpoint_ip'   => $cn_endpoint_ip
+      },
+    }
+
     profile::kubernetes::apply{ "jenkinsio/ingress-tls.yaml on ${context}":
       context    => $context,
       parameters => {
@@ -70,6 +85,12 @@ class profile::kubernetes::resources::jenkinsio (
       },
       resource   => 'jenkinsio/ingress-tls.yaml'
     }
+
+    profile::kubernetes::apply{ "jenkinsio/configmap.yaml on ${context}":
+      context  => $context,
+      resource => 'jenkinsio/configmap.yaml'
+    }
+
     profile::kubernetes::apply{ "jenkinsio/deployment.yaml on ${context}":
       context    => $context,
       parameters => {
@@ -85,6 +106,7 @@ class profile::kubernetes::resources::jenkinsio (
       app        => 'jenkinsio',
       depends_on => [
         'jenkinsio/secret.yaml',
+        'jenkinsio/configmap.yaml',
       ]
     }
 

--- a/dist/profile/templates/kubernetes/resources/jenkinsio/cn-endpoint.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/jenkinsio/cn-endpoint.yaml.erb
@@ -1,0 +1,10 @@
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: jenkinsio-cn
+subsets:
+  - addresses:
+      - ip: <%= @parameters['cn_endpoint_ip'] %>
+    ports:
+      - name: https
+        port: 443

--- a/dist/profile/templates/kubernetes/resources/jenkinsio/cn-service.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/jenkinsio/cn-service.yaml.erb
@@ -1,0 +1,10 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: jenkinsio-cn
+spec:
+  ports:
+  - protocol: TCP 
+    port: 80
+    targetPort: 443

--- a/dist/profile/templates/kubernetes/resources/jenkinsio/configmap.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/jenkinsio/configmap.yaml.erb
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jenkinsio
+data:
+  default.conf: |
+    server {
+      listen       80;
+      server_name  localhost;
+  
+      if ( $host != 'jenkins.io') {
+        return 301 $scheme://jenkins.io$request_uri;
+      }
+  
+      location / {
+          root   /usr/share/nginx/html;
+          index  index.html index.htm;
+      }
+  
+      error_page  404              /404/index.html;
+  
+      # redirect server error pages to the static page /50x.html
+      #
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+          root   /usr/share/nginx/html;
+      }
+  
+      # compatibility with old package repository locations
+      rewrite ^/redhat/(.*) https://pkg.jenkins.io/redhat/$1 permanent;
+      rewrite ^/opensuse/(.*) https://pkg.jenkins.io/opensuse/$1 permanent;
+      rewrite ^/debian/(.*) https://pkg.jenkins.io/debian/$1 permanent;
+  
+      # convenient short URLs
+      rewrite ^/issue/(.+)          https://issues.jenkins-ci.org/browse/JENKINS-$1 permanent;
+      rewrite ^/commit/core/(.+)    https://github.com/jenkinsci/jenkins/commit/$1 permanent;
+      rewrite ^/commit/(.+)/(.+)    https://github.com/jenkinsci/$1/commit/$2 permanent;
+      rewrite ^/pull/(.+)/([0-9]+)  https://github.com/jenkinsci/$1/pull/$2 permanent;
+  
+      rewrite ^/maven-site/hudson-core /maven-site/jenkins-core permanent;
+  
+      # https://issues.jenkins-ci.org/browse/INFRA-351
+      rewrite ^/maven-hpi-plugin(.*) http://jenkinsci.github.io/maven-hpi-plugin/$1 permanent;
+  
+      # Probably not needed but, rating code moved a while ago
+      rewrite ^/rate/(.*) https://rating.jenkins.io/$1 permanent;
+      rewrite ^/census/(.*) https://census.jenkins.io/$1 permanent;
+      rewrite ^/jenkins-ci.org.key$ https://pkg.jenkins.io/redhat/jenkins.io.key permanent;
+  
+      # permalinks
+      # - this one is referenced from 1.395.1 "sign post" release
+      rewrite ^/why$            https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=53608972 permanent;
+      # baked in the help file to create account on Oracle for JDK downloads
+      rewrite ^/oracleAccountSignup$    http://www.oracle.com/webapps/redirect/signon?nexturl=http://jenkins-ci.org/ permanent;
+      # to the donation page
+      rewrite ^/donate$        https://wiki.jenkins-ci.org/display/JENKINS/Donation permanent;
+      # CLA links used in the CLA forms
+      rewrite ^/license$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla permanent;
+      rewrite ^/licenses$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla permanent;
+      # used to advertise the project meeting
+      rewrite ^/meetings/$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda permanent;
+      # used from friends of Jenkins plugin to link to the thank you page
+      rewrite ^/friend$        https://wiki.jenkins-ci.org/display/JENKINS/Donation permanent;
+      # used by Gradle JPI plugin to include fragment
+      rewrite ^/gradle-jpi-plugin/latest$    https://raw.github.com/jenkinsci/gradle-jpi-plugin/master/install permanent;
+      # used when encouraging people to subscribe to security advisories
+      rewrite ^/advisories$        https://wiki.jenkins-ci.org/display/JENKINS/Security+Advisories permanent;
+      # used in slides and handouts to refer to survey
+      rewrite ^/survey$        http://s.zoomerang.com/s/JenkinsSurvey permanent;
+      # used by RekeySecretAdminMonitor in Jenkins
+      rewrite ^/rekey$            https://wiki.jenkins-ci.org/display/SECURITY/Re-keying permanent;
+      # persistent Google hangout link
+      rewrite ^/hangout$        https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38 permanent;
+      # .16.203.43 repo.jenkins-ci.org
+      rewrite ^/pull-request-greeting$    https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories permanent;
+      # Mailer plugin uses this to redirect to Javamail javadoc page
+      rewrite ^/javamail-properties$   https://javamail.java.net/nonav/docs/api/overview-summary.html#overview_description permanent;
+      # baked in jenkins.war 1.587 / 1.580.1
+      rewrite ^/security-144$          https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control permanent;
+      # baked in 1.600 easter egg
+      rewrite ^/100k$                  https://jenkins.io/content/jenkins-celebration-day-february-26 permanent;
+      rewrite ^/jep/([0-9]+) https://github.com/jenkinsci/jep/blob/master/jep/$1/README.adoc permanent;
+    }

--- a/dist/profile/templates/kubernetes/resources/jenkinsio/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/jenkinsio/deployment.yaml.erb
@@ -18,24 +18,29 @@ spec:
         spec:
             containers:
                 - name: jenkinsio
-                  image: jenkinsciinfra/jenkinsio:<%= @parameters['image_tag'] %>
+                  image: nginx:<%= @parameters['image_tag'] %>
                   imagePullPolicy: Always
                   livenessProbe:
                       tcpSocket:
                           port: 80
-                      initialDelaySeconds: 20
+                      initialDelaySeconds: 4
                       timeoutSeconds: 5
                   readinessProbe:
                       tcpSocket:
                           port: 80
-                      initialDelaySeconds: 30
+                      initialDelaySeconds: 5
                       timeoutSeconds: 5
                   volumeMounts:
                     - name: html
                       mountPath: /usr/share/nginx/html
+                    - name: config
+                      mountPath: /etc/nginx/conf.d
             volumes:
                 - name: html
                   azureFile: 
                       secretName: jenkinsio
                       shareName: jenkinsio
                       readOnly: true
+                - name: config
+                  configMap:
+                    name: jenkinsio

--- a/dist/profile/templates/kubernetes/resources/jenkinsio/ingress-tls.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/jenkinsio/ingress-tls.yaml.erb
@@ -28,6 +28,10 @@ spec:
         backend:
           serviceName: jenkinsio
           servicePort: 80
+      - path: /cn/
+        backend:
+          serviceName: jenkinsio-cn
+          servicePort: 80
   <% @parameters['aliases'].each do |vhost_alias| %>
   - host: <%= vhost_alias %>
     http:
@@ -35,5 +39,9 @@ spec:
       - path: /
         backend:
           serviceName: jenkinsio
+          servicePort: 80
+      - path: /cn/
+        backend:
+          serviceName: jenkinsio-cn
           servicePort: 80
   <% end %>

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -212,7 +212,7 @@ profile::kubernetes::resources::accountapp::ldap_url: ldaps://ldap.jenkins.io:63
 profile::kubernetes::resources::accountapp::smtp_server: smtp.sendgrid.net
 profile::kubernetes::resources::accountapp::domain_name: accounts.jenkins.io
 
-profile::kubernetes::resources::jenkinsio::image_tag: '127648'
+profile::kubernetes::resources::jenkinsio::image_tag: 'latest'
 
 profile::kubernetes::resources::ldap::image_tag: '12-builde29683'
 profile::kubernetes::resources::ldap::whitelisted_sources:

--- a/spec/classes/profile/kubernetes/jenkinsio_spec.rb
+++ b/spec/classes/profile/kubernetes/jenkinsio_spec.rb
@@ -22,6 +22,8 @@ describe 'profile::kubernetes::resources::jenkinsio' do
   }
 
   it { should contain_profile__kubernetes__apply('jenkinsio/service.yaml on minikube')}
+  it { should contain_profile__kubernetes__apply('jenkinsio/cn-service.yaml on minikube')}
+  it { should contain_profile__kubernetes__apply('jenkinsio/cn-endpoint.yaml on minikube')}
 
   it {
     should contain_profile__kubernetes__apply('jenkinsio/deployment.yaml on minikube')


### PR DESCRIPTION
This PR introduce following changes
* Move jenkinsio nginx configuration from the custom docker image to a k8s configmap which reduce the need of a custom docker image
* Add an ingress rule to redirect jenkins.io/cn to the chinese website
* Set DNS A record "cn.jenkins.io" to "122.112.226.199"