### PR TITLE
Reset to default HTTPS X-Forwarded-Port

### DIFF
--- a/hieradata/clients/cert-ci.yaml
+++ b/hieradata/clients/cert-ci.yaml
@@ -1,6 +1,5 @@
 ---
 profile::buildmaster::ci_fqdn: 'cert.ci.jenkins.io'
-profile::buildmaster::proxy_port: 1443
 profile::buildmaster::letsencrypt: false
 # These are plugins we need in our ci environment
 profile::buildmaster::plugins:


### PR DESCRIPTION
This was introduced in https://github.com/jenkins-infra/jenkins-infra/pull/1225/files#diff-53ea1f4868304b3f7ebae4d429221e35R3 but I don't understand why: All this does is change what the reverse proxy tells Jenkins was the port in the original request – which controls whether Jenkins will show a reverse proxy error or not.

I configured cert.ci consider https://cert.ci.jenkins.io (i.e. port 443) the canonical URL, since the VPN access now seems to work. So remove this override, preventing Jenkins from showing an error related to reverse proxy configuration.