### PR TITLE
Redirect wiki "Plugins" to www.jenkins.io (Update vhost.conf)

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3003,6 +3003,7 @@ RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://jenkins.io/doc/book/m
 RewriteRule "^/display/JENKINS/FreeBSD$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/FreeBSD\+4.9$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/How\+to\+report\+an\+issue$" "https://www.jenkins.io/participate/report-issue/" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Plugins$" "https://plugins.jenkins.io/" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
Fixes [#3211](https://github.com/jenkins-infra/jenkins.io/issues/3211)