### PR TITLE
Bump letsencrypt puppet module to version 5.0.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -73,7 +73,7 @@ mod 'puppetlabs/lvm', '0.3.2'
 mod 'datadog/datadog_agent', '3.3.0'
 
 # Used for grabbing certificates for jenkins.io
-mod 'puppet-letsencrypt', '3.0.0'
+mod 'puppet-letsencrypt', '5.0.0'
 
 # For managing ldap, and dependencies
 mod 'camptocamp/openldap', '1.14.0'

--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -6,6 +6,7 @@ class profile::archives {
   # volume configuration is in hiera
   include ::lvm
   include profile::apachemisc
+  include profile::letsencrypt
 
   $archives_dir = '/srv/releases'
 


### PR DESCRIPTION
Signed-off-by: Olivier Vernin <olivier@vernin.me>

We are quite back in the module version, and it would allows us to switch to letsencrypt v2 api and allow dns configuration.
It doesn't appear to break our configuration

https://forge.puppet.com/puppet/letsencrypt/changelog
