### PR TITLE
[INFRA-2310] Move back to G1GC + use 16Gb of Heap

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -20,7 +20,7 @@ profile::buildmaster::groovy_d_lock_down_jenkins: 'present'
 profile::buildmaster::groovy_d_pipeline_configuration: 'present'
 profile::buildmaster::groovy_d_set_up_git: 'present'
 profile::buildmaster::groovy_d_terraform_credentials: 'present'
-profile::buildmaster::java_opts: "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/jenkins_home/ -verbose:gc -Xloggc:/var/jenkins_home/gc.log -XX:NumberOfGCLogFiles=2 -XX:+UseGCLogFileRotation -XX:GCLogFileSize=100m -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCCause -XX:+PrintTenuringDistribution -XX:+PrintReferenceGC -XX:+PrintAdaptiveSizePolicy -XX:ErrorFile=/var/jenkins_home/hs_err_%p.log -XX:+LogVMOutput -XX:LogFile=/var/jenkins_home/jvm.log -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UnlockDiagnosticVMOptions -Xms16g -Xmx16g -XX:+UseStringDeduplication -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2" # Java11 specific configuration
+profile::buildmaster::java_opts: "-server -Xlog:gc+heap*=debug,ref*=debug,ergo*=trace,age*=trace:file=/var/jenkins_home/gc-%t.log::filecount=5,filesize=20M -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UnlockDiagnosticVMOptions -Xms16g -Xmx16g -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2" # Java11 specific configuration
 # These are plugins we need in our ci environment
 profile::buildmaster::plugins:
   - ansicolor


### PR DESCRIPTION
I reverted our changes of this morning because they aren't J11 compatible and it introduces a lot of changes at the same time which is making difficult to understand if they are helping or not.