### PR TITLE
Redirect 'GitHub API Plugin' from wiki to plugins site

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -49,6 +49,8 @@ RewriteRule "^/display/JENKINS/Exclusion\-Plugin$" "https://plugins.jenkins.io/E
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gatekeeper\+Plugin$" "https://plugins.jenkins.io/GatekeeperPlugin" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/GitHub\+API\+Plugin$" "https://plugins.jenkins.io/github-api" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JDK\+Parameter\+Plugin$" "https://plugins.jenkins.io/JDK_Parameter_Plugin" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "/display/JENKINS/JDK\+Tool\+Plugin$" "https://plugins.jenkins.io/jdk-tool" [NC,L,QSA,R=301]


### PR DESCRIPTION
Fixes: https://github.com/jenkins-infra/jenkins.io/issues/3802

Followed the instructions added in above issue.
Please let me know if there are more changes needed to fix this.
