### PR TITLE
Upgrade datadog module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -70,7 +70,7 @@ mod 'saz/ssh', '5.0.0'
 mod 'puppetlabs-sshkeys_core', '1.0.2'
 
 mod 'puppetlabs/lvm', '0.3.2'
-mod 'datadog/datadog_agent', '2.5.0'
+mod 'datadog/datadog_agent', '3.3.0'
 
 # Used for grabbing certificates for jenkins.io
 mod 'puppet-letsencrypt', '3.0.0'

--- a/dist/profile/files/datadog_pluginsite_check/plugins_api_check.py
+++ b/dist/profile/files/datadog_pluginsite_check/plugins_api_check.py
@@ -1,20 +1,33 @@
-# Return pluginsite elasticsearch index age in hour
-#
-import urllib2
+"""
+    Datadog custom monitoring check
+"""
+
+from urllib.request import urlopen
 import json
-from datetime import datetime, timedelta
-from checks import AgentCheck
+from datetime import datetime
+from datadog_checks.base.checks import AgentCheck
+
+
+def get_index_age(site):
+    """
+        get_index_age returns pluginsite api age
+    """
+    url = "https://{0}/api/health/elasticsearch".format(site)
+    health_status = urlopen(url).read()
+    index_creation = datetime.strptime(json.loads(health_status)['createdAt'],
+                                       '%Y-%m-%dT%H:%M:%S')
+    age = datetime.today() - index_creation
+    return age.seconds / 3600
 
 class PluginsApiCheck(AgentCheck):
-    def check(self,instance):
-        metric = 'plugins.index.age'
-        site = instance ['site']
-        tag = "site:" + site
-        self.gauge(metric,self.get_index_age(site),tags=[tag])
+    """
+        Return pluginsite elasticsearch index age in hour
+    """
+    def check(self, instance):
 
-    def get_index_age(self, site):
-        url = "https://{0}/api/health/elasticsearch".format(site)
-        health_status = urllib2.urlopen(url).read()
-        index_creation = datetime.strptime(json.loads(health_status)['createdAt'],'%Y-%m-%dT%H:%M:%S')
-        age = datetime.today() - index_creation
-        return  age.seconds / 3600
+        """ check tests if the monitoring test is successfull or not"""
+
+        metric = 'plugins.index.age'
+        site = instance['site']
+        tag = "site:" + site
+        self.gauge(metric, get_index_age(site), tags=[tag])


### PR DESCRIPTION
Agent version lower than 5.32.6 cannot connect to Datadog api since 30th of May due to an expired certificate.

[Link](https://docs.datadoghq.com/agent/faq/certificate_verify_failed-error/) to issue 

Datadog Module [Changelog](https://forge.puppet.com/datadog/datadog_agent/changelog)
