### PR TITLE
[INFRA-2328] - Cleanup redirects from jenkins.io to Wiki for migrated and obsolete pages

### DIFF
--- a/dist/profile/templates/kubernetes/resources/jenkinsio/configmap.yaml.erb
+++ b/dist/profile/templates/kubernetes/resources/jenkinsio/configmap.yaml.erb
@@ -56,36 +56,34 @@ data:
       rewrite ^/census/(.*) https://census.jenkins.io/$1 permanent;
       rewrite ^/jenkins-ci.org.key$ https://pkg.jenkins.io/redhat/jenkins.io.key permanent;
   
+      # TODO: Migrate to jenkins.io redirects
       # permalinks
       # - this one is referenced from 1.395.1 "sign post" release
-      rewrite ^/why$            https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=53608972 permanent;
+      rewrite ^/why$            https://www.jenkins.io/ permanent;
       # baked in the help file to create account on Oracle for JDK downloads
       rewrite ^/oracleAccountSignup$    http://www.oracle.com/webapps/redirect/signon?nexturl=http://jenkins-ci.org/ permanent;
-      # to the donation page
-      rewrite ^/donate$        https://wiki.jenkins-ci.org/display/JENKINS/Donation permanent;
       # CLA links used in the CLA forms
-      rewrite ^/license$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla permanent;
-      rewrite ^/licenses$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Document#GovernanceDocument-cla permanent;
+      rewrite ^/license$        https://www.jenkins.io/project/governance/#cla permanent;
+      rewrite ^/licenses$        https://www.jenkins.io/project/governance/#cla permanent;
       # used to advertise the project meeting
-      rewrite ^/meetings/$        https://wiki.jenkins-ci.org/display/JENKINS/Governance+Meeting+Agenda permanent;
+      rewrite ^/meetings/$        https://www.jenkins.io/project/governance-meeting/ permanent;
       # used from friends of Jenkins plugin to link to the thank you page
-      rewrite ^/friend$        https://wiki.jenkins-ci.org/display/JENKINS/Donation permanent;
+      rewrite ^/friend$        https://www.jenkins.io/donate/#friend-of-jenkins permanent;
       # used by Gradle JPI plugin to include fragment
       rewrite ^/gradle-jpi-plugin/latest$    https://raw.github.com/jenkinsci/gradle-jpi-plugin/master/install permanent;
       # used when encouraging people to subscribe to security advisories
-      rewrite ^/advisories$        https://wiki.jenkins-ci.org/display/JENKINS/Security+Advisories permanent;
-      # used in slides and handouts to refer to survey
-      rewrite ^/survey$        http://s.zoomerang.com/s/JenkinsSurvey permanent;
+      rewrite ^/advisories$        https://www.jenkins.io/security/advisories/ permanent;
+      # used in slides and handouts to refer to survey - SURVEY IS OVER
+      rewrite ^/survey$        https://www.jenkins.io/ permanent;
       # used by RekeySecretAdminMonitor in Jenkins
-      rewrite ^/rekey$            https://wiki.jenkins-ci.org/display/SECURITY/Re-keying permanent;
+      rewrite ^/rekey$            https://www.jenkins.io/security/advisory/2013-01-04/re-keying/ permanent;
       # persistent Google hangout link
       rewrite ^/hangout$        https://plus.google.com/hangouts/_/event/cjh74ltrnc8a8r2e3dbqlfnie38 permanent;
       # .16.203.43 repo.jenkins-ci.org
+      # TODO: To be migrated
       rewrite ^/pull-request-greeting$    https://wiki.jenkins-ci.org/display/JENKINS/Pull+Request+to+Repositories permanent;
       # Mailer plugin uses this to redirect to Javamail javadoc page
       rewrite ^/javamail-properties$   https://javamail.java.net/nonav/docs/api/overview-summary.html#overview_description permanent;
-      # baked in jenkins.war 1.587 / 1.580.1
-      rewrite ^/security-144$          https://wiki.jenkins-ci.org/display/JENKINS/Slave+To+Master+Access+Control permanent;
       # baked in 1.600 easter egg
       rewrite ^/100k$                  https://jenkins.io/content/jenkins-celebration-day-february-26 permanent;
       rewrite ^/jep/([0-9]+) https://github.com/jenkinsci/jep/blob/master/jep/$1/README.adoc permanent;


### PR DESCRIPTION
CC @MarkEWaite 

https://issues.jenkins-ci.org/browse/INFRA-2399

