### PR TITLE
Remove postfix yaml commit

### DIFF
--- a/updateCli/updatecli.d/jenkins-lts.tpl
+++ b/updateCli/updatecli.d/jenkins-lts.tpl
@@ -28,7 +28,6 @@ targets:
   imageTag:
     name: "Update Docker Image Digest for jenkins/jenkins:lts"
     kind: yaml
-    postfix: " #tag: lts"
     spec:
       file: "hieradata/common.yaml"
       key: "profile::buildmaster::docker_tag"


### PR DESCRIPTION
This postfix definition as unwanted effect on the target file [here](https://github.com/jenkins-infra/jenkins-infra/blob/f3cb763995c50289fe93341779550f796d0c9f99/hieradata/common.yaml#L253)
Signed-off-by: Olivier Vernin <olivier@vernin.me>