### PR TITLE
Increase usage lvm disk size from 99G to 200G

### DIFF
--- a/hieradata/clients/usage.yaml
+++ b/hieradata/clients/usage.yaml
@@ -5,5 +5,5 @@ lvm::volume_groups:
       - /dev/xvdf
     logical_volumes:
       usage:
-        size: 99G
+        size: 200G
         mountpath: /srv/usage


### PR DESCRIPTION
We upgrade the disk size manually but we haven't did it from puppet

```
Error: Decreasing the size requires manual intervention (99G < 200G)
Error: /Stage[main]/Lvm/Lvm::Volume_group[data]/Lvm::Logical_volume[usage]/Logical_volume[usage]/size: change from '200G' to '99G' failed: Decreasing the size requires manual intervention (99G < 200G)
```