### PR TITLE
Added redirect for JENKINS/Configuring+Jenkins+upon+start+up

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3067,6 +3067,7 @@ RewriteRule "^/display/JENKINS/Running\+Jenkins\+behind\+Nginx$" "https://www.je
 RewriteRule "^/display/JENKINS/Thanks\+for\+using\+Windows\+Installer$" "https://www.jenkins.io/download/thank-you-downloading-windows-installer/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Executor\+Starvation$" "https://www.jenkins.io/doc/book/using/executor-starvation" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Configuring\+Content\+Security\+Policy$" "https://www.jenkins.io/doc/book/system-administration/security/configuring-content-security-policy" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Configuring\+Jenkins\+upon\+start\+up$" "https://www.jenkins.io/doc/book/managing/groovy-hook-scripts" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Monitor\+and\+Restart\+Offline\+Slaves$" "https://www.jenkins.io/doc/book/managing/nodes" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/How\+to\+view\+Jenkins\+in\+your\+language$" "https://www.jenkins.io/doc/book/using/using-local-language/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/JClouds\+Plugin$" "https://plugins.jenkins.io/jclouds-jenkins/" [NE,NC,L,QSA,R=301]


### PR DESCRIPTION
 It wil redirect JENKINS/Configuring+Jenkins+upon+start+up to https://www.jenkins.io/doc/book/managing/groovy-hook-scripts.

This PR fixes: https://github.com/jenkins-infra/jenkins.io/issues/3792