### PR TITLE
Redirect 'Nexus Platform Plugin' from wiki to plugins site

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -1767,6 +1767,8 @@ RewriteRule "^/display/JENKINS/Next\+Build\+Number\+Plugin$" "https://plugins.je
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nexus\+Artifact\+Uploader$" "https://plugins.jenkins.io/nexus-artifact-uploader" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Nexus\+Platform\+Plugin$" "https://plugins.jenkins.io/nexus-jenkins-plugin" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nexus\+Task\+Runner\+Plugin$" "https://plugins.jenkins.io/nexus-task-runner" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nirmata\+Plugin$" "https://plugins.jenkins.io/nirmata" [NC,L,QSA,R=301]


### PR DESCRIPTION
Fixes: https://github.com/jenkins-infra/jenkins.io/issues/3803

added my changes by looking at https://github.com/jenkins-infra/jenkins-infra/pull/1542