### PR TITLE
hacktoberfest: Redirect " Pipeline Build Step Plugin" from wiki to plugins site

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2922,6 +2922,8 @@ RewriteRule "^/display/JENKINS/SAML\+Plugin$" "https://plugins.jenkins.io/saml" 
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Purge\+Job\+History\+Plugin" "https://plugins.jenkins.io/purge-job-history" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/Pipeline\+Build\+Step\+Plugin" "https://plugins.jenkins.io/pipeline-build-step" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 # Perforce plugin no longer exists apparently, so redirect to p4
 RewriteRule "^/display/JENKINS/Perforce\+Plugin$" "https://plugins.jenkins.io/p4" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
issue: https://github.com/jenkins-infra/jenkins.io/issues/3775

from: https://wiki.jenkins.io/display/JENKINS/Pipeline+Build+Step+Plugin#
to: https://plugins.jenkins.io/pipeline-build-step/

(The plugin docs already points to Github)