### PR TITLE
Add redirect for the System Properties Listing Wiki page

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2974,6 +2974,7 @@ RewriteRule "^/display/JENKINS/Logo$" "https://jenkins.io/artwork/" [NC,L,QSA,R=
 RewriteRule "^/display/JENKINS/Logging$" "https://jenkins.io/doc/book/system-administration/viewing-logs/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Jenkins\+Script\+Console$" "https://jenkins.io/doc/book/managing/script-console/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Starting\+and\+Accessing\+Jenkins$" "https://jenkins.io/doc/book/installing/#configuring-http" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Features\+controlled\+by\+system\+properties$" "https://jenkins.io/doc/book/managing/system-properties/" [NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteRule "^/display/JENKINS/Adopt\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" [NC,L,QSA,R=301]


### PR DESCRIPTION
The page was migrated to jenkins.io in https://github.com/jenkins-infra/jenkins.io/pull/2992