### PR TITLE
Redirect 'Starting and Accessing' to parameter description

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3015,6 +3015,7 @@ RewriteRule "^/display/JENKINS/FreeBSD$" "https://jenkins.io/doc/book/installing
 RewriteRule "^/display/JENKINS/FreeBSD\+4.9$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/How\+to\+report\+an\+issue$" "https://www.jenkins.io/participate/report-issue/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Remote\+Access\+API$" "https://www.jenkins.io/doc/book/using/remote-access-api/" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Starting\+and\+Accessing\+Jenkins$" "https://www.jenkins.io/doc/book/installing/#jenkins-parameters" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Installing\+Jenkins\+on\+Red\+Hat\+distributions$" "https://www.jenkins.io/doc/book/installing/#red-hat-centos" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Installing\+Jenkins\+on\+Ubuntu$" "https://www.jenkins.io/doc/book/installing/#debianubuntu" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Installing\+Jenkins\+with\+Docker$" "https://www.jenkins.io/doc/book/installing/#docker" [NE,NC,L,QSA,R=301]


### PR DESCRIPTION
## Redirect 'Starting and Accessing' to parameter description

Seems the dominant part of the page.

Resolves https://github.com/jenkins-infra/jenkins.io/issues/3221

Should redirect from

https://wiki.jenkins.io/display/JENKINS//Starting+and+Accessing+Jenkins

to 

https://www.jenkins.io/doc/book/installing/#jenkins-parameters