### PR TITLE
Stop redirectiring pkg.jenkins.io to azure blob storage

### DIFF
--- a/dist/profile/templates/pkgrepo/debian_htaccess.erb
+++ b/dist/profile/templates/pkgrepo/debian_htaccess.erb
@@ -12,8 +12,5 @@ RewriteRule ^binary/(.*)\.deb$  /<%= @name %>/direct/$1.deb [L]
 # 
 # See also: https://issues.jenkins-ci.org/browse/INFRA-964
 RewriteCond %{HTTPS} on
-RewriteRule ^binary/(.*)\.deb$ https://prodjenkinsreleases.blob.core.windows.net/<%= @name %>/$1.deb [R=302,L]
 
-
-# otherwise redirect to mirror
 RewriteRule ^binary/(.*)\.deb$ http://mirrors.jenkins.io/<%= @name %>/$1.deb [R=302,L]

--- a/dist/profile/templates/pkgrepo/redhat_htaccess.erb
+++ b/dist/profile/templates/pkgrepo/redhat_htaccess.erb
@@ -8,10 +8,6 @@ Options -Indexes
 # See also: https://issues.jenkins-ci.org/browse/INFRA-967
 RewriteCond %{HTTPS} on
 RewriteCond %{REQUEST_URI} ^/<%= @name %>/RPMS/noarch/*
-RewriteRule ^(.*)/noarch/(.*)\.rpm$ https://prodjenkinsreleases.blob.core.windows.net/<%= @name %>/$2.rpm [R=302,L]
-
-RewriteCond %{HTTPS} on
-RewriteRule ^(.*)\.rpm$ https://prodjenkinsreleases.blob.core.windows.net/<%= @name %>/$1.rpm [R=302,L]
 
 RedirectMatch /<%= @name %>/RPMS/noarch/(.*)\.rpm$ http://mirrors.jenkins.io/<%= @name %>/$1.rpm
 RedirectMatch /<%= @name %>/(.*)\.rpm$ http://mirrors.jenkins.io/<%= @name %>/$1.rpm


### PR DESCRIPTION
This redirection is not usefull anymore, either we rely on Fastly or our mirrors.