### PR TITLE
[INFRA-1985]Replace azure upload script for releases

### DIFF
--- a/dist/profile/files/mirrorbrain/batch-upload.bash
+++ b/dist/profile/files/mirrorbrain/batch-upload.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+source /srv/releases/.azure-storage-env
+
+## Sync files from "/srv/releases/jenkins/$CONTAINER" to $CONTAINER for each container in "$AZURE_STORAGE_ACCOUNT",
+for CONTAINER in $(az storage container list --account-name "$AZURE_STORAGE_ACCOUNT" --account-key "$AZURE_STORAGE_KEY" --query '[*].name' --output table ); do 
+        if [ -d "/srv/releases/jenkins/$CONTAINER" ]; then
+                echo "Syncing Container: $CONTAINER";
+
+                time blobxfer upload \
+                        --local-path "/srv/releases/jenkins/$CONTAINER/" \
+                        --storage-account-key "$AZURE_STORAGE_KEY" \
+                        --storage-account "$AZURE_STORAGE_ACCOUNT" \
+                        --remote-path "$CONTAINER" \
+                        --recursive \
+                        --skip-on-lmt-ge \
+                        --connect-timeout 30 \
+                        --exclude '.htaccess' 
+        fi
+done;

--- a/dist/profile/files/mirrorbrain/batch-upload.bash
+++ b/dist/profile/files/mirrorbrain/batch-upload.bash
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 source /srv/releases/.azure-storage-env
 
 ## Sync files from "/srv/releases/jenkins/$CONTAINER" to $CONTAINER for each container in "$AZURE_STORAGE_ACCOUNT",
@@ -18,3 +20,5 @@ for CONTAINER in $(az storage container list --account-name "$AZURE_STORAGE_ACCO
                         --exclude '.htaccess' 
         fi
 done;
+
+exit 0

--- a/dist/profile/files/mirrorbrain/sync.sh
+++ b/dist/profile/files/mirrorbrain/sync.sh
@@ -46,7 +46,7 @@ popd
 
 echo ">> Delivering bits to fallback"
 /srv/releases/populate-archives.sh
-/srv/releases/azure-sync.sh
+/srv/releases/batch-upload.bash
 
 echo ">> Updating the latest symlink for weekly"
 /srv/releases/update-latest-symlink.sh

--- a/dist/profile/manifests/azure.pp
+++ b/dist/profile/manifests/azure.pp
@@ -29,5 +29,9 @@ class profile::azure (
         ensure  => present,
         require => Apt::Source['azure-cli'],
     }
+
+    package { 'blobxfer' :
+        ensure   => present,
+        provider => pip,
   }
 }

--- a/dist/profile/manifests/azure.pp
+++ b/dist/profile/manifests/azure.pp
@@ -32,6 +32,7 @@ class profile::azure (
 
     package { 'blobxfer' :
         ensure   => present,
-        provider => pip,
+        provider => pip
+    }
   }
 }

--- a/dist/profile/manifests/mirrorbrain.pp
+++ b/dist/profile/manifests/mirrorbrain.pp
@@ -111,7 +111,7 @@ export AZURE_STORAGE_KEY=${azure_access_key}",
   }
 
   file { "${home_dir}/azure-sync.sh" :
-    ensure  => present,
+    ensure  => absent,
     content => "#!/bin/sh
 
 eval `cat ${home_dir}/.azure-storage-env`
@@ -123,6 +123,20 @@ wget -O release-blob-sync https://raw.githubusercontent.com/jenkins-infra/azure/
     require => [
         Package['azure-cli'],
         Package['azure-storage'],
+        File["${home_dir}/.azure-storage-env"],
+    ],
+  }
+
+  file { "${home_dir}/batch-upload.bash":
+    ensure  => present,
+    owner   => $user,
+    group   => $group,
+    mode    => '0644',
+    source  => "puppet:///modules/${module_name}/mirrorbrain/batch-upload.bash",
+    require => [
+        Package['azure-cli'],
+        Package['blobxfer'],
+        Exec['install-azure-storage-gem'],
         File["${home_dir}/.azure-storage-env"],
     ],
   }


### PR DESCRIPTION
This PR replace [release-blob-sync](https://github.com/jenkins-infra/azure/blob/master/scripts/release-blob-sync) by another one that rely on blobxfer and azure-cli  which is more robust 

The output looks like this (in dry-run) and allow to skip upload based on different algorithms (md5 or  last modified )
 
`2019-02-04 19:14:53,877 INFO - [DRY RUN] skipping: /srv/releases/jenkins/windows/jenkins-2.75.zip -> windows/jenkins-2.75.zip
`

Remark this PR as not been tested yet