### PR TITLE
Upgrade the wiki usage reporting script

### DIFF
--- a/dist/profile/files/confluence/report_last_log.sh
+++ b/dist/profile/files/confluence/report_last_log.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
+set -euxo pipefail
 # make sure all can read this file
 umask 100
+
+FINAL_FILE=${FINALFILE:-/var/www/html/reports/top_urls.txt}
+
+# create a temporary file
+TMPLOGFILE=`mktemp -p /tmp`
+trap "{ rm -f $TMPLOGFILE; }" EXIT
+
 # grab all log files but sort by date
-find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -type f -printf "%T+\t%p\n" | sort -nk1 | \
+LOGFILENAME=$(find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -not -name 'access.log' -type f | sort -nk1 | \
   # grab the two newest
   tail -n 2 | \
   # then grab the second newest (so one day ago)
-  head -n 1 | \
-  # grab the actual filename
-  awk -F"\t" '{print $2}' | \
-  # cat it (zcat -f will handled gzip and non gzip files)
-  xargs zcat -f | \
+  head -n 1)
+
+echo "# LogFile: $(basename $LOGFILENAME)" >> $TMPLOGFILE
+echo "# LastUpdated: $(TZ=UTC date)" >> $TMPLOGFILE
+
+
+# cat it (zcat -f will handled gzip and non gzip files)
+zcat -f $LOGFILENAME | \
   # url field
   awk -F" " '$9 == "200" { print $7 }' | \
   # remove the blank lines
@@ -26,5 +37,11 @@ find /var/log/apache2/wiki.jenkins-ci.org -name 'access.log*' -type f -printf "%
   # sort by the higest number of them
   sort -nrk1 | \
   # find the 100 newest
-  head -n 100 > /var/www/html/reports/top_urls.txt
+  head -n 100 >> $TMPLOGFILE
+  
+if [ "$FINALFILE" = "-" ]; then
+  cat $TMPLOGFILE
+else
+  mv $TMPLOGFILE $FINALFILE
+fi
 


### PR DESCRIPTION
* Record which filename was last used for future debugging
* Drop sorting by file time, but sort by filename, which shouldn't be affected by gzipping or anything else
* Record last run time to make sure we can tell its running
* Set all the bash error reporting to make sure it bails if anything goes wrong
* support running with FINALFILE=- for debugging