### PR TITLE
Downgrade datadog module version

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -68,7 +68,7 @@ mod 'nanliu/staging', '0.4.0'
 mod 'saz/ssh', '3.0.1'
 
 mod 'puppetlabs/lvm', '0.3.2'
-mod 'datadog/datadog_agent', '2.3.0'
+mod 'datadog/datadog_agent', '2.2.0'
 
 # Used for grabbing certificates for jenkins.io
 mod 'puppet-letsencrypt', '2.5.0'


### PR DESCRIPTION
The latest version introduced a bug that needs to be addressed and lead puppet agent to always return ''current_value absent, should be Setting proxy_host will have no effect on agent6 please use agent6_extra_options to set your proxy (noop)'