### PR TITLE
Enable updatecli on this repository

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,21 @@
+name: Update CLI
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  update_cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update CLI
+        env:
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -sSfL -o updatecli https://github.com/olblak/updatecli/releases/download/v0.0.21/updatecli.linux.amd64
+          chmod +x ./updatecli
+          ./updatecli diff --config ./updateCli/updateCli.d --values ./updateCli/values.github-action.yaml
+          ./updatecli apply --config ./updateCli/updateCli.d --values ./updateCli/values.github-action.yaml

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -17,5 +17,5 @@ jobs:
         run: |
           curl -sSfL -o updatecli https://github.com/olblak/updatecli/releases/download/v0.0.21/updatecli.linux.amd64
           chmod +x ./updatecli
-          ./updatecli diff --config ./updateCli/updateCli.d --values ./updateCli/values.github-action.yaml
-          ./updatecli apply --config ./updateCli/updateCli.d --values ./updateCli/values.github-action.yaml
+          ./updatecli diff --config ./updateCli/updatecli.d --values ./updateCli/values.github-action.yaml
+          ./updatecli apply --config ./updateCli/updatecli.d --values ./updateCli/values.github-action.yaml

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -11,7 +11,7 @@ accounts:
       rsandell:
         key: AAAAB3NzaC1yc2EAAAADAQABAAACAQDwdnCxqQGMo1LTOhCDu7TpzT31sqJPYltmQEeKOut1lRP2HSn3Zac5XKXKq2Vn9xlmjSayC6mQcUw23x8VGa2bnCqWTxiAGSpAmcE4dZFRf/T20Il8YiuYNyP+Pl8zLOisOWMQ6XU6F//yoNeE+y1rnOolK0AHmO7/vz6FlnvM/pn5jSuHj+sicBdR5sA+wfejSkvW1Z3wH3vpa4xNFkS8nNjrC/Qv7rj+WmBxYMd4z7M5NFadfH1byH7omRLUZ2XNi6cDOY4g0+qbpwSmzs+JLTXa10uIMn9dcA3WOQDcBlYdQ0FSwsSYJy6jskf2A62yHJ3TESnNGis9o19AEGsVFxPo1aXdLJ5X9jEogjOX5CKK2kchpONaQoX7nh04ys5at8jzcn3B9KvSfx8B6UFlsvOHZOKlVNymZ+pe/JJecY08A4E/1Teo4wL4oVkBcMTbX2z04pXLbMtqELpzU29yeF5MRO1B37Jzf5E71TGWWxdllQ/WO+RTAInha1tLyujQoUop2EyZMFCvPtozVYIJpVV8hwQC1j4NyTnslmGaUd/3dyTVcnKKctDimGT+zULWE6ckCNwzsrIEY5ESERwa3JE5HtoEnolsddR5OQiVb4AImFz0Y4T3TvCQVFdhjs/1xjIRKsbg9eFzF2cy52GzTKDzcb9NQeRbPXPeLyZrBQ
     groups:
-      - sudo    
+      - sudo   
 profile::buildmaster::anonymous_access: true
 profile::buildmaster::admin_ldap_groups:
   - admins
@@ -20,7 +20,7 @@ profile::buildmaster::ci_fqdn: 'ci.jenkins.io'
 profile::buildmaster::ci_resource_domain: 'assets.ci.jenkins.io'
 profile::buildmaster::letsencrypt: true
 profile::buildmaster::docker_image: 'jenkins/jenkins@sha256'
-profile::buildmaster::docker_tag: 'e302541e96852c2aee571cba83dc6b45d8c9ee71a45727d3117abd7304e59b31'
+profile::buildmaster::docker_tag: 'e302541e96852c2aee571cba83dc6b45d8c9ee71a45727d3117abd7304e59b31' # tag: lts-jdk11
 profile::buildmaster::groovy_init_enabled: true
 profile::buildmaster::groovy_d_agent_security: 'present'
 profile::buildmaster::groovy_d_enable_ssh_port: 'present'

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -19,7 +19,8 @@ profile::buildmaster::admin_ldap_groups:
 profile::buildmaster::ci_fqdn: 'ci.jenkins.io'
 profile::buildmaster::ci_resource_domain: 'assets.ci.jenkins.io'
 profile::buildmaster::letsencrypt: true
-profile::buildmaster::docker_tag: 'lts-jdk11'
+profile::buildmaster::docker_image: 'jenkins/jenkins@sha256'
+profile::buildmaster::docker_tag: 'e302541e96852c2aee571cba83dc6b45d8c9ee71a45727d3117abd7304e59b31'
 profile::buildmaster::groovy_init_enabled: true
 profile::buildmaster::groovy_d_agent_security: 'present'
 profile::buildmaster::groovy_d_enable_ssh_port: 'present'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -289,7 +289,7 @@ profile::kubernetes::resources::ldap::whitelisted_sources:
 
 
 profile::buildmaster::docker_image: jenkins/jenkins@sha256
-profile::buildmaster::docker_tag: e302541e96852c2aee571cba83dc6b45d8c9ee71a45727d3117abd7304e59b31
+profile::buildmaster::docker_tag: aa1ec2a6a106608a286dc06c334053fced1df87a7cb307853ca1cf8fa48ba09b #tag: lts
 profile::buildmaster::plugins:
   - workflow-aggregator
   - pipeline-stage-view

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -288,6 +288,8 @@ profile::kubernetes::resources::ldap::whitelisted_sources:
   - '52.147.174.4/32'      # Accept inbound LDAPS from public.aks.jenkins.io
 
 
+profile::buildmaster::docker_image: jenkins/jenkins@sha256
+profile::buildmaster::docker_tag: e302541e96852c2aee571cba83dc6b45d8c9ee71a45727d3117abd7304e59b31
 profile::buildmaster::plugins:
   - workflow-aggregator
   - pipeline-stage-view

--- a/updateCli/updatecli.d/jenkins-lts-alpine.tpl
+++ b/updateCli/updatecli.d/jenkins-lts-alpine.tpl
@@ -28,7 +28,7 @@ targets:
   imageTag:
     name: "Update Docker Image Digest for jenkins/jenkins:lts"
     kind: yaml
-    postfix: " #tag: lts-alpine"
+    postfix: " #tag: lts"
     spec:
       file: "hieradata/common.yaml"
       key: "profile::buildmaster::docker_tag"

--- a/updateCli/updatecli.d/jenkins-lts-alpine.tpl
+++ b/updateCli/updatecli.d/jenkins-lts-alpine.tpl
@@ -1,0 +1,43 @@
+---
+source:
+  kind: dockerDigest
+  name: Get latest jenkins/jenkins:lts-jdk11 docker digest
+  spec:
+    image: "jenkins/jenkins"
+    tag: "lts"
+
+conditions:
+  defaultCiDockerImage:
+    name: "Ensure default jenkins docker image name set to jenkins/jenkins@sha256"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::buildmaster::docker_image"
+      value: "jenkins/jenkins@sha256"
+    scm:
+      github:
+        user: "{{ .github.user }}" 
+        email: "{{ .github.email }}" 
+        owner: "{{ .github.owner }}" 
+        repository: "{{ .github.repository }}" 
+        token: "{{ requiredEnv .github.token }}" 
+        username: "{{ .github.username }}" 
+        branch: "{{ .github.branch }}" 
+
+targets:
+  imageTag:
+    name: "Update Docker Image Digest for jenkins/jenkins:lts"
+    kind: yaml
+    postfix: " #tag: lts-alpine"
+    spec:
+      file: "hieradata/common.yaml"
+      key: "profile::buildmaster::docker_tag"
+    scm:
+      github:
+        user: "{{ .github.user }}" 
+        email: "{{ .github.email }}" 
+        owner: "{{ .github.owner }}" 
+        repository: "{{ .github.repository }}" 
+        token: "{{ requiredEnv .github.token }}" 
+        username: "{{ .github.username }}" 
+        branch: "{{ .github.branch }}" 

--- a/updateCli/updatecli.d/jenkins-lts-jdk11.tpl
+++ b/updateCli/updatecli.d/jenkins-lts-jdk11.tpl
@@ -1,0 +1,42 @@
+---
+source:
+  kind: dockerDigest
+  name: Get latest jenkins/jenkins:lts-jdk11 docker digest
+  spec:
+    image: "jenkins/jenkins"
+    tag: "lts-jdk11"
+
+conditions:
+  ciDockerImage:
+    name: "Ensure default jenkins docker image name set to jenkins/jenkins@sha256"
+    kind: yaml
+    spec:
+      file: hieradata/clients/azure.ci.jenkins.io.yaml
+      key: "profile::buildmaster::docker_image"
+      value: "jenkins/jenkins@sha256"
+    scm:
+      github:
+        user: "{{ .github.user }}" 
+        email: "{{ .github.email }}" 
+        owner: "{{ .github.owner }}" 
+        repository: "{{ .github.repository }}" 
+        token: "{{ requiredEnv .github.token }}" 
+        username: "{{ .github.username }}" 
+        branch: "{{ .github.branch }}" 
+
+targets:
+  imageTag:
+    name: "Update Docker Image Digest for jenkins/jenkins:lts-jdk11"
+    kind: "yaml"
+    spec:
+      file: "hieradata/clients/azure.ci.jenkins.io.yaml"
+      key: "profile::buildmaster::docker_tag"
+    scm:
+      github:
+        user: "{{ .github.user }}" 
+        email: "{{ .github.email }}" 
+        owner: "{{ .github.owner }}" 
+        repository: "{{ .github.repository }}" 
+        token: "{{ requiredEnv .github.token }}" 
+        username: "{{ .github.username }}" 
+        branch: "{{ .github.branch }}" 

--- a/updateCli/updatecli.d/jenkins-lts-jdk11.tpl
+++ b/updateCli/updatecli.d/jenkins-lts-jdk11.tpl
@@ -28,6 +28,7 @@ targets:
   imageTag:
     name: "Update Docker Image Digest for jenkins/jenkins:lts-jdk11"
     kind: "yaml"
+    postfix: " #tag: lts-jdk11"
     spec:
       file: "hieradata/clients/azure.ci.jenkins.io.yaml"
       key: "profile::buildmaster::docker_tag"

--- a/updateCli/updatecli.d/jenkins-lts.tpl
+++ b/updateCli/updatecli.d/jenkins-lts.tpl
@@ -1,7 +1,7 @@
 ---
 source:
   kind: dockerDigest
-  name: Get latest jenkins/jenkins:lts-jdk11 docker digest
+  name: Get latest jenkins/jenkins:lts docker digest
   spec:
     image: "jenkins/jenkins"
     tag: "lts"

--- a/updateCli/values.github-action.yaml
+++ b/updateCli/values.github-action.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "GitHub Actions"
+  email: "41898282+github-actions[bot]@users.noreply.github.com"
+  username: "github-actions"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "staging"
+  owner: "jenkins-infra"
+  repository: "jenkins-infra"

--- a/updateCli/values.yaml
+++ b/updateCli/values.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "updatebot"
+  email: "updatebot@olblak.com"
+  username: "olblak"
+  token: "UPDATECLI_GITHUB_TOKEN" 
+  branch: "staging"
+  owner: "olblak"
+  repository: "jenkins-infra"


### PR DESCRIPTION
This pull request enables updatecli on this repository. As a first iteration, it will automate Jenkins docker image tag update similar to [jenkins-infra/charts](https://github.com/jenkins-infra/charts/pull/512)

