### PR TITLE
Set X-Forwarded-Host for our jenkins instances

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -386,6 +386,7 @@ class profile::buildmaster(
     custom_fragment       => "
 RequestHeader set X-Forwarded-Proto \"https\"
 RequestHeader set X-Forwarded-Port \"${proxy_port}\"
+RequestHeader set X-Forwarded-Host \"${ci_fqdn}\"
 
 RewriteEngine on
 


### PR DESCRIPTION
In the current state, trusted.ci.jenkins.io is unusable because it reuses the host then append the port set by `X-Forwarded-Port` which lead to url like this.
```
https://[localhost:1443]:1443/configureClouds/
```

This PR ensure that host will always be 'trusted.ci.jenkins.io'

Signed-off-by: Olivier Vernin <olivier@vernin.me>