### PR TITLE
Replace markewaite ED25519 public key with RSA key

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -72,8 +72,8 @@ accounts:
       - sudo
   markewaite:
     ssh_keys:
-      muggle:
-        key: AAAAC3NzaC1lZDI1NTE5AAAAIP1YKQM/oJaYlZqAPSCPNbCo+dASh4AG/rxLtO5vVlwq
+      markewaite:
+        key: AAAAB3NzaC1yc2EAAAADAQABAAABgQCjfyyHgIygnhF/eRoeOwmHZ8VkmjNllLOCstF1+70BoKC+guy/itLQ5dDwS9phbwpI1oYO2v86ngzKkbXvJv642n1J7ydAhTL/DSdPkKfcmJLtmLtT0U+umo4S+ALeuqcLTByIVCe3BF45ILH3ky11gsAbSLJ2+Rptv0kt6NC7f+t/W8PblsWTaps4tQv7HHIMhPbXEs8Sri9QCxkqfnWP2ww5VcNr8g7CStBMYz7jrBdZuk+M0ov3fGrIqxAtBL29wDpgKt7LQIGYQYVu4pk4yh6TcLAOhruz9jdfvwmgzFsk5WMQOwvQ3zoJBGfXVLbAvmRWIGz1IGs5XytPmBSUooj3r3cuRbSPykWsV/IOd9YH1pi8oB5inT6g9LUDaTG50xJhhw3dLY6ZHkSl726EzqzAs5JKLeWK1CHSBsEmX7r81TzsVW0BtWZxH4RBK0HlKkGbv4bkW5iNSuHMthyxPDnvjkvo1sUqJJYyczfwuYUht1OjlJpl/cm/DABxV7c=
     groups:
       - atlassian-admins
       - sudo


### PR DESCRIPTION
## Replace markewaite ED25519 public key with RSA key

No indicator on any of the keys for the type of key.  All the other keys appear to be RSA keys.  Likely that the key is being used as an RSA key even when it is an ED25519 key.

Should have followed the standard pattern in the file and used an RSA key originally.