### PR TITLE
Fixed Wiki page redirect pull request #3212

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2998,6 +2998,8 @@ RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Features\+controlled\+by\+system\+properties$" "https://jenkins.io/doc/book/managing/system-properties/" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy\+Hook\+Script$" "https://jenkins.io/doc/book/managing/groovy-hook-scripts/" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://www.jenkins.io/doc/book/managing/security/#cross-site-request-forgery" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2999,7 +2999,7 @@ RewriteRule "^/display/JENKINS/Features\+controlled\+by\+system\+properties$" "h
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy\+Hook\+Script$" "https://jenkins.io/doc/book/managing/groovy-hook-scripts/" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
-RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://www.jenkins.io/doc/book/managing/security/#cross-site-request-forgery" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://jenkins.io/doc/book/managing/security/#cross-site-request-forgery" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
Wiki pages are migrated one at a time. When the content of a wiki page has been migrated from wiki.jenkins.io and merged into www.jenkins.io, we can "hide" the wiki page by redirecting all requests for that page to the replacement page on www.jenkins.io. A page redirect pull request is used to define that redirect.
![Capture jenkins fix](https://user-images.githubusercontent.com/29729601/82002711-68edf300-9656-11ea-90a4-58e0dd64b474.JPG)
