### PR TITLE
Update puppetlabs-docker to 3.2.0 to support puppet 6

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -28,7 +28,7 @@ mod 'reidmv/yamlfile'
 # Needed by `yamlfile`
 mod 'adrien/filemapper'
 
-mod 'puppetlabs-docker', '3.1.0'
+mod 'puppetlabs-docker', '3.2.0'
 
 # Deps for docker
 mod 'puppetlabs/apt', '6.2.1'


### PR DESCRIPTION
This PR fix several compatibility issues that we have with puppet 6.
Especially this one [Puppet 6 support](https://github.com/puppetlabs/puppetlabs-docker/pull/375)