### PR TITLE
Remove repo.azure.jenkins.io from datadog monitoring check

### DIFF
--- a/dist/profile/manifests/datadog_http_check.pp
+++ b/dist/profile/manifests/datadog_http_check.pp
@@ -169,19 +169,6 @@ class profile::datadog_http_check(
       'tags'                         => ['production','jenkins-ci.org']
     },
     {
-      'sitename'                     => 'repo.azure.jenkins.io',
-      'url'                          => 'https://repo.azure.jenkins.io/api/system/ping',
-      'timeout'                      => $timeout,
-      'threshold'                    => $threshold,
-      'window'                       => $window,
-      'collect_response_time'        => true ,
-      'check_certificate_expiration' => true,
-      'days_warning'                 => $days_warning,
-      'days_critical'                => $days_critical,
-      'contact'                      => $contact,
-      'tags'                         => ['production','jenkins.io']
-    },
-    {
       'sitename'                     => 'reports.jenkins.io',
       'url'                          => 'https://reports.jenkins.io/artifactory-ldap-users-report.json',
       'timeout'                      => $timeout,


### PR DESCRIPTION
This service doesn't exist anymore since we delete the prodbean (old kubernetes cluster)