### PR TITLE
Add more urls from daily report

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2930,6 +2930,7 @@ RewriteRule "^/display/JENKINS/Adopt\+a\+Plugin$" "https://jenkins.io/doc/develo
 RewriteRule "^/display/JENKINS/Disable\+security$" "https://jenkins.io/doc/book/system-administration/security/#disabling-security" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Securing\+Jenkins$" "https://jenkins.io/doc/book/system-administration/security/" [NC,L,QSA,R=301]
 RewriteRule "^/display/SECURITY/Jenkins\+Security\+Advisory\+2015-11-11$" "https://jenkins.io/security/advisory/2015-11-11/" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Logo$" "https://jenkins.io/artwork/" [NC,L,QSA,R=301]
 
 
 <Proxy *>

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2824,8 +2824,8 @@ RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zulip\+Plugin$" "https://plugins.jenkins.io/zulip" [NC,L,QSA,R=301]
 
 ## from https://wiki.jenkins.io/.well-known/reports/top_urls.txt
-RewriteRule "^/display/JENKINS/Parameterized\+Trigger\+Plugin$" "https://plugins.jenkins.io/parameterized-trigger" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Parameterized\+Trigger\+Plugin$" "https://plugins.jenkins.io/parameterized-trigger" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Active\+Choices\+Plugin$" "https://plugins.jenkins.io/uno-choice" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
@@ -2853,12 +2853,86 @@ RewriteRule "^/display/JENKINS/Subversion\+Plugin$" "https://plugins.jenkins.io/
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kubernetes\+Plugin$" "https://plugins.jenkins.io/kubernetes" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
-RewriteRule "^/display/JENKINS/Warnings\+Next\+Generation+Plugin$" "https://plugins.jenkins.io/warnings-ng" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Warnings\+Next\+Generation\+Plugin$" "https://plugins.jenkins.io/warnings-ng" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Lockable\+Resources\+Plugin$" "https://plugins.jenkins.io/lockable-resources" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Warnings\+Plugin$" "https://plugins.jenkins.io/warnings" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^display/JENKINS/Bitbucket\+Branch\+Source\+Plugin$" "https://plugins.jenkins.io/cloudbees-bitbucket-branch-source" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Splunk\+Plugin\+for\+Jenkins$" "https://plugins.jenkins.io/pmd" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/PMD\+Plugin$" "https://plugins.jenkins.io/splunk-devops" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Micro\+Focus\+Application\+Automation\+Tools$" "https://plugins.jenkins.io/hp-application-automation-tools-plugin" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Configure+the+Job$" "https://plugins.jenkins.io/zap" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Configuration\+as\+Code\+Plugin$" "https://plugins.jenkins.io/configuration-as-code" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Google\+Play\+Android\+Publisher\+Plugin$" "https://plugins.jenkins.io/google-play-android-publisher"
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Ant\+Plugin$" "https://plugins.jenkins.io/ant" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/FindBugs\+Plugin$" "https://plugins.jenkins.io/findbugs" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/CloudBees\+Folders\+Plugin$" "https://plugins.jenkins.io/cloudbees-folder" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Metrics\+Plugin$" "https://plugins.jenkins.io/metrics" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/HashiCorp\+Vault\+Plugin$" "https://plugins.jenkins.io/hashicorp-vault-plugin" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/PowerShell\+Plugin$" "https://plugins.jenkins.io/powershell" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/SAML\+Plugin$" "https://plugins.jenkins.io/saml" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+# Perforce plugin no longer exists apparently, so redirect to p4
+RewriteRule "^/display/JENKINS/Perforce\+Plugin$" "https://plugins.jenkins.io/p4" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Xcode\+Plugin$" "https://plugins.jenkins.io/xcode-plugin" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Embeddable\+Build\+Status\+Plugin$" "https://plugins.jenkins.io/embeddable-build-status" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/SSH\+Credentials\+Plugin$" "https://plugins.jenkins.io/ssh-credentials" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Pipeline\+Groovy\+Plugin$" "https://plugins.jenkins.io/workflow-cps" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Git\+Changelog\+Plugin$" "https://plugins.jenkins.io/git-changelog" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Robot\+Framework\+Plugin$" "https://plugins.jenkins.io/robot" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/SSH\+Slaves\+plugin$" "https://plugins.jenkins.io/ssh-slaves" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Bitbucket\+Push\+And\+Pull\+Request\+Plugin$" "https://plugins.jenkins.io/bitbucket-push-and-pull-request" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Checkstyle\+Plugin$" "https://plugins.jenkins.io/checkstyle" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Script\+Security\+Plugin$" "https://plugins.jenkins.io/script-security" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Git\+Client\+Plugin$" "https://plugins.jenkins.io/git-client" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Gradle\+Plugin$" "https://plugins.jenkins.io/gradle" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Bitbucket\+Branch\+Source\+Plugin$" "https://plugins.jenkins.io/cloudbees-bitbucket-branch-source" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Docker\+Pipeline\+Plugin$" "https://plugins.jenkins.io/docker-workflow" [NC,L,QSA,R=301]
+# RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+# RewriteRule "^/display/JENKINS/Dynamic\+Parameter\+Plug-in$" "" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/OWASP+Dependency-Check\+Plugin$" "https://plugins.jenkins.io/dependency-check-jenkins-plugin" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Promoted\+Builds\+Plugin$" "https://plugins.jenkins.io/promoted-builds" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Amazon\+EC2\+Plugin$" "https://plugins.jenkins.io/ec2" [NC,L,QSA,R=301]
+
+# Non plugin rewrites
+# already migrated, so don't need wiki exporter exception
+RewriteRule "^/display/JENKINS/Adopt\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Disable\+security$" "https://jenkins.io/doc/book/operating/security/#disabling-security" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Securing\+Jenkins$" "https://jenkins.io/doc/book/system-administration/security/" [NC,L,QSA,R=301]
+RewriteRule "^/display/SECURITY/Jenkins\+Security\+Advisory\+2015-11-11$" "https://jenkins.io/security/advisory/2015-11-11/" [NC,L,QSA,R=301]
+
 
 <Proxy *>
     Order allow,deny

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2929,7 +2929,7 @@ RewriteRule "^/display/JENKINS/Amazon\+EC2\+Plugin$" "https://plugins.jenkins.io
 # Non plugin rewrites
 # already migrated, so don't need wiki exporter exception
 RewriteRule "^/display/JENKINS/Adopt\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" [NC,L,QSA,R=301]
-RewriteRule "^/display/JENKINS/Disable\+security$" "https://jenkins.io/doc/book/operating/security/#disabling-security" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Disable\+security$" "https://jenkins.io/doc/book/system-administration/security/#disabling-security" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Securing\+Jenkins$" "https://jenkins.io/doc/book/system-administration/security/" [NC,L,QSA,R=301]
 RewriteRule "^/display/SECURITY/Jenkins\+Security\+Advisory\+2015-11-11$" "https://jenkins.io/security/advisory/2015-11-11/" [NC,L,QSA,R=301]
 

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2861,9 +2861,9 @@ RewriteRule "^/display/JENKINS/Warnings\+Plugin$" "https://plugins.jenkins.io/wa
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^display/JENKINS/Bitbucket\+Branch\+Source\+Plugin$" "https://plugins.jenkins.io/cloudbees-bitbucket-branch-source" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
-RewriteRule "^/display/JENKINS/Splunk\+Plugin\+for\+Jenkins$" "https://plugins.jenkins.io/pmd" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Splunk\+Plugin\+for\+Jenkins$" "https://plugins.jenkins.io/splunk-devops" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
-RewriteRule "^/display/JENKINS/PMD\+Plugin$" "https://plugins.jenkins.io/splunk-devops" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/PMD\+Plugin$" "https://plugins.jenkins.io/pmd" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Micro\+Focus\+Application\+Automation\+Tools$" "https://plugins.jenkins.io/hp-application-automation-tools-plugin" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
@@ -2917,8 +2917,6 @@ RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Branch\+Source\+Plugin$" "https://plugins.jenkins.io/cloudbees-bitbucket-branch-source" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Docker\+Pipeline\+Plugin$" "https://plugins.jenkins.io/docker-workflow" [NC,L,QSA,R=301]
-# RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
-# RewriteRule "^/display/JENKINS/Dynamic\+Parameter\+Plug-in$" "" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OWASP+Dependency-Check\+Plugin$" "https://plugins.jenkins.io/dependency-check-jenkins-plugin" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
@jenkins-infra/docs please review

I did it all by hand based on the plugin widget in wiki (for the migrated docs, they had a link redirecting)

From Gitter (for the most part, i left the unknown ones alone):

15:55 halkeye> https://wiki.jenkins.io/display/JENKINS/Bitbucket+Branch+Source+Plugin and https://plugins.jenkins.io/cloudbees-bitbucket-branch-source are very very different
15:55 halkeye> probably should be overridden to https://github.com/jenkinsci/bitbucket-branch-source-plugin/blob/master/docs/USER_GUIDE.adoc ?
17:03 halkeye>  /display/JENKINS/Terminology should get finished
17:12 halkeye> https://wiki.jenkins.io/display/JENKINS/Configure+the+Job is a lovely page
17:16 halkeye> things like https://wiki.jenkins.io/display/JENKINS/Remove+Git+Plugin+BuildsByBranch+BuildData should get moved to a cookbook of sorts
19:22 halkeye> should https://wiki.jenkins.io/display/JENKINS/FindBugs+Plugin goto https://plugins.jenkins.io/findbugs
19:22 halkeye> or https://plugins.jenkins.io/warnings-ng
19:45 halkeye> I'm making https://wiki.jenkins.io/display/JENKINS/Perforce+Plugin goto p4 plugin
19:49 halkeye> https://wiki.jenkins.io/display/JENKINS/Build+Flow+Plugin leave alone or redirect?
19:50 halkeye> so https://wiki.jenkins.io/display/JENKINS/SSH+Slaves+plugin has an image but not https://plugins.jenkins.io/ssh-slaves