### PR TITLE
Add redirects to plugin site

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -2849,12 +2849,18 @@ RewriteRule "^/display/JENKINS/ZMQ\+Event\+Publisher\+Plugin$" "https://plugins.
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zoom\+Plugin$" "https://plugins.jenkins.io/zoom" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
-RewriteRule "^/display/JENKINS/IBM\+zOS\+Connector$" "https://plugins.jenkins.io/zos-connector" [NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/IBM\+zOS\+Connector\+Plugin$" "https://plugins.jenkins.io/zos-connector" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/violation\+comments\+to\+gitlab\+Plugin$" "https://plugins.jenkins.io/violation-comments-to-gitlab" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/claim\+Plugin$" "https://plugins.jenkins.io/claim/" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/appcenter\+Plugin$" "https://plugins.jenkins.io/appcenter/" [NC,L,QSA,R=301]
+RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+RewriteRule "^/display/JENKINS/xml-job-to-job-dsl\+Plugin$" "https://plugins.jenkins.io/xml-job-to-job-dsl/" [NC,L,QSA,R=301]
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zulip\+Plugin$" "https://plugins.jenkins.io/zulip" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Remove\+Git\+Plugin\+BuildsByBranch\+BuildData$" "https://plugins.jenkins.io/git/#remove-git-plugin-buildsbybranch-builddata-script" [NE,NC,L,QSA,R=301]
-RewriteRule "^/display/JENKINS/violation\+comments\+to\+gitlab$" "https://plugins.jenkins.io/violation-comments-to-gitlab" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 
 ## from https://wiki.jenkins.io/.well-known/reports/top_urls.txt
 RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$


### PR DESCRIPTION
I've updated section *Rewrite all plugin docs to plugins.jenkins.io if user agent is not the wiki exporter* to add three links/redirects, following examples already on the page.

I also fixed the following two entries to add `\+Plugin$` to them:
* display/JENKINS/violation\+comments\+to\+gitlab\+Plugin$
* display/JENKINS/IBM\+zOS\+Connector\+Plugin$

This PR fixes

- https://github.com/jenkins-infra/jenkins.io/issues/3777
- https://github.com/jenkins-infra/jenkins.io/issues/3773
- https://github.com/jenkins-infra/jenkins.io/issues/3759