### PR TITLE
Add a redirect for the old Release Process page

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3046,6 +3046,7 @@ RewriteRule "^/display/JENKINS/Installing\+Jenkins\+on\+Ubuntu$" "https://www.je
 RewriteRule "^/display/JENKINS/Installing\+Jenkins\+with\+Docker$" "https://www.jenkins.io/doc/book/installing/#docker" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Plugins$" "https://plugins.jenkins.io/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/How\+to\+fix\+RequireUpperBoundDeps$" "https://www.jenkins.io/doc/developer/plugin-development/updating-parent/#understanding-requireupperbounddeps-failures-and-fixes" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Release\+Process$" "https://github.com/jenkinsci/jenkins/blob/master/docs/MAINTAINERS.adoc#release-process" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/LTS\+Release\+Line$" "https://www.jenkins.io/download/lts/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Installing\+Jenkins$" "https://www.jenkins.io/doc/book/installing/#installing-jenkins" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Aborting\+a\+build$" "https://www.jenkins.io/doc/book/using/aborting-a-build/" [NE,NC,L,QSA,R=301]


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/jenkins/pull/4971

Replaces https://wiki.jenkins.io/display/JENKINS/Release+Process by the actual documentation.

CC @olblak @MarkEWaite @olivergondza 