### PR TITLE
Fix LTS Release Line redirect

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,9 +56,9 @@ pipeline {
                 stage('vhost check') {
                     agent { label 'linux' }
                     steps {
-                        # Check that rewrite rules that contain '#' also include the 'NE' attribute
-                        # to assure that the '#' in the rewrite is not escaped
-                        # This is an imperfect test that would have detected the most recent failures
+                        // Check that rewrite rules that contain '#' also include the 'NE' attribute
+                        // to assure that the '#' in the rewrite is not escaped
+                        // This is an imperfect test that would have detected the most recent failures
                         sh 'git grep "RewriteRule.*#" | grep -v NE,NC,L,QSA'
                     }
                 }

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3020,7 +3020,7 @@ RewriteRule "^/display/JENKINS/Installing\+Jenkins\+on\+Ubuntu$" "https://www.je
 RewriteRule "^/display/JENKINS/Installing\+Jenkins\+with\+Docker$" "https://www.jenkins.io/doc/book/installing/#docker" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Plugins$" "https://plugins.jenkins.io/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/How\+to\+fix\+RequireUpperBoundDeps$" "https://www.jenkins.io/doc/developer/plugin-development/updating-parent/#understanding-requireupperbounddeps-failures-and-fixes" [NE,NC,L,QSA,R=301]
-RewriteRule "^/display/JENKINS//LTS\+Release\+Line$" "https://www.jenkins.io/download/lts/" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/LTS\+Release\+Line$" "https://www.jenkins.io/download/lts/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Installing\+Jenkins$" "https://www.jenkins.io/doc/book/installing/#installing-jenkins" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Aborting\+a\+build$" "https://www.jenkins.io/doc/book/using/aborting-a-build/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Browser\+Compatibility\+Matrix$" "https://jenkins.io/doc/administration/requirements/web-browsers/" [NC,L,QSA,R=301]


### PR DESCRIPTION
https://github.com/jenkins-infra/jenkins.io/issues/3312 duplicated '/' in the reference URL.

Duplicate was copied to this redirect change.