### PR TITLE
fix rubygems package name for ubuntu 18.04

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -7,6 +7,8 @@
 # resource intensive
 apache::mpm_module: 'event'
 
+ruby::rubygems_package: 'rubygems-integration'
+
 accounts:
   tyler:
     ssh_keys:


### PR DESCRIPTION
The default value for rubygems_package is set to 'rubygems', because this package name doesn't exist on ubuntu 18.04, it tries to reinstall it constantly