### PR TITLE
Install python-certbot-apache for letsencrypt plugin

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -8,6 +8,10 @@ class profile::letsencrypt {
     }
   }
 
+  package { 'python-certbot-apache':
+    ensure => present
+  }
+
   cron { 'letsencrypt-renew-reload':
     ensure  => present,
     command => '/opt/letsencrypt/letsencrypt-auto renew --quiet --renew-hook="service apache2 reload"',


### PR DESCRIPTION
This package is needed to use apache plugin