### PR TITLE
Report commonly used wiki urls

### DIFF
--- a/dist/profile/files/confluence/report_last_log.sh
+++ b/dist/profile/files/confluence/report_last_log.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+GIST_ID=
+# grab all log files but sort by date
+find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -type f -printf "%T+\t%p\n" | sort | \
+  # grab the two newest
+  tail -n 2 | \
+  # then grab the second newest (so one day ago)
+  head -n 1 | \
+  # cat it
+  xargs cat | \
+  # url field
+  awk -F" " '{print $7}' | \
+  # truncate querystring
+  awk -F"?" '{print $1}' | \
+  # sort them all
+  sort | \
+  # sort and count unique
+  uniq -c | \
+  # sort by the higest number of them
+  sort -nrk1 | \
+  # find the 100 newest
+  head -n 100 | \
+  # post to git
+  gist -u $GIST_ID -f urls.txt
+

--- a/dist/profile/files/confluence/report_last_log.sh
+++ b/dist/profile/files/confluence/report_last_log.sh
@@ -9,7 +9,9 @@ find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -type f -printf "%
   # cat it
   xargs cat | \
   # url field
-  awk -F" " '{print $7}' | \
+  awk -F" " '$9 == "200" { print $7 }' | \
+  # remove the blank lines
+  awk 'NF > 0' | \
   # truncate querystring
   awk -F"?" '{print $1}' | \
   # sort them all

--- a/dist/profile/files/confluence/report_last_log.sh
+++ b/dist/profile/files/confluence/report_last_log.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-GIST_ID=
+# make sure all can read this file
+umask 100
 # grab all log files but sort by date
 find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -type f -printf "%T+\t%p\n" | sort | \
   # grab the two newest
@@ -21,7 +22,5 @@ find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -type f -printf "%
   # sort by the higest number of them
   sort -nrk1 | \
   # find the 100 newest
-  head -n 100 | \
-  # post to git
-  gist -u $GIST_ID -f urls.txt
+  head -n 100 > /var/www/html/reports/top_urls.txt
 

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -27,16 +27,17 @@ class profile::confluence (
     comment  => 'Runs confluence',
   }
 
-  ensure_packages([
-      'gist'
-  ])
-
   file { '/etc/cron.daily/access_logs_reporter.sh':
     ensure  => file,
     mode    => '0755',
     owner   => 'root',
     source  => 'puppet:///modules/profile/confluence/report_last_log.sh',
-    require => Package['gist'],
+  }
+
+  file { '/var/www/html/reports':
+    enure => directory
+    mode  => '0755',
+    owner => 'root',
   }
 
   file { '/var/log/apache2/wiki.jenkins-ci.org':

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -35,9 +35,9 @@ class profile::confluence (
   }
 
   file { '/var/www/html/reports':
-    enure => directory,
-    mode  => '0755',
-    owner => 'root',
+    ensure => directory,
+    mode   => '0755',
+    owner  => 'root',
   }
 
   file { '/var/log/apache2/wiki.jenkins-ci.org':

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -28,10 +28,10 @@ class profile::confluence (
   }
 
   file { '/etc/cron.daily/access_logs_reporter.sh':
-    ensure  => file,
-    mode    => '0755',
-    owner   => 'root',
-    source  => 'puppet:///modules/profile/confluence/report_last_log.sh',
+    ensure => file,
+    mode   => '0755',
+    owner  => 'root',
+    source => 'puppet:///modules/profile/confluence/report_last_log.sh',
   }
 
   file { '/var/www/html/reports':

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -35,7 +35,7 @@ class profile::confluence (
   }
 
   file { '/var/www/html/reports':
-    enure => directory
+    enure => directory,
     mode  => '0755',
     owner => 'root',
   }

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -32,10 +32,10 @@ class profile::confluence (
   ])
 
   file { '/etc/cron.daily/access_logs_reporter.sh':
-    ensure => file,
-    mode   => '0755',
-    owner  => 'root',
-    source => 'puppet:///modules/profile/confluence/report_last_log.sh',
+    ensure  => file,
+    mode    => '0755',
+    owner   => 'root',
+    source  => 'puppet:///modules/profile/confluence/report_last_log.sh',
     require => Package['gist'],
   }
 

--- a/dist/profile/manifests/confluence.pp
+++ b/dist/profile/manifests/confluence.pp
@@ -27,6 +27,18 @@ class profile::confluence (
     comment  => 'Runs confluence',
   }
 
+  ensure_packages([
+      'gist'
+  ])
+
+  file { '/etc/cron.daily/access_logs_reporter.sh':
+    ensure => file,
+    mode   => '0755',
+    owner  => 'root',
+    source => 'puppet:///modules/profile/confluence/report_last_log.sh',
+    require => Package['gist'],
+  }
+
   file { '/var/log/apache2/wiki.jenkins-ci.org':
     ensure => directory,
     group  => $profile::atlassian::group_name,

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -37,4 +37,13 @@ ProxyPassReverse / http://localhost:8009/
 # https://issues.jenkins-ci.org/browse/INFRA-592
 Header always append X-Frame-Options SAMEORIGIN
 
+Alias /.well-known/reports/ "/var/www/html/.well-known/reports/"
+<Directory "/var/www/html/.well-known/reports/">
+    Order allow,deny
+    Allow from all
+    AllowOverride None
+    Options Indexes
+    Require all granted
+</Directory>
+
 CustomLog "|/usr/bin/rotatelogs /var/log/apache2/wiki.jenkins-ci.org/access.log.%Y%m%d%H%M%S 86400" combined


### PR DESCRIPTION
In an effort to not have split results for google, i'm starting to add redirects to the wiki for migrated content. #1411 will add apache redirects for all the existing plugins, but after that its harder to do programatically.

Like for example, https://wiki.jenkins.io/display/JENKINS/Building+Jenkins should be linked to https://github.com/jenkinsci/jenkins/blob/master/CONTRIBUTING.md

---

This script will report the top 100 non redirected urls

Implementation ideas:
1) GIST
* Will update the same gist($GIST_ID) every day, so it always has the latest update
* Will need to login to gist cli tool which is not included in this patch - https://github.com/defunkt/gist#login

2) Mailing list
* Email a mailing list (new?) with the daily report

3) File on disk (Current)
* Create a file on disk, and update apache implementation to be able to serve that file
* /.well-known/yesterdays-urls.txt or something