### PR TITLE
Install EC2 plugin

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -42,6 +42,7 @@ profile::buildmaster::plugins:
   - credentials
   - credentials-binding
   - docker-workflow
+  - ec2
   - embeddable-build-status
   - findbugs
   - git-client


### PR DESCRIPTION
I just noticed that the EC2 plugin is not listed in this list.