### PR TITLE
Redirect 'Home' wiki page to www.jenkins.io

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3018,6 +3018,7 @@ RewriteRule "^/display/JENKINS/Installing\+Jenkins$" "https://www.jenkins.io/doc
 RewriteRule "^/display/JENKINS/Aborting\+a\+build$" "https://www.jenkins.io/doc/book/using/aborting-a-build/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Browser\+Compatibility\+Matrix$" "https://jenkins.io/doc/administration/requirements/web-browsers/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Fingerprint$" "https://www.jenkins.io/doc/book/using/fingerprints/" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Home$" "https://www.jenkins.io/" [NE,NC,L,QSA,R=301]
 
 ## Developer documentation
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
Fixes: [#3207](https://github.com/jenkins-infra/jenkins.io/issues/3207)