### PR TITLE
Add rewrite rule for ecutest-plugin

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2581,6 +2581,8 @@ RewriteRule "^/display/jenkins/Trac\+Plugin$" "https://plugins.jenkins.io/trac" 
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Trac\+Publisher\+Plugin$" "https://plugins.jenkins.io/trac-publisher-plugin" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/TraceTronic\+ECU\-TEST\+Plugin$" "https://plugins.jenkins.io/ecutest-plugin" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tracking\+Git\+Plugin$" "https://plugins.jenkins.io/tracking-git" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tracking\+SVN\+Plugin$" "https://plugins.jenkins.io/tracking-svn" [NC,L,QSA,R=301]


### PR DESCRIPTION
Unfortunately, the rewrite rule for the [ecutest-plugin](https://plugins.jenkins.io/ecutest) is missing.