### PR TITLE
Push artifacts on azure file storage from sync.sh

### DIFF
--- a/dist/profile/files/mirrorbrain/sync.sh
+++ b/dist/profile/files/mirrorbrain/sync.sh
@@ -44,6 +44,10 @@ pushd ${UPDATES_DIR}
     rsync ${RSYNC_ARGS} --delete ${BASE_DIR}/updates/ ${HOST}:jenkins/updates
 popd
 
+echo ">> Updating artifacts on get.jenkins.io"
+source /srv/releases/.azure-storage-env
+time  blobxfer upload --storage-account "$AZURE_STORAGE_ACCOUNT" --storage-account-key "$AZURE_STORAGE_KEY" --local-path "$BASE_DIR" --remote-path mirrorbits --recursive --mode file --file-md5  --skip-on-md5-match --progress-bar --exclude 'mvn%20org.apache.maven.plugins:maven-release-plugin:2.5:perform'
+
 echo ">> Delivering bits to fallback"
 /srv/releases/populate-archives.sh
 /srv/releases/azure-sync.sh


### PR DESCRIPTION
Update sync.sh to also push packages on an azure file storage that can be used by this [service](https://github.com/jenkins-infra/charts/pull/122)

Ps: Because puppet agent cannot run anymore on pkg.jenkins.io, once approved, I'll manually change the file