### PR TITLE
Remove duplicated entry for node-sharing

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -1765,8 +1765,6 @@ RewriteRule "^/display/JENKINS/Node\+Iterator\+API\+Plugin$" "https://plugins.je
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Node\+Sharing\+Plugin$" "https://plugins.jenkins.io/node-sharing-executor" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
-RewriteRule "^/display/JENKINS/Node\+Sharing\+Plugin$" "https://plugins.jenkins.io/node-sharing-orchestrator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NodeJS\+Plugin$" "https://plugins.jenkins.io/nodejs" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NodeLabel\+Parameter\+Plugin$" "https://plugins.jenkins.io/nodelabelparameter" [NC,L,QSA,R=301]


### PR DESCRIPTION
Node sharing is really a couple of plugins sharing a single wiki page. Redirect to executor page is sufficient.