### PR TITLE
hacktoberfest: Redirect "Purge Job History Plugin" from wiki to plugins site

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2899,6 +2899,8 @@ RewriteRule "^/display/JENKINS/PowerShell\+Plugin$" "https://plugins.jenkins.io/
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SAML\+Plugin$" "https://plugins.jenkins.io/saml" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Purge\+Job\+History\+Plugin" "https://plugins.jenkins.io/purge-job-history" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 # Perforce plugin no longer exists apparently, so redirect to p4
 RewriteRule "^/display/JENKINS/Perforce\+Plugin$" "https://plugins.jenkins.io/p4" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
**issue:** https://github.com/jenkins-infra/jenkins.io/issues/3795

A redirect entry was added to `dist/profile/templates/confluence/vhost.conf`
from:  https://wiki.jenkins.io/display/JENKINS/Purge+Job+History+Plugin 
to: https://plugins.jenkins.io/purge-job-history