### PR TITLE
Redirect 'Violation Comments to GitLab Plugin' page from wiki to plugins site

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2853,7 +2853,8 @@ RewriteRule "^/display/JENKINS/IBM\+zOS\+Connector$" "https://plugins.jenkins.io
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zulip\+Plugin$" "https://plugins.jenkins.io/zulip" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Remove\+Git\+Plugin\+BuildsByBranch\+BuildData$" "https://plugins.jenkins.io/git/#remove-git-plugin-buildsbybranch-builddata-script" [NE,NC,L,QSA,R=301]
-RewriteRule "^/display/JENKINS/violation\+comments\+to\+gitlab$" "https://plugins.jenkins.io/violation-comments-to-gitlab" [NC,L,QSA,R=301] RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+ RewriteRule "^/display/JENKINS/violation\+comments\+to\+gitlab$" "https://plugins.jenkins.io/violation-comments-to-gitlab" [NC,L,QSA,R=301]
+ RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 
 ## from https://wiki.jenkins.io/.well-known/reports/top_urls.txt
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2853,6 +2853,7 @@ RewriteRule "^/display/JENKINS/IBM\+zOS\+Connector$" "https://plugins.jenkins.io
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zulip\+Plugin$" "https://plugins.jenkins.io/zulip" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Remove\+Git\+Plugin\+BuildsByBranch\+BuildData$" "https://plugins.jenkins.io/git/#remove-git-plugin-buildsbybranch-builddata-script" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/violation\+comments\+to\+gitlab$" "https://plugins.jenkins.io/violation-comments-to-gitlab" [NC,L,QSA,R=301] RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 
 ## from https://wiki.jenkins.io/.well-known/reports/top_urls.txt
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$

--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2853,8 +2853,8 @@ RewriteRule "^/display/JENKINS/IBM\+zOS\+Connector$" "https://plugins.jenkins.io
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zulip\+Plugin$" "https://plugins.jenkins.io/zulip" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Remove\+Git\+Plugin\+BuildsByBranch\+BuildData$" "https://plugins.jenkins.io/git/#remove-git-plugin-buildsbybranch-builddata-script" [NE,NC,L,QSA,R=301]
- RewriteRule "^/display/JENKINS/violation\+comments\+to\+gitlab$" "https://plugins.jenkins.io/violation-comments-to-gitlab" [NC,L,QSA,R=301]
- RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/violation\+comments\+to\+gitlab$" "https://plugins.jenkins.io/violation-comments-to-gitlab" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 
 ## from https://wiki.jenkins.io/.well-known/reports/top_urls.txt
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
This is to fix https://github.com/jenkins-infra/jenkins.io/issues/3783

I think that trying to close issues using keywords (Fixes #3783) won't work here because the Issue is on `jenkins.io` project, whilst the PR (file to be fixed) is on `jenkins-infra` project.

This is my first work with 'Redirect page', so please let me know if I got it right. Also, please label this for the hackthoberfest. 

Thanks.
