### PR TITLE
Installing Jenkins page redirect

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3003,7 +3003,6 @@ RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://jenkins.io/doc/book/m
 RewriteRule "^/display/JENKINS/FreeBSD$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/FreeBSD\+4.9$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/How\+to\+report\+an\+issue$" "https://www.jenkins.io/participate/report-issue/" [NE,NC,L,QSA,R=301]
-RewriteRule "^/display/JENKINS//Installing\+Jenkins$" "https://www.jenkins.io/doc/book/installing/#installing-jenkins" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Installing\+Jenkins$" "https://www.jenkins.io/doc/book/installing/#installing-jenkins" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3003,6 +3003,8 @@ RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://jenkins.io/doc/book/m
 RewriteRule "^/display/JENKINS/FreeBSD$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/FreeBSD\+4.9$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/How\+to\+report\+an\+issue$" "https://www.jenkins.io/participate/report-issue/" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS//Installing\+Jenkins$" "https://www.jenkins.io/doc/book/installing/#installing-jenkins" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Installing\+Jenkins$" "https://www.jenkins.io/doc/book/installing/#installing-jenkins" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
issue #2889 - Installing Jenkins page redirect

The wiki url page has double bars (between JENKINS//Installing) so for secure i put two rules targeting the same end point.