### PR TITLE
Redirect Fortify On Demand Uploader Plugin to Plugins site

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3007,6 +3007,8 @@ RewriteRule "^/display/JENKINS/OWASP\+Markup\+Formatter\+Plugin$" "https://plugi
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Nodes\+and\+Processes\+Plugin$" "https://plugins.jenkins.io/workflow-durable-task-step" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Fortify\+On\+Demand\+Uploader\+Plugin$" "https://plugins.jenkins.io/fortify-on-demand-uploader" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Matrix\+Authorization\+Strategy\+Plugin$" "https://plugins.jenkins.io/matrix-auth" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Matrix\+Configuration\+Parameter\+Plugin$" "https://plugins.jenkins.io/matrix-combinations-parameter/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Git$" "https://plugins.jenkins.io/git/" [NE,NC,L,QSA,R=301]


### PR DESCRIPTION
As per [Issue # 3796](https://github.com/jenkins-infra/jenkins.io/issues/3796)
Redirected this wiki page https://wiki.jenkins.io/display/JENKINS/Fortify+On+Demand+Uploader+Plugin to https://plugins.jenkins.io/fortify-on-demand-uploader