### PR TITLE
Redirect "Deprecating a plugin" to the new page

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2967,6 +2967,7 @@ RewriteRule "^/display/JENKINS/Build\+Name\+Setter\+Plugin$" "https://plugins.je
 # Non plugin rewrites
 # already migrated, so don't need wiki exporter exception
 RewriteRule "^/display/JENKINS/Adopt\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Deprecating\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Disable\+security$" "https://jenkins.io/doc/book/system-administration/security/#disabling-security" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Securing\+Jenkins$" "https://jenkins.io/doc/book/system-administration/security/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Logo$" "https://jenkins.io/artwork/" [NC,L,QSA,R=301]


### PR DESCRIPTION
https://jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/