### PR TITLE
Use jenkins/jenkins Docker image

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -67,7 +67,7 @@ class profile::buildmaster(
   }
 
   docker::run { 'jenkins':
-    image            => 'jenkinsci/jenkins:lts-alpine',
+    image            => 'jenkins/jenkins:lts-alpine',
     # This is a "clever" hack to force the init script to pass the numeric UID
     # through on `docker run`. Since passing the string 'jenkins' doesn't
     # actually map the UIDs properly. Using the extra_parameters option because


### PR DESCRIPTION
Manually applied to `ci.jenkins.io`, and the agent is currently, deliberately, disabled.