### PR TITLE
Fix the redirect under the language of zh

### DIFF
--- a/dist/profile/templates/kubernetes/resources/jenkinsio/configmap.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/jenkinsio/configmap.yaml.erb
@@ -22,7 +22,7 @@ data:
           index  index.html index.htm;
           # Language setting
           if ($lang) {
-            rewrite ^/$ http://localhost/$lang$1;
+            rewrite ^/$ https://jenkins.io/$lang$1;
           }   
       }
   


### PR DESCRIPTION
@olblak I missed the setting before, I thought it's ok for the nginx.
If I visit https://jenkins.io from China, I'll be redirected to localhost/zh.