### PR TITLE
Redirect governance documents from wiki to jenkins.io

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2977,6 +2977,11 @@ RewriteRule "^/display/JENKINS/Logging$" "https://jenkins.io/doc/book/system-adm
 RewriteRule "^/display/JENKINS/Jenkins\+Script\+Console$" "https://jenkins.io/doc/book/managing/script-console/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Hosting\+Plugins$" "https://jenkins.io/doc/developer/publishing/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Starting\+and\+Accessing\+Jenkins$" "https://jenkins.io/doc/book/installing/#configuring-http" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Board\+Candidacy\+Process" "https://jenkins.io/project/board-election-process/" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Board\+Election\+Process$" "https://jenkins.io/project/board-election-process/" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Governance\+Board$" "https://jenkins.io/project/board/" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Governance\+Document$" "https://jenkins.io/project/governance/#compatibility-matters" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Governance\+Meeting\+Agenda$" "https://jenkins.io/project/governance-meeting/" [NC,L,QSA,R=301]
 
 RewriteRule "^/display/SECURITY/Jenkins\+Security\+Advisory\+([0-9]+)-([0-9]+)-([0-9]+)$" "https://jenkins.io/security/advisory/$1-$2-$3/" [NC,L,QSA,R=301]
 

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2980,7 +2980,7 @@ RewriteRule "^/display/JENKINS/Starting\+and\+Accessing\+Jenkins$" "https://jenk
 RewriteRule "^/display/JENKINS/Board\+Candidacy\+Process" "https://jenkins.io/project/board-election-process/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Board\+Election\+Process$" "https://jenkins.io/project/board-election-process/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Governance\+Board$" "https://jenkins.io/project/board/" [NC,L,QSA,R=301]
-RewriteRule "^/display/JENKINS/Governance\+Document$" "https://jenkins.io/project/governance/#compatibility-matters" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Governance\+Document$" "https://jenkins.io/project/governance/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Governance\+Meeting\+Agenda$" "https://jenkins.io/project/governance-meeting/" [NC,L,QSA,R=301]
 
 RewriteRule "^/display/SECURITY/Jenkins\+Security\+Advisory\+([0-9]+)-([0-9]+)-([0-9]+)$" "https://jenkins.io/security/advisory/$1-$2-$3/" [NC,L,QSA,R=301]


### PR DESCRIPTION
## Redirect Governance Documents from wiki to jenkins.io

The governance document and governance meeting pages have already migrated and are only pointers to the official jenkins.io pages.

The governance board page has been migrated to jenkins.io but does not have a pointer in the page.  This redirect avoids editing that page by redirecting to jenkins.io.

The candidacy process and election process for the Jenkins board are maintained on jenkins.io.  No need to show the user an outdated copy from the wiki.

Would like review from @oleg-nenashev, @slide, and other members of the Jenkins board to assure that I've not missed something in proposing this redirect.