### PR TITLE
[INFRA-2115] Prepare migration of ci.jenkins.io to Java 11

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -227,7 +227,7 @@ class profile::buildmaster(
     env              => [
       "HOME=${jenkins_home}",
       'USER=jenkins',
-      "JAVA_OPTS=-server -Xloggc:/var/jenkins_home/gc-%t.log -XX:NumberOfGCLogFiles=5 -XX:+UseGCLogFileRotation -XX:GCLogFileSize=20m -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCCause -XX:+PrintTenuringDistribution -XX:+PrintReferenceGC -XX:+PrintAdaptiveSizePolicy -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1 -Xms${java_opts_xms} -Xmx${java_opts_xmx} -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2",
+      "JAVA_OPTS=-server -Xlog:gc+heap*=debug,ref*=debug,ergo*=trace,age*=trace:file=/var/jenkins_home/gc-%t.log::filecount=5,filesize=20M -XX:+PrintTenuringDistribution -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+UnlockDiagnosticVMOptions -Xms${java_opts_xms} -Xmx${java_opts_xmx} -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2",
       'JENKINS_OPTS=--httpKeepAliveTimeout=60000',
     ],
     ports            => ['8080:8080', '50000:50000', '22222:22222'],

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -211,7 +211,7 @@ class profile::buildmaster(
   ##############################################################################
 
   docker::run { 'jenkins':
-    image            => 'jenkins/jenkins:lts-alpine',
+    image            => 'jenkins/jenkins:lts-jdk11',
     # This is a "clever" hack to force the init script to pass the numeric UID
     # through on `docker run`. Since passing the string 'jenkins' doesn't
     # actually map the UIDs properly. Using the extra_parameters option because


### PR DESCRIPTION
The GC logging was changed using [this reference](https://docs.oracle.com/javase/9/tools/java.htm#JSWOR-GUID-BE93ABDC-999C-4CB5-A88B-1994AAAC74D5).

Moving away from G1 to ZGC, which made some parameters useless as well. We could choose not to perform this "migration" at the same time, as G1 is still available. 

cc @jenkins-infra/java11-support 