### PR TITLE
Set minimal jenkins plugin to install on cert.ci

### DIFF
--- a/hieradata/clients/cert-ci.yaml
+++ b/hieradata/clients/cert-ci.yaml
@@ -3,3 +3,6 @@ profile::buildmaster::ci_fqdn: 'cert.ci.jenkins.io'
 profile::buildmaster::proxy_port: 1443
 profile::buildmaster::letsencrypt: false
 profile::buildmaster::groovy_init_enabled: false
+## Ensure we override the default plugins to install defined from hieradata/common.yaml
+profile::buildmaster::plugins:
+  - ldap


### PR DESCRIPTION
Ensure that we override default plugins to install defined in hieradata/common.yaml