### PR TITLE
Redirect Groovy Hooks Wiki to the recent jenkins.io page

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2975,6 +2975,7 @@ RewriteRule "^/display/JENKINS/Logging$" "https://jenkins.io/doc/book/system-adm
 RewriteRule "^/display/JENKINS/Jenkins\+Script\+Console$" "https://jenkins.io/doc/book/managing/script-console/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Starting\+and\+Accessing\+Jenkins$" "https://jenkins.io/doc/book/installing/#configuring-http" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Features\+controlled\+by\+system\+properties$" "https://jenkins.io/doc/book/managing/system-properties/" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Groovy\+Hook\+Script$" "https://jenkins.io/doc/book/managing/groovy-hook-scripts/" [NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteRule "^/display/JENKINS/Adopt\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" [NC,L,QSA,R=301]


### PR DESCRIPTION
https://jenkins.io/doc/book/managing/groovy-hook-scripts/ contains more documentation than the historical Wiki page. So we can just add a redirect