### PR TITLE
Create Redirects from Wiki to jenkins.io

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3003,6 +3003,9 @@ RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://jenkins.io/doc/book/m
 RewriteRule "^/display/JENKINS/FreeBSD$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/FreeBSD\+4.9$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/How\+to\+report\+an\+issue$" "https://www.jenkins.io/participate/report-issue/" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Installing\+Jenkins\+on\+Red\+Hat\+distributions$" "https://www.jenkins.io/doc/book/installing/#red-hat-centos" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Installing\+Jenkins\+on\+Ubuntu$" "https://www.jenkins.io/doc/book/installing/#debianubuntu" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Installing\+Jenkins\+with\+Docker$" "https://www.jenkins.io/doc/book/installing/#docker" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
#2889 - Items: 
 Redirect from Jenkins on Red Hat wiki page to Installing Jenkins
 Redirect from Jenkins on Ubuntu wiki page to Installing Jenkins
 Redirect from Jenkins with Docker wiki page to Installing Jenkins