### PR TITLE
Don't pin down jenkins uid&gid for buildmaster

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -67,13 +67,10 @@ class profile::buildmaster(
 
   group { 'jenkins':
     ensure => present,
-    gid    => 999,
   }
 
   user { 'jenkins':
     ensure => present,
-    uid    => 999,
-    gid    => 999,
     home   => $jenkins_home,
   }
 

--- a/spec/classes/profile/buildmaster_spec.rb
+++ b/spec/classes/profile/buildmaster_spec.rb
@@ -11,15 +11,12 @@ describe 'profile::buildmaster' do
   context 'Jenkins configuration' do
     it { is_expected.to contain_user('jenkins').with(
         'ensure' => 'present',
-        'uid'    => '999',
-        'gid'    => '999',
         'home'   => '/var/lib/jenkins'
       )
     }
 
     it { is_expected.to contain_group('jenkins').with(
         'ensure' => 'present',
-        'gid'    => '999'
       )
     }
 


### PR DESCRIPTION
Obviously everything jenkins instances have a different uid and gid