### PR TITLE
Redirect 'Amazon Web Services SDK library' from wiki to plugins site

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -111,6 +111,8 @@ RewriteRule "^/display/JENKINS/All\+Changes\+Plugin$" "https://plugins.jenkins.i
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Allure\+Plugin$" "https://plugins.jenkins.io/allure-jenkins-plugin" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/Jenkins/Amazon\+Web\+Services\+SDK\+library$" "https://plugins.jenkins.io/aws-java-sdk" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Amazon\+ECR$" "https://plugins.jenkins.io/amazon-ecr" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AMQP\+Build\+Trigger\+Plugin$" "https://plugins.jenkins.io/amqp-build-trigger" [NC,L,QSA,R=301]


### PR DESCRIPTION
Fixes jenkins-infra/jenkins.io/issues/3798

I've followed the similar approach listed on the issue. I double-checked the rails commands listed in the `Jenkinsfile`, and have confirmed the shell scripts in the `Jenkinsfile` also operate.

I'm not quite sure how to confirm the redirect locally, but I'm hoping the PR build will help confirm correctness. Apologies if I've missed a step.