### PR TITLE
Upload *.msi and *.sha256 files to OSUOSL mirror

### DIFF
--- a/dist/profile/files/mirrorbrain/rsync.filter
+++ b/dist/profile/files/mirrorbrain/rsync.filter
@@ -8,6 +8,8 @@
 + *.war
 + *.hpi
 + *.jpi
++ *.msi
++ *.sha256
 
 # we recurse into directories
 + */


### PR DESCRIPTION
According to our investigation with @MarkEWaite today, msi files weren't uploaded to OSUOSL mirrors. This PR just alignes with manual changes.

 Signed-off-by: Olivier Vernin <olivier@vernin.me>