### PR TITLE
Fix the top wiki urls script

### DIFF
--- a/dist/profile/files/confluence/report_last_log.sh
+++ b/dist/profile/files/confluence/report_last_log.sh
@@ -9,8 +9,8 @@ find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -type f -printf "%
   head -n 1 | \
   # grab the actual filename
   awk -F"\t" '{print $2}' | \
-  # cat it
-  xargs zcat | \
+  # cat it (zcat -f will handled gzip and non gzip files)
+  xargs zcat -f | \
   # url field
   awk -F" " '$9 == "200" { print $7 }' | \
   # remove the blank lines

--- a/dist/profile/files/confluence/report_last_log.sh
+++ b/dist/profile/files/confluence/report_last_log.sh
@@ -17,6 +17,8 @@ find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -type f -printf "%
   awk 'NF > 0' | \
   # truncate querystring
   awk -F"?" '{print $1}' | \
+  # only handle wiki urls
+  grep "/display/" | \
   # sort them all
   sort | \
   # sort and count unique

--- a/dist/profile/files/confluence/report_last_log.sh
+++ b/dist/profile/files/confluence/report_last_log.sh
@@ -2,13 +2,15 @@
 # make sure all can read this file
 umask 100
 # grab all log files but sort by date
-find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -type f -printf "%T+\t%p\n" | sort | \
+find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -type f -printf "%T+\t%p\n" | sort -nk1 | \
   # grab the two newest
   tail -n 2 | \
   # then grab the second newest (so one day ago)
   head -n 1 | \
+  # grab the actual filename
+  awk -F"\t" '{print $2}' | \
   # cat it
-  xargs cat | \
+  xargs zcat | \
   # url field
   awk -F" " '$9 == "200" { print $7 }' | \
   # remove the blank lines


### PR DESCRIPTION
Find statement returns 2 colums, 1 for sorting (date) 1 for using (filename). Then often files are gz, so use zcat