### PR TITLE
[INFRA-2316] Improve GC settings

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -82,6 +82,11 @@ class profile::buildmaster(
     group  => 'jenkins'
   }
 
+  file { "${jenkins_home}/gc":
+    ensure => directory,
+    owner  => 'jenkins',
+    group  => 'jenkins'
+  }
 
   file { '/etc/default/jenkins':
     ensure  => absent,

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -20,7 +20,8 @@ profile::buildmaster::groovy_d_lock_down_jenkins: 'present'
 profile::buildmaster::groovy_d_pipeline_configuration: 'present'
 profile::buildmaster::groovy_d_set_up_git: 'present'
 profile::buildmaster::groovy_d_terraform_credentials: 'present'
-profile::buildmaster::java_opts: "-server -Xlog:gc+heap*=debug,ref*=debug,ergo*=trace,age*=trace:file=/var/jenkins_home/gc-%t.log::filecount=5,filesize=20M -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UnlockDiagnosticVMOptions -Xms16g -Xmx16g -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2" # Java11 specific configuration
+# ! java_opts needs to be java11 compliant
+profile::buildmaster::java_opts: "-server -Xlog:gc+heap*=debug,ref*=debug,ergo*=trace,age*=trace:file=/var/jenkins_home/gc-%t.log::filecount=5,filesize=20M -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UnlockDiagnosticVMOptions -Xms16g -Xmx16g -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2"
 # These are plugins we need in our ci environment
 profile::buildmaster::plugins:
   - ansicolor

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -20,7 +20,7 @@ profile::buildmaster::groovy_d_lock_down_jenkins: 'present'
 profile::buildmaster::groovy_d_pipeline_configuration: 'present'
 profile::buildmaster::groovy_d_set_up_git: 'present'
 profile::buildmaster::groovy_d_terraform_credentials: 'present'
-profile::buildmaster::java_opts: "-server -Xlog:gc+heap*=debug,ref*=debug,ergo*=trace,age*=trace:file=/var/jenkins_home/gc-%t.log::filecount=5,filesize=20M -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UnlockDiagnosticVMOptions -Xms16g -Xmx16g -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2" # Java11 specific configuration
+profile::buildmaster::java_opts: "-server -Xlog:gc+heap*=debug,ref*=debug,ergo*=trace,age*=trace:file=/var/jenkins_home/gc/gc.log::filecount=5,filesize=40M -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UnlockDiagnosticVMOptions -Xms16g -Xmx16g -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2" # Java11 specific configuration
 # These are plugins we need in our ci environment
 profile::buildmaster::plugins:
   - ansicolor

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -20,7 +20,7 @@ profile::buildmaster::groovy_d_lock_down_jenkins: 'present'
 profile::buildmaster::groovy_d_pipeline_configuration: 'present'
 profile::buildmaster::groovy_d_set_up_git: 'present'
 profile::buildmaster::groovy_d_terraform_credentials: 'present'
-profile::buildmaster::java_opts: "-server -Xlog:gc+heap*=debug,ref*=debug,ergo*=trace,age*=trace:file=/var/jenkins_home/gc/gc.log::filecount=5,filesize=40M -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UnlockDiagnosticVMOptions -Xms16g -Xmx16g -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2" # Java11 specific configuration
+profile::buildmaster::java_opts: "-server -Xlog:gc*=info,ref*=debug,ergo*=trace,age*=trace:file=/var/jenkins_home/gc/gc.log::filecount=5,filesize=40M -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UnlockDiagnosticVMOptions -Xms16g -Xmx16g -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2" # Java11 specific configuration
 # These are plugins we need in our ci environment
 profile::buildmaster::plugins:
   - ansicolor


### PR DESCRIPTION
[INFRA-2316](https://issues.jenkins-ci.org/browse/INFRA-2316)

* GC logs are stored under the subfolder gc
* no more timestamp in the log filename (only the rotation done by the JVM based on the file size)
* Increase the file size to 40Mb instead of 20Mb to get more history