### PR TITLE
Redirect 'Static Analysis in Pipelines' to warnings-ng plugin

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -17,6 +17,8 @@ RewriteRule ^.* - [F,L]
 
 # Rewrite all plugin docs to plugins.jenkins.io if user agent is not the wiki exporter
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Static\+Analysis\+in\+Pipelines$" "https://plugins.jenkins.io/warnings-ng" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AnchorChain\+plugin$" "https://plugins.jenkins.io/AnchorChain" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Apica\+Loadtest\+Plugin$" "https://plugins.jenkins.io/ApicaLoadtest" [NC,L,QSA,R=301]


### PR DESCRIPTION
Adresses https://github.com/jenkins-infra/jenkins.io/issues/3725
Adds redirect from 'Static Analysis in Pipelines' wiki page to warnings-ng plugin page