### PR TITLE
Add rewrite rule for 'Pipeline CPS Method Mismatches' wiki page

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3018,6 +3018,7 @@ RewriteRule "^/display/JENKINS/Installing\+Jenkins$" "https://www.jenkins.io/doc
 RewriteRule "^/display/JENKINS/Aborting\+a\+build$" "https://www.jenkins.io/doc/book/using/aborting-a-build/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Browser\+Compatibility\+Matrix$" "https://jenkins.io/doc/administration/requirements/web-browsers/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Fingerprint$" "https://www.jenkins.io/doc/book/using/fingerprints/" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Pipeline\+CPS\+method\+mismatches$" "https://www.jenkins.io/doc/book/pipeline/cps-method-mismatches/" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
Opening as a draft PR for now since this depends on https://github.com/jenkins-infra/jenkins.io/pull/3366 which moves the content to jenkins.io.