### PR TITLE
Update Jenkins IRC bot to v1.5.0

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -114,7 +114,7 @@ profile::jenkinsadmin::jira_password: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYC
 profile::jenkinsadmin::nick_password: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEApcoIRvdK5ucSrPibeyrhAQactyxQGTJLdVaopQdEu8MUVQIPcsi052ib60se8E51JUSiQhus3dV9b7KTnLqPGV2eYz08jAgUJTnYcxOlSp7nRY8HXRXIAJ8uhjrYxXpw8B0pisxb4joEEMhYdlBMrFthXUxD8g3LoybOLsRVjQViFJeRfvg9cVUQ2fgqHnXKyyTCadqQCYyNXlSB9yc8J4W1/xfjpIfE3EcQ6GcHYe225tPy0aPMetUnt7v5qRzuuO5xPYO86ByBDd4rSxn6El1cokOxIIg1IAr4q55h6QwFLHoXX4GtvV05CHB9pgfxuxc0JHV7Mv9L/+cDpwyq8jA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCvd92Vb6hSA9rBlA48KfaogBDLJlf7Q+XwAU4fMZbOO7go]
 # Tag is the docker container image tag from our build process, this job:
 # <https://trusted.ci.jenkins.io:1443/job/Containers/job/ircbot>
-profile::jenkinsadmin::image_tag: '45-build7611d7'
+profile::jenkinsadmin::image_tag: '64-build32db94'
 
 # Key that Jenkins uses to push bits into OSUOSL
 profile::jenkins::mirroring_privkey: |


### PR DESCRIPTION
Picks up https://github.com/jenkins-infra/ircbot/releases/tag/v1.5.0.
CC @olblak @slide @PierreBtz