### PR TITLE
Do not escape the '#' in Starting & Accessing redirect

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2993,7 +2993,7 @@ RewriteRule "^/display/JENKINS/Logging$" "https://jenkins.io/doc/book/system-adm
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jenkins\+Script\+Console$" "https://jenkins.io/doc/book/managing/script-console/" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
-RewriteRule "^/display/JENKINS/Starting\+and\+Accessing\+Jenkins$" "https://jenkins.io/doc/book/installing/#configuring-http" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Starting\+and\+Accessing\+Jenkins$" "https://jenkins.io/doc/book/installing/#configuring-http" [NE,NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Features\+controlled\+by\+system\+properties$" "https://jenkins.io/doc/book/managing/system-properties/" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
The 'NE' flag ([RewriteRule flag](http://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriteflags)) is used successfully with the other URL in the rewrite which uses an ID inside the page.  Use it here as well.

Fixes [jenkins.io issue 3097](https://github.com/jenkins-infra/jenkins.io/issues/3097)

@halkeye could you review this to confirm that it is safe to use the same technique for "Starting and Accessing Jenkins" as is used for "Disabling Security"?