### PR TITLE
Redirect FreeBSD wiki to jenkins.io installing

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3000,6 +3000,8 @@ RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy\+Hook\+Script$" "https://jenkins.io/doc/book/managing/groovy-hook-scripts/" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://jenkins.io/doc/book/managing/security/#cross-site-request-forgery" [NE,NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/FreeBSD$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3001,7 +3001,6 @@ RewriteRule "^/display/JENKINS/Groovy\+Hook\+Script$" "https://jenkins.io/doc/bo
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://jenkins.io/doc/book/managing/security/#cross-site-request-forgery" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/FreeBSD$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FreeBSD\+4.9$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3000,7 +3000,6 @@ RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy\+Hook\+Script$" "https://jenkins.io/doc/book/managing/groovy-hook-scripts/" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://jenkins.io/doc/book/managing/security/#cross-site-request-forgery" [NE,NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FreeBSD$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FreeBSD\+4.9$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3002,6 +3002,8 @@ RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://jenkins.io/doc/book/managing/security/#cross-site-request-forgery" [NE,NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FreeBSD$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/FreeBSD\+4.9$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
FreeBSD installation is described on the [destination page](https://www.jenkins.io/doc/book/installing/?abc=1#freebsd). Configuration modification is described in other locations.