### PR TITLE
Labels are invalid without a selector

### DIFF
--- a/dist/profile/templates/kubernetes/resources/chatbot_jenkinsadmin/deployment.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/chatbot_jenkinsadmin/deployment.yaml.erb
@@ -5,6 +5,9 @@ metadata:
     name: jenkinsadmin
     namespace: chatbot
 spec:
+    selector:
+      matchLabels:
+        app: jenkinsadmin
     replicas: 1
     template:
         metadata:


### PR DESCRIPTION
fixing this k8s resource, not sure how this was originally deployed

    Notice: /Stage[main]/Profile::Kubernetes::Resources::Chatbot_jenkinsadmin/Profile::Kubernetes::Apply[chatbot_jenkinsadmin/deployment.yaml on prodbean]/Exec[update chatbot_jenkinsadmin/deployment.yaml on prodbean]/returns: The Deployment "jenkinsadmin" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"jenkinsadmin", "logtype":"stream", "type":"chatbot"}: `selector` does not match template `labels`
    Error: /Stage[main]/Profile::Kubernetes::Resources::Chatbot_jenkinsadmin/Profile::Kubernetes::Apply[chatbot_jenkinsadmin/deployment.yaml on prodbean]/Exec[update chatbot_jenkinsadmin/deployment.yaml on prodbean]: Failed to call refresh: 'kubectl apply --context prodbean -f /home/k8s/resources/prodbean/chatbot_jenkinsadmin/deployment.yaml' returned 1 instead of one of [0]
    Error: /Stage[main]/Profile::Kubernetes::Resources::Chatbot_jenkinsadmin/Profile::Kubernetes::Apply[chatbot_jenkinsadmin/deployment.yaml on prodbean]/Exec[update chatbot_jenkinsadmin/deployment.yaml on prodbean]: 'kubectl apply --context prodbean -f /home/k8s/resources/prodbean/chatbot_jenkinsadmin/deployment.yaml' returned 1 instead of one of [0]
I