### PR TITLE
[INFRA-2357] Disable pluginsite deployment from puppet

### DIFF
--- a/dist/profile/manifests/kubernetes/resources/pluginsite.pp
+++ b/dist/profile/manifests/kubernetes/resources/pluginsite.pp
@@ -1,3 +1,7 @@
+#  !! This class is deprecated in favor of the plugin-site helm chart
+#  !! https://github.com/jenkins-infra/charts/tree/master/charts/plugin-site
+#
+#
 #   Class: profile::kubernetes::resources::pluginsite
 #
 #   This class deploy plugins jenkins website

--- a/dist/role/manifests/kubernetes.pp
+++ b/dist/role/manifests/kubernetes.pp
@@ -6,7 +6,6 @@ class role::kubernetes{
   include profile::kubernetes::resources::chatbot_jenkinsadmin
   include profile::kubernetes::resources::updates_proxy
   include profile::kubernetes::resources::javadoc
-  include profile::kubernetes::resources::pluginsite
   include profile::kubernetes::resources::kube_state_metrics
   include profile::kubernetes::resources::fluentd
   include profile::kubernetes::resources::repo_proxy


### PR DESCRIPTION
As the plugins.jenkins.io is now deployed from [jenkins-infra/charts](https://github.com/jenkins-infra/charts), we can now remove it from puppet 