### PR TITLE
Enable https on archives.jenkins-ci.org

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -6,7 +6,7 @@ mod "puppet/r10k", '6.8.0'
 # Deps for zack/r10k
 mod "puppetlabs/stdlib", '5.2.0'
 
-mod 'puppetlabs/ruby', '1.0.0'
+mod 'puppetlabs/ruby', '1.0.1'
 mod "puppetlabs/gcc", '0.3.0'
 # Used for installing gems for the puppetserver, like with hiera-eyaml
 mod "puppetlabs/puppetserver_gem", '1.1.0'
@@ -31,7 +31,7 @@ mod 'adrien/filemapper'
 mod 'puppetlabs-docker', '3.2.0'
 
 # Deps for docker
-mod 'puppetlabs/apt', '6.2.1'
+mod 'puppetlabs/apt', '7.4.2'
 mod 'stahnma/epel', '1.2.2'
 
 # Dependencies for the Puppet IRC report processor, using our forked version

--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -113,12 +113,12 @@ class profile::archives {
     # When Apache is upgraded to >= 2.4.8 this should be changed to
     # fullchain.pem
       ssl_key       => '/etc/letsencrypt/live/archives.jenkins.io/privkey.pem',
-      ssl_cert      => '/etc/letsencrypt/live/archives.jenkins.io/cert.pem',
+      ssl_cert      => '/etc/letsencrypt/live/archives.jenkins.io/fullchain.pem',
       ssl_chain     => '/etc/letsencrypt/live/archives.jenkins.io/chain.pem',
     }
     Apache::Vhost <| title == 'archives.jenkins-ci.org' |> {
       ssl_key       => '/etc/letsencrypt/live/archives.jenkins.io/privkey.pem',
-      ssl_cert      => '/etc/letsencrypt/live/archives.jenkins.io/cert.pem',
+      ssl_cert      => '/etc/letsencrypt/live/archives.jenkins.io/fullchain.pem',
       ssl_chain     => '/etc/letsencrypt/live/archives.jenkins.io/chain.pem',
     }
   }

--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -41,11 +41,15 @@ class profile::archives {
     ensure => directory,
   }
 
+  file { '/var/log/apache2/archives.jenkins.io':
+    ensure => directory,
+  }
+
   apache::mod { 'bw':
     require => Package['libapache2-mod-bw'],
   }
 
-  apache::vhost { 'archives.jenkins-ci.org':
+  apache::vhost { 'archives.jenkins-ci.org non-ssl':
     servername      => 'archives.jenkins-ci.org',
     vhost_name      => '*',
     port            => '80',
@@ -60,4 +64,64 @@ class profile::archives {
                         Mount[$archives_dir],
                         Apache::Mod['bw']],
   }
+
+  apache::vhost { 'archives.jenkins-ci.org':
+    port            => '443',
+    ssl             =>  true,
+    docroot         => $archives_dir,
+    access_log      => false,
+    error_log_file  => 'archives.jenkins-ci.org/error.log',
+    log_level       => 'warn',
+    custom_fragment => template("${module_name}/archives/vhost.conf"),
+
+    notify          => Service['apache2'],
+    require         => File['/var/log/apache2/archives.jenkins-ci.org'],
+  }
+
+
+  apache::vhost { 'archives.jenkins.io non-ssl':
+    # redirect non-SSL to SSL
+    servername      => 'archives.jenkins.io',
+    port            => '80',
+    docroot         => $archives_dir,
+    redirect_status => 'temp',
+    redirect_dest   => 'https://archives.jenkins.io'
+  }
+
+  apache::vhost { 'archives.jenkins.io':
+    port            => '443',
+    ssl             =>  true,
+    docroot         => $archives_dir,
+    access_log      => false,
+    error_log_file  => 'archives.jenkins.io/error.log',
+    log_level       => 'warn',
+    custom_fragment => template("${module_name}/archives/vhost.conf"),
+
+    notify          => Service['apache2'],
+    require         => File['/var/log/apache2/archives.jenkins-ci.org'],
+  }
+
+  # We can only acquire certs in production due to the way the letsencrypt
+  # challenge process works
+  if (($::environment == 'production') and ($::vagrant != '1')) {
+    letsencrypt::certonly { 'archives.jenkins.io':
+        domains     => ['archives.jenkins.io','archives.jenkins-ci.org'],
+        plugin      => 'apache',
+        manage_cron => true,
+    }
+    Apache::Vhost <| title == 'archives.jenkins.io' |> {
+    # When Apache is upgraded to >= 2.4.8 this should be changed to
+    # fullchain.pem
+      ssl_key       => '/etc/letsencrypt/live/archives.jenkins.io/privkey.pem',
+      ssl_cert      => '/etc/letsencrypt/live/archives.jenkins.io/cert.pem',
+      ssl_chain     => '/etc/letsencrypt/live/archives.jenkins.io/chain.pem',
+    }
+    Apache::Vhost <| title == 'archives.jenkins-ci.org' |> {
+      ssl_key       => '/etc/letsencrypt/live/archives.jenkins.io/privkey.pem',
+      ssl_cert      => '/etc/letsencrypt/live/archives.jenkins.io/cert.pem',
+      ssl_chain     => '/etc/letsencrypt/live/archives.jenkins.io/chain.pem',
+    }
+  }
+
+
 }

--- a/dist/role/manifests/okra.pp
+++ b/dist/role/manifests/okra.pp
@@ -3,6 +3,4 @@
 class role::okra {
   include profile::base
   include profile::archives
-  include profile::bind
-  include profile::jenkinsadmin
 }

--- a/spec/classes/role/okra_spec.rb
+++ b/spec/classes/role/okra_spec.rb
@@ -4,6 +4,4 @@ describe 'role::okra' do
   it_should_behave_like 'a standard role'
 
   it { should contain_class 'profile::archives' }
-  it { should contain_class 'profile::jenkinsadmin' }
-  it { should contain_class 'profile::bind' }
 end


### PR DESCRIPTION
Enable https on archives.jenkins-ci.org
Enable https/http for archives.jenkins.io