### PR TITLE
Reduce wiki-exporter special case to one rule

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -15,3015 +15,1521 @@ RewriteEngine on
 RewriteCond %{HTTP_USER_AGENT} ADSARobot|ah-ha|AhrefsBot|almaden|aktuelles|Anarchie|amzn_assoc|ASPSeek|ASSORT|ATHENS|Atomz|attach|attache|autoemailspider|BackWeb|Bandit|BatchFTP|bdfetch|big.brother|BlackWidow|bmclient|Boston\ Project|BravoBrian\ SpiderEngine\ MarcoPolo|Bot\ mailto:craftbot@yahoo.com|Buddy|Bullseye|bumblebee|capture|CherryPicker|ChinaClaw|CICC|clipping|Collector|Copier|Crescent|Crescent\ Internet\ ToolPak|Custo|cyberalert|DA$|Deweb|diagem|Digger|Digimarc|DIIbot|DISCo|DISCo\ Pump|DISCoFinder|Download\ Demon|Download\ Wonder|Downloader|Drip|DSurf15a|DTS.Agent|EasyDL|eCatch|ecollector|efp@gmx\.net|Email\ Extractor|EirGrabber|email|EmailCollector|EmailSiphon|EmailWolf|Express\ WebPictures|ExtractorPro|EyeNetIE|FavOrg|fastlwspider|Favorites\ Sweeper|Fetch|FEZhead|FileHound|FlashGet\ WebWasher|FlickBot|fluffy|FrontPage|GalaxyBot|Generic|Getleft|GetRight|GetSmart|GetWeb!|GetWebPage|gigabaz|Girafabot|Go\!Zilla|Go!Zilla|Go-Ahead-Got-It|GornKer|gotit|Grabber|GrabNet|Grafula|Green\ Research|grub-client|Harvest|hhjhj@yahoo|hloader|HMView|HomePageSearch|http\ generic|HTTrack|httpdown|httrack|ia_archiver|IBM_Planetwide|Image\ Stripper|Image\ Sucker|imagefetch|IncyWincy|Indy*Library|Indy\ Library|informant|Ingelin|InterGET|Internet\ Ninja|InternetLinkagent|Internet\ Ninja|InternetSeer\.com|Iria|Irvine|JBH*agent|JetCar|JOC|JOC\ Web\ Spider|JustView|KWebGet|Lachesis|larbin|LeechFTP|LexiBot|lftp|libwww|likse|Link|Link*Sleuth|LINKS\ ARoMATIZED|LinkWalker|LWP|lwp-trivial|Mag-Net|Magnet|Mac\ Finder|Mag-Net|Mass\ Downloader|MCspider|Memo|Microsoft.URL|MIDown\ tool|Mirror|Missigua\ Locator|Mister\ PiX|MMMtoCrawl\/UrlDispatcherLLL|^Mozilla$|Mozilla.*Indy|Mozilla.*NEWT|Mozilla*MSIECrawler|MS\ FrontPage*|MSFrontPage|MSIECrawler|MSProxy|multithreaddb|nationaldirectory|Navroad|NearSite|NetAnts|NetCarta|NetMechanic|netprospector|NetResearchServer|NetSpider|Net\ Vampire|NetZIP|NetZip\ Downloader|NetZippy|NEWT|NICErsPRO|Ninja|NPBot|Octopus|Offline\ Explorer|Offline\ Navigator|OpaL|Openfind|OpenTextSiteCrawler|OrangeBot|PageGrabber|Papa\ Foto|PackRat|pavuk|pcBrowser|PersonaPilot|Ping|PingALink|Pockey|Proxy|psbot|PSurf|puf|Pump|PushSite|QRVA|RealDownload|Reaper|Recorder|ReGet|replacer|RepoMonkey|Robozilla|Rover|RPT-HTTPClient|Rsync|Scooter|SearchExpress|searchhippo|searchterms\.it|Second\ Street\ Research|Seeker|Shai|Siphon|sitecheck|sitecheck.internetseer.com|SiteSnagger|SlySearch|SmartDownload|snagger|Snake|SpaceBison|Spegla|SpiderBot|sproose|SqWorm|Stripper|Sucker|SuperBot|SuperHTTP|Surfbot|SurfWalker|Szukacz|tAkeOut|tarspider|Teleport\ Pro|Templeton|TrueRobot|TV33_Mercator|UIowaCrawler|UtilMind|URLSpiderPro|URL_Spider_Pro|Vacuum|vagabondo|vayala|visibilitygap|VoidEYE|vspider|Web\ Downloader|w3mir|Web\ Data\ Extractor|Web\ Image\ Collector|Web\ Sucker|Wweb|WebAuto|WebBandit|web\.by\.mail|Webclipping|webcollage|webcollector|WebCopier|webcraft@bea|webdevil|webdownloader|Webdup|WebEMailExtrac|WebFetch|WebGo\ IS|WebHook|Webinator|WebLeacher|WEBMASTERS|WebMiner|WebMirror|webmole|WebReaper|WebSauger|Website|Website\ eXtractor|Website\ Quester|WebSnake|Webster|WebStripper|websucker|webvac|webwalk|webweasel|WebWhacker|WebZIP|Whacker|whizbang|WhosTalking|Widow|WISEbot|WWWOFFLE|x-Tractor|^Xaldon\ WebSpider|WUMPUS|Xenu|XGET|Zeus.*Webster|Zeus [NC]
 RewriteRule ^.* - [F,L]
 
-# Rewrite all plugin docs to plugins.jenkins.io if user agent is not the wiki exporter
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
+# Ignore all following redirects for the wiki exporter
+RewriteCond %{HTTP_USER_AGENT} ^jenkins-wiki-exporter/.*$
+RewriteRule ^.*$ - [L]
+
+# Rewrite all plugin docs to plugins.jenkins.io
 RewriteRule "^/display/JENKINS/Writinng\+an\+SCM\+plugin$" "https://www.jenkins.io/doc/developer/plugin-development/writing-an-scm-plugin" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/PlasticSCM\+Plugin$" "https://plugins.jenkins.io/plasticscm-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Static\+Analysis\+in\+Pipelines$" "https://plugins.jenkins.io/warnings-ng" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AnchorChain\+plugin$" "https://plugins.jenkins.io/AnchorChain" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Apica\+Loadtest\+Plugin$" "https://plugins.jenkins.io/ApicaLoadtest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Audit\+Trail\+Plugin$" "https://plugins.jenkins.io/audit-trail" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BlameSubversion$" "https://plugins.jenkins.io/BlameSubversion" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BlazeMeter\+Plugin$" "https://plugins.jenkins.io/BlazeMeterJenkinsPlugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CFLint\+plugin$" "https://plugins.jenkins.io/CFLint" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ColumnPack\+Plugin$" "https://plugins.jenkins.io/ColumnsPlugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Custom\+History$" "https://plugins.jenkins.io/CustomHistory" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DotCi\+Plugin$" "https://plugins.jenkins.io/DotCi" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DotCi\+DockerPublish\+Plugin$" "https://plugins.jenkins.io/DotCi-DockerPublish" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DotCi\+InstallPackages\+Plugin$" "https://plugins.jenkins.io/DotCi-InstallPackages" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DotCi\+Plugins\+Starter\+Pack\+Plugin$" "https://plugins.jenkins.io/DotCi-Plugins-Starter-Pack" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Exclusion\-Plugin$" "https://plugins.jenkins.io/Exclusion" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gatekeeper\+Plugin$" "https://plugins.jenkins.io/GatekeeperPlugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+API\+Plugin$" "https://plugins.jenkins.io/github-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JDK\+Parameter\+Plugin$" "https://plugins.jenkins.io/JDK_Parameter_Plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "/display/JENKINS/JDK\+Tool\+Plugin$" "https://plugins.jenkins.io/jdk-tool" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JiraTestResultReporter\-plugin$" "https://plugins.jenkins.io/JiraTestResultReporter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Matrix\+configuration\+sorter\+plugin$" "https://plugins.jenkins.io/Matrix-sorter-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Office\+365\+Connector\+Plugin$" "https://plugins.jenkins.io/Office-365-Connector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Parameterized\+Remote\+Trigger\+Plugin$" "https://plugins.jenkins.io/Parameterized-Remote-Trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Priority\+Sorter\+Plugin$" "https://plugins.jenkins.io/PrioritySorter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SBuild\+Plugin$" "https://plugins.jenkins.io/SBuild" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/StashBranchParameter$" "https://plugins.jenkins.io/StashBranchParameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Surround\+SCM\+Plugin$" "https://plugins.jenkins.io/Surround-SCM-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TestComplete\+Support\+Plugin$" "https://plugins.jenkins.io/TestComplete" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TestFairy\+Plugin$" "https://plugins.jenkins.io/TestFairy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Twilio\+Notifier\+Plugin$" "https://plugins.jenkins.io/TwilioNotifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/URL\+SCM$" "https://plugins.jenkins.io/URLSCM" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Accelerated\+Build\+Now\+Plugin$" "https://plugins.jenkins.io/accelerated-build-now-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ACE\+Editor\+Plugin$" "https://plugins.jenkins.io/ace-editor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Active\+Directory\+Plugin$" "https://plugins.jenkins.io/active-directory" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Acunetix\+Plugin$" "https://plugins.jenkins.io/acunetix" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Adaptive\+Disconnector\+Plugin$" "https://plugins.jenkins.io/adaptive-disconnector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Additional\+Identities\+Plugin$" "https://plugins.jenkins.io/additional-identities-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Additional\+Metrics\+Plugin$" "https://plugins.jenkins.io/additional-metrics" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Advanced\+Installer\+Msi\+Builder\+Plugin$" "https://plugins.jenkins.io/advanced-installer-msi-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Agent\+LoadBalance\+Plugin$" "https://plugins.jenkins.io/agent-loadbalance" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Alauda\+DevOps\+Credentials\+Provider\+Plugin$" "https://plugins.jenkins.io/alauda-devops-credentials-provider" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Alauda\+DevOps\+Pipeline\+Plugin$" "https://plugins.jenkins.io/alauda-devops-pipeline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Alauda\+DevOps\+Sync\+Plugin$" "https://plugins.jenkins.io/alauda-devops-sync" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Alauda\+Kubernetes\+Support\+Plugin$" "https://plugins.jenkins.io/alauda-kubernetes-support" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Alauda\+Pipeline\+Plugin$" "https://plugins.jenkins.io/alauda-pipeline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Aliyun\+Container\+Service\+Deploy\+Plugin$" "https://plugins.jenkins.io/aliyun-container-service-deploy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/All\+Changes\+Plugin$" "https://plugins.jenkins.io/all-changes" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Allure\+Plugin$" "https://plugins.jenkins.io/allure-jenkins-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/Jenkins/Amazon\+Web\+Services\+SDK\+library$" "https://plugins.jenkins.io/aws-java-sdk" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Amazon\+ECR$" "https://plugins.jenkins.io/amazon-ecr" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AMQP\+Build\+Trigger\+Plugin$" "https://plugins.jenkins.io/amqp-build-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Android\+Apk\+Size\+Watcher\+Plugin$" "https://plugins.jenkins.io/android-apk-size-watcher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Android\+Emulator\+Plugin$" "https://plugins.jenkins.io/android-emulator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Android\+Lint\+Plugin$" "https://plugins.jenkins.io/android-lint" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Android\+Signing\+Plugin$" "https://plugins.jenkins.io/android-signing" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Veertu\+Plugin$" "https://plugins.jenkins.io/anka-build" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ansible\+Plugin$" "https://plugins.jenkins.io/ansible" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AnsiColor\+Plugin$" "https://plugins.jenkins.io/ansicolor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ant\+In\+Workspace\+Plugin$" "https://plugins.jenkins.io/ant-in-workspace" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AntExec\+plugin$" "https://plugins.jenkins.io/antexec" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Any\+Build\+Step\+Plugin$" "https://plugins.jenkins.io/any-buildstep" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/API\+Fortress$" "https://plugins.jenkins.io/apifortress" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Application\+Detector\+Plugin$" "https://plugins.jenkins.io/app-detector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Appaloosa\+Plugin$" "https://plugins.jenkins.io/appaloosa-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AppDynamics\+Plugin/$" "https://plugins.jenkins.io/appdynamics-dashboard" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Appetize\.io\+Plugin$" "https://plugins.jenkins.io/appetize" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/App\.io\+Plugin$" "https://plugins.jenkins.io/appio" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Applatix\+Plugin$" "https://plugins.jenkins.io/applatix" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/vFabric\+Application\+Director\+Plugin$" "https://plugins.jenkins.io/application-director-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Applitools\+Eyes\+Plugin$" "https://plugins.jenkins.io/applitools-eyes" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Apprenda\+Plugin$" "https://plugins.jenkins.io/apprenda" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Aqua\+MicroScanner\+Plugin$" "https://plugins.jenkins.io/aqua-microscanner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Aqua\+Serverless\+Plugin$" "https://plugins.jenkins.io/aqua-serverless" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Arachni\+Scanner\+plugin$" "https://plugins.jenkins.io/arachni-scanner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Archived\+Artifact\+Url\+Viewer\+PlugIn$" "https://plugins.jenkins.io/archived-artifact-url-viewer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/aRESTocats\-Plugin$" "https://plugins.jenkins.io/arestocats" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Artifact\+Diff\+Plugin$" "https://plugins.jenkins.io/artifact-diff-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Artifact\+Manager\+S3\+Plugin$" "https://plugins.jenkins.io/artifact-manager-s3" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/ArtifactPromotionPlugin$" "https://plugins.jenkins.io/artifact-promotion" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ArtifactDeployer\+Plugin$" "https://plugins.jenkins.io/artifactdeployer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Artifactory\+Plugin$" "https://plugins.jenkins.io/artifactory" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Artifactory\+-\+Working\+With\+Pipeline\+Jobs\+in\+Jenkins" "https://plugins.jenkins.io/workflow-aggregator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AsakusaSatellite\+Plugin$" "https://plugins.jenkins.io/asakusa-satellite-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/assembla\+plugin$" "https://plugins.jenkins.io/assembla" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Assembla\+Auth\+Plugin$" "https://plugins.jenkins.io/assembla-auth" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Assembla\+Merge\+Request\+Builder\+Plugin$" "https://plugins.jenkins.io/assembla-merge-request-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AssertThat\+BDD\+Jira\+Plugin$" "https://plugins.jenkins.io/assertthat-bdd-jira" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Associated\+Files\+Plugin$" "https://plugins.jenkins.io/associated-files" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Async\+Http\+Client\+Plugin$" "https://plugins.jenkins.io/async-http-client" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Async\+Job\+Plugin$" "https://plugins.jenkins.io/async-job" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Atlassian\+Jira\+Software\+Cloud\+Plugin$" "https://plugins.jenkins.io/atlassian-jira-software-cloud" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Attention\-plugin$" "https://plugins.jenkins.io/attention" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Audit\+To\+Database\+Plugin$" "https://plugins.jenkins.io/audit2db" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Authentication\+Tokens\+API\+Plugin$" "https://plugins.jenkins.io/authentication-tokens" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Authorize\+Project\+plugin$" "https://plugins.jenkins.io/authorize-project" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AutoAction\+Step\+Plugin$" "https://plugins.jenkins.io/autoaction-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Auto\+Complete\+Parameter\+Plugin$" "https://plugins.jenkins.io/autocomplete-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Avatar\+Plugin$" "https://plugins.jenkins.io/avatar" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+Beanstalk\+Publisher\+Plugin$" "https://plugins.jenkins.io/aws-beanstalk-publisher-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+Bucket\+Credentials\+Plugin$" "https://plugins.jenkins.io/aws-bucket-credentials" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+CloudWatch\+Logs\+Publisher\+Plugin$" "https://plugins.jenkins.io/aws-cloudwatch-logs-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+CodeBuild\+Plugin$" "https://plugins.jenkins.io/aws-codebuild" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Aws\+Codecommit\+Jobs$" "https://plugins.jenkins.io/aws-codecommit-jobs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+CodeCommit\+Trigger\+Plugin$" "https://plugins.jenkins.io/aws-codecommit-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+CodePipeline\+Plugin$" "https://plugins.jenkins.io/aws-codepipeline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudBees\+AWS\+Credentials\+Plugin$" "https://plugins.jenkins.io/aws-credentials" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+Device\+Farm\+Plugin$" "https://plugins.jenkins.io/aws-device-farm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+Global\+Configuration\+Plugin$" "https://plugins.jenkins.io/aws-global-configuration" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+Lambda\+Plugin$" "https://plugins.jenkins.io/aws-lambda" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+Parameter\+Store\+Plugin$" "https://plugins.jenkins.io/aws-parameter-store" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+SAM\+Plugin$" "https://plugins.jenkins.io/aws-sam" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+SQS\+Plugin$" "https://plugins.jenkins.io/aws-sqs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+Yum\+Parameter\+Plugin$" "https://plugins.jenkins.io/aws-yum-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWSEB\+Deployment\+Plugin$" "https://plugins.jenkins.io/awseb-deployment-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Container\+Service\+Plugin$" "https://plugins.jenkins.io/azure-acs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+AD\+Plugin$" "https://plugins.jenkins.io/azure-ad" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+App\+Service\+Plugin$" "https://plugins.jenkins.io/azure-app-service" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Artifact\+Manager\+Plugin$" "https://plugins.jenkins.io/azure-artifact-manager" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Batch\+Parallel\+Test\+Execution\+Plugin$" "https://plugins.jenkins.io/azure-batch-parallel" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+CLI\+Plugin$" "https://plugins.jenkins.io/azure-cli" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Commons\+Plugin$" "https://plugins.jenkins.io/azure-commons" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Container\+Agents\+Plugin$" "https://plugins.jenkins.io/azure-container-agents" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Container\+Registry\+Tasks\+Plugin$" "https://plugins.jenkins.io/azure-container-registry-tasks" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Credentials\+plugin$" "https://plugins.jenkins.io/azure-credentials" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Dev\+Spaces\+Plugin$" "https://plugins.jenkins.io/azure-dev-spaces" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Event\+Grid\+Notifier$" "https://plugins.jenkins.io/azure-event-grid-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Function\+Plugin$" "https://plugins.jenkins.io/azure-function" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+IoT\+Edge\+Plugin$" "https://plugins.jenkins.io/azure-iot-edge" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+PublisherSettings\+Credentials\+Plugin$" "https://plugins.jenkins.io/azure-publishersettings-credentials" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+VM\+Agents\+Plugin$" "https://plugins.jenkins.io/azure-vm-agents" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Azure\+Virtual\+Machine\+Scale\+Set\+Plugin$" "https://plugins.jenkins.io/azure-vmss" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Backlog\+Plugin$" "https://plugins.jenkins.io/backlog" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Backup\+Plugin$" "https://plugins.jenkins.io/backup" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Backup\+and\+interrupt\+running\+job\+plugin$" "https://plugins.jenkins.io/backup-interrupt-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Badge\+Plugin$" "https://plugins.jenkins.io/badge" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BART\+Plugin$" "https://plugins.jenkins.io/bart" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Basic\+Branch\+Build\+Strategies\+Plugin$" "https://plugins.jenkins.io/basic-branch-build-strategies" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Batch\+Task\+Plugin$" "https://plugins.jenkins.io/batch-task" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bazaar\+Plugin$" "https://plugins.jenkins.io/bazaar" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RAD\+Studio\+Plugin$" "https://plugins.jenkins.io/bds-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Beagle\+Security\+Plugin$" "https://plugins.jenkins.io/beagle-security" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Beaker\+Builder\+Plugin$" "https://plugins.jenkins.io/beaker-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BearyChat\+Plugin$" "https://plugins.jenkins.io/bearychat" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Beer\+Plugin$" "https://plugins.jenkins.io/beer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Behave\+Test\+Results\+Publisher\+Plugin$" "https://plugins.jenkins.io/behave-testresults-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Benchmark\+Plugin$" "https://plugins.jenkins.io/benchmark" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Benchmark\+Evaluator\+Plugin$" "https://plugins.jenkins.io/benchmark-evaluator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BitBucket\+Plugin$" "https://plugins.jenkins.io/bitbucket" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Approval\+Filter\+Plugin$" "https://plugins.jenkins.io/bitbucket-approval-filter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Approve\+Plugin$" "https://plugins.jenkins.io/bitbucket-approve" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Cloud\+Build\+Status\+Notifier\+Plugin$" "https://plugins.jenkins.io/bitbucket-build-status-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Filter\+Project\+Trait\+Plugin$" "https://plugins.jenkins.io/bitbucket-filter-project-trait" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+OAuth\+Plugin$" "https://plugins.jenkins.io/bitbucket-oauth" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+pullrequest\+builder\+plugin$" "https://plugins.jenkins.io/bitbucket-pullrequest-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Aged\+References\+SCM\+Filter\+Plugin$" "https://plugins.jenkins.io/bitbucket-scm-filter-aged-refs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Jira\+Validator\+SCM\+Filter\+Plugin$" "https://plugins.jenkins.io/bitbucket-scm-filter-jira-validator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Commit\+Skip\+SCM\+Behaviour\+Plugin$" "https://plugins.jenkins.io/bitbucket-scm-trait-commit-skip" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BitKeeper\+Plugin$" "https://plugins.jenkins.io/bitkeeper" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Synopsys\+Detect\+Plugin$" "https://plugins.jenkins.io/blackduck-detect" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Blink1\+Plugin$" "https://plugins.jenkins.io/blink1" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Blitz_io$" "https://plugins.jenkins.io/blitz_io-jenkins" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Block\+Build\+Final\+Project\+Plugin$" "https://plugins.jenkins.io/block-build-final-project" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Block\+queued\+job\+plugin$" "https://plugins.jenkins.io/block-queued-job" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Block\+Same\+Builds\+Plugin$" "https://plugins.jenkins.io/block-same-builds" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Blue\+Ocean\+Plugin$" "https://plugins.jenkins.io/blueocean-analytics-tools" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Blue\+Ocean\+Autofavorite\+Plugin$" "https://plugins.jenkins.io/blueocean-autofavorite" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Blue\+Ocean\+Core\+JS$" "https://plugins.jenkins.io/blueocean-core-js" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BlueOcean\+Display\+URL\+Plugin$" "https://plugins.jenkins.io/blueocean-display-url" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RPD\+Plugin$" "https://plugins.jenkins.io/bmc-rpd" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Boot\-clj\+Plugin$" "https://plugins.jenkins.io/boot-clj" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Twitter\+Bootstrap$" "https://plugins.jenkins.io/bootstrap" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bootstraped\+Multi\+Test\+Results\+Report$" "https://plugins.jenkins.io/bootstraped-multi-test-results-report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Brakeman\+Plugin$" "https://plugins.jenkins.io/brakeman" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Branch\+API\+Plugin$" "https://plugins.jenkins.io/branch-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Browser\+axis\+plugin$" "https://plugins.jenkins.io/browser-axis-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BrowserStack\+Plugin$" "https://plugins.jenkins.io/browserstack-integration" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BTC\+EmbeddedPlatform$" "https://plugins.jenkins.io/btc-embeddedplatform" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Buckminster\+PlugIn$" "https://plugins.jenkins.io/buckminster" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Buddycloud\+Plugin$" "https://plugins.jenkins.io/buddycloud" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bugzilla\+Plugin$" "https://plugins.jenkins.io/bugzilla" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Alias\+Setter\+Plugin$" "https://plugins.jenkins.io/build-alias-setter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Blocker\+Plugin$" "https://plugins.jenkins.io/build-blocker-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Cause\+Run\+Condition$" "https://plugins.jenkins.io/build-cause-run-condition" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Env\+Propagator\+Plugin$" "https://plugins.jenkins.io/build-env-propagator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Environment\+Plugin$" "https://plugins.jenkins.io/build-environment" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Failure\+Analyzer$" "https://plugins.jenkins.io/build-failure-analyzer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+History\+Metrics\+Plugin$" "https://plugins.jenkins.io/build-history-metrics-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Keeper\+Plugin$" "https://plugins.jenkins.io/build-keeper-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/build\+line\+plugin$" "https://plugins.jenkins.io/build-line" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/build\-metrics\-plugin$" "https://plugins.jenkins.io/build-metrics" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Monitor\+Plugin$" "https://plugins.jenkins.io/build-monitor-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Pipeline\+Plugin$" "https://plugins.jenkins.io/build-pipeline-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Publisher\+Plugin$" "https://plugins.jenkins.io/build-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Steps\+from\+Json\+Plugin$" "https://plugins.jenkins.io/build-steps-from-json" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Symlink\+Plugin$" "https://plugins.jenkins.io/build-symlink" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Time\+Blame\+Plugin$" "https://plugins.jenkins.io/build-time-blame" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\-timeout\+Plugin$" "https://plugins.jenkins.io/build-timeout" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Timestamp\+Plugin$" "https://plugins.jenkins.io/build-timestamp" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+User\+Vars\+Plugin$" "https://plugins.jenkins.io/build-user-vars-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+View\+Column\+Plugin$" "https://plugins.jenkins.io/build-view-column" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+With\+Parameters\+Plugin$" "https://plugins.jenkins.io/build-with-parameters" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BuildContextCapture\+Plugin$" "https://plugins.jenkins.io/buildcontext-capture" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Graph\+View\+Plugin$" "https://plugins.jenkins.io/buildgraph-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/BuildResultTrigger\+Plugin$" "https://plugins.jenkins.io/buildresult-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Rotator\+Plugin$" "https://plugins.jenkins.io/buildrotator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Trigger\+Badge\+Plugin$" "https://plugins.jenkins.io/buildtriggerbadge" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Built\-on\+Column$" "https://plugins.jenkins.io/built-on-column" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bulk\+Builder\+Plugin$" "https://plugins.jenkins.io/bulk-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bumblebee\+HP\+ALM\+Plugin$" "https://plugins.jenkins.io/bumblebee" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Byteguard\+Build\+Actions\+Plugin$" "https://plugins.jenkins.io/byteguard-build-actions" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CA\+APM\+Plugin$" "https://plugins.jenkins.io/ca-apm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CA\+Service\+Virtualization\+Plugin$" "https://plugins.jenkins.io/ca-service-virtualization" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cachet\+Gate\+Plugin$" "https://plugins.jenkins.io/cachet-gating" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Calendar\+View\+Plugin$" "https://plugins.jenkins.io/calendar-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Call\+Remote\+Job\+Plugin$" "https://plugins.jenkins.io/call-remote-job-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Campfire\+Plugin$" "https://plugins.jenkins.io/campfire" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Capitomcat\+Plugin$" "https://plugins.jenkins.io/capitomcat" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CAS\+Plugin$" "https://plugins.jenkins.io/cas-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CATALOGIC\+ECX\+PLUGIN$" "https://plugins.jenkins.io/catalogic-ecx" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Categorized\+Jobs\+View$" "https://plugins.jenkins.io/categorized-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CCCC\+Plugin$" "https://plugins.jenkins.io/cccc" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CCM\+Plugin$" "https://plugins.jenkins.io/ccm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CCtray\+XML\+Plugin$" "https://plugins.jenkins.io/cctray-xml" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cerberus\+Jenkins\+Plugin$" "https://plugins.jenkins.io/cerberus-testing" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Change\+Assembly\+Version$" "https://plugins.jenkins.io/change-assembly-version-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Change\+Log\+History\+Plugin$" "https://plugins.jenkins.io/changelog-history" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Changes\+Since\+Last\+Success\+Plugin$" "https://plugins.jenkins.io/changes-since-last-success" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Chaos\+Butler\+Plugin$" "https://plugins.jenkins.io/chaos-butler" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ChatWork\+Plugin$" "https://plugins.jenkins.io/chatwork" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Checkmarx\+CxSAST\+Plugin$" "https://plugins.jenkins.io/checkmarx" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/chef\-identity\+plugin$" "https://plugins.jenkins.io/chef-identity" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Chef\+Tracking\+Plugin$" "https://plugins.jenkins.io/chef-tracking" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Chosen\+plugin$" "https://plugins.jenkins.io/chosen" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Chosen\+Views\+Tab\+Bar$" "https://plugins.jenkins.io/chosen-views-tabbar" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ChromeDriver\+plugin$" "https://plugins.jenkins.io/chromedriver" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/chroot\+Plugin$" "https://plugins.jenkins.io/chroot" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ChuckNorris\+Plugin$" "https://plugins.jenkins.io/chucknorris" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/The\+Continuous\+Integration\+Game\+plugin$" "https://plugins.jenkins.io/ci-game" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ci\+Skip\+Plugin$" "https://plugins.jenkins.io/ci-skip" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Continuous\+Integration\+with\+Toad\+DevOps\+Toolkit\+Plugin$" "https://plugins.jenkins.io/ci-with-toad-devops-toolkit" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Continuous\+Integration\+With\+Toad\+Edge\+Plugin$" "https://plugins.jenkins.io/ci-with-toad-edge" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Spark\+Plugin$" "https://plugins.jenkins.io/cisco-spark" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Spark\+Notifier\+Plugin$" "https://plugins.jenkins.io/cisco-spark-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ClamAV\+Plugin$" "https://plugins.jenkins.io/clamav" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Clang\+Scan\-Build\+Plugin$" "https://plugins.jenkins.io/clang-scanbuild" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ClearCase\+Plugin$" "https://plugins.jenkins.io/clearcase" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ClearCase\+Release\+Plugin$" "https://plugins.jenkins.io/clearcase-release" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ClearCase\+UCM\+Baseline\+Plugin$" "https://plugins.jenkins.io/clearcase-ucm-baseline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ClearCase\+UCM\+Plugin$" "https://plugins.jenkins.io/clearcase-ucm-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CLI\+Commander\+Plugin$" "https://plugins.jenkins.io/cli-commander" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CLIF\+Performance\+Testing\+Plugin$" "https://plugins.jenkins.io/clif-performance-testing" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Clone\+Workspace\+SCM\+Plugin$" "https://plugins.jenkins.io/clone-workspace-scm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cloud\+Statistics\+Plugin$" "https://plugins.jenkins.io/cloud-stats" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudBees\+Credentials\+Plugin$" "https://plugins.jenkins.io/cloudbees-credentials" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudBees\+DevOptics\+Installation\+Plugin$" "https://plugins.jenkins.io/cloudbees-devoptics-enabler" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudBees\+Simple\+Disk\+Usage\+Plugin$" "https://plugins.jenkins.io/cloudbees-disk-usage-simple" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudBees\+Free\+Enterprise\+Plugins$" "https://plugins.jenkins.io/cloudbees-plugin-gateway" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudCoreo\+DeployTime\+Plugin$" "https://plugins.jenkins.io/cloudcoreo-deploytime" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cloud\+Foundry\+Plugin$" "https://plugins.jenkins.io/cloudfoundry" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudShare\+Docker\-Machine\+Plugin$" "https://plugins.jenkins.io/cloudshare-docker" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudShell\+Sandbox\+Plugin$" "https://plugins.jenkins.io/cloudshell-sandbox" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SOASTA\+CloudTest\+Plugin$" "https://plugins.jenkins.io/cloudtest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Clover\+Plugin$" "https://plugins.jenkins.io/clover" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Clover\+PHP\+Plugin$" "https://plugins.jenkins.io/cloverphp" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cluster\+Statistics\+Plugin$" "https://plugins.jenkins.io/cluster-stats" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CMVC\+Plugin$" "https://plugins.jenkins.io/cmvc" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cobertura\+Plugin$" "https://plugins.jenkins.io/cobertura" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CocoaPods\+Plugin$" "https://plugins.jenkins.io/cocoapods-integration" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CodeBeamer\+Source\+Code\+Coverage\+Publisher\+Plugin$" "https://plugins.jenkins.io/codebeamer-coverage-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Codebeamer\+Result\+Trend\+Updater\+Plugin$" "https://plugins.jenkins.io/codebeamer-result-trend-updater" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Codebeamer\+xUnit\+Importer\+Plugin$" "https://plugins.jenkins.io/codebeamer-xunit-importer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CodeBuilder%3A\+AWS\+CodeBuild\+Cloud\+Agents\+Plugin$" "https://plugins.jenkins.io/codebuilder-cloud" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TODO\+Plugin$" "https://plugins.jenkins.io/codeclimate-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CodeCommit\+URL\+Helper$" "https://plugins.jenkins.io/codecommit-url-helper" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CodeCover\+Plugin$" "https://plugins.jenkins.io/codecover" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+Codedeploy\+plugin$" "https://plugins.jenkins.io/codedeploy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Code\+Dx\+Plugin$" "https://plugins.jenkins.io/codedx" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Codefresh\+Plugin$" "https://plugins.jenkins.io/codefresh" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CodeScanner\+Plugin$" "https://plugins.jenkins.io/codescanner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CodeSonar\+Plugin$" "https://plugins.jenkins.io/codesonar" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Coding\+Webhook\+Plugin$" "https://plugins.jenkins.io/coding-webhook" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CollabNet\+Plugin$" "https://plugins.jenkins.io/collabnet" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Comments\+Remover\+Plugin$" "https://plugins.jenkins.io/comments-remover" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Commit\+Message\+Trigger\+Plugin$" "https://plugins.jenkins.io/commit-message-trigger-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Compact\+Columns$" "https://plugins.jenkins.io/compact-columns" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Compatability\+Action\+Storage\+Plugin$" "https://plugins.jenkins.io/compatibility-action-storage" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Composer\+Security\+Checker\+Plugin$" "https://plugins.jenkins.io/composer-security-checker" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Compound\+Slaves$" "https://plugins.jenkins.io/compound-slaves" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Compress\+Artifacts\+Plugin$" "https://plugins.jenkins.io/compress-artifacts" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Compress\+Build\+Log\+Plugin$" "https://plugins.jenkins.io/compress-buildlog" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Computer\+queue\+plugin$" "https://plugins.jenkins.io/computer-queue-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Compuware\+Common\+Configuration\+Plugin$" "https://plugins.jenkins.io/compuware-common-configuration" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Compuware\+Source\+Code\+Download\+for\+Endevor%2C\+PDS%2C\+and\+ISPW\+Plugin$" "https://plugins.jenkins.io/compuware-scm-downloader" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Compuware\+Topaz\+Utilities\+Plugin$" "https://plugins.jenkins.io/compuware-topaz-utilities" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Compuware\+Xpediter\+Code\+Coverage\+Plugin$" "https://plugins.jenkins.io/compuware-xpediter-code-coverage" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Concordion\+Presenter\+Plugin$" "https://plugins.jenkins.io/concordionpresenter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Concurrent\+Login\+Plugin$" "https://plugins.jenkins.io/concurrent-login-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Conditional\+BuildStep\+Plugin$" "https://plugins.jenkins.io/conditional-buildstep" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Config\+AutoRefresh\+Plugin$" "https://plugins.jenkins.io/config-autorefresh-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/config\+rotator\+plugin$" "https://plugins.jenkins.io/config-rotator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Configuration\+Slicing\+Plugin$" "https://plugins.jenkins.io/configurationslicing" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Configure\+Job\+Column\+Plugin$" "https://plugins.jenkins.io/configure-job-column-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Confluence\+Publisher\+Plugin$" "https://plugins.jenkins.io/confluence-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CONS3RT\+Plugin$" "https://plugins.jenkins.io/cons3rt" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Console\+Badge\+Plugin$" "https://plugins.jenkins.io/console-badge" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Console\+Column\+Plugin$" "https://plugins.jenkins.io/console-column-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Console\+Tail\+Plugin$" "https://plugins.jenkins.io/console-tail" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Consul\+Plugin$" "https://plugins.jenkins.io/consul" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Consul\-KV\-Builder\+Plugin$" "https://plugins.jenkins.io/consul-kv-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Container\+Slaves\+Plugin$" "https://plugins.jenkins.io/container-slaves" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Continuum\+Plugin$" "https://plugins.jenkins.io/continuum" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Convert\+To\+Pipeline\+Plugin$" "https://plugins.jenkins.io/convert-to-pipeline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Convertigo\+Mobile\+Platform\+Plugin$" "https://plugins.jenkins.io/convertigo-mobile-platform" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Coordinator$" "https://plugins.jenkins.io/coordinator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Copado\+Plugin$" "https://plugins.jenkins.io/copado" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Copr\+Plugin$" "https://plugins.jenkins.io/copr" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Copy\+Data\+To\+Workspace\+Plugin$" "https://plugins.jenkins.io/copy-data-to-workspace-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Copy\+project\+link\+plugin$" "https://plugins.jenkins.io/copy-project-link" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Copy\+Artifact\+Plugin$" "https://plugins.jenkins.io/copyartifact" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cors\+Filter\+Plugin$" "https://plugins.jenkins.io/cors-filter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CouchDB\+Statistics\+Plugin$" "https://plugins.jenkins.io/couchdb-statistics" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Coverage\+Complexity\+Scatter\+Plot\+PlugIn$" "https://plugins.jenkins.io/covcomplplot" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Coverity\+Plugin$" "https://plugins.jenkins.io/coverity" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cppcheck\+Plugin$" "https://plugins.jenkins.io/cppcheck" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CPPNCSS\+Plugin$" "https://plugins.jenkins.io/cppncss" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cpptest\+Plugin$" "https://plugins.jenkins.io/cpptest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Crap4J\+Plugin$" "https://plugins.jenkins.io/crap4j" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Fingerprint\+Plugin$" "https://plugins.jenkins.io/create-fingerprint" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Create\+Job\+Advanced\+Plugin$" "https://plugins.jenkins.io/createjobadvanced" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Credentials\+Binding\+Plugin$" "https://plugins.jenkins.io/credentials-binding" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Crittercism\+dSYM\+Plugin$" "https://plugins.jenkins.io/crittercism-dsym" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cron\+Shelve\+Plugin$" "https://plugins.jenkins.io/cron-shelve" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cron\+Column\+Plugin$" "https://plugins.jenkins.io/cron_column" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CrossBrowserTesting\+Plugin$" "https://plugins.jenkins.io/crossbrowsertesting" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Crowd\+Plugin$" "https://plugins.jenkins.io/crowd" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Crowd\+2\+Plugin$" "https://plugins.jenkins.io/crowd2" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CRX\+Content\+Package\+Deployer\+Plugin$" "https://plugins.jenkins.io/crx-content-package-deployer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CryptoMove\+Plugin$" "https://plugins.jenkins.io/cryptomove" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cucumber\+Living\+Documentation\+Plugin$" "https://plugins.jenkins.io/cucumber-living-documentation" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cucumber\+Performance\+Reports\+Plugin$" "https://plugins.jenkins.io/cucumber-perf" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cucumber\+Reports\+Plugin$" "https://plugins.jenkins.io/cucumber-reports" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cucumber\+Slack\+Notifier\+Plugin$" "https://plugins.jenkins.io/cucumber-slack-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cucumber\+Test\+Result\+Plugin$" "https://plugins.jenkins.io/cucumber-testresult-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cucumber\+Trend\+Report\+Plugin$" "https://plugins.jenkins.io/cucumber-trends-report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Curseforge\+Publisher\+Plugin$" "https://plugins.jenkins.io/curseforge-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Custom\+Build\+Properties\+Plugin$" "https://plugins.jenkins.io/custom-build-properties" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Custom\+Job\+Icon\+Plugin$" "https://plugins.jenkins.io/custom-job-icon" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Custom\+Tools\+Plugin$" "https://plugins.jenkins.io/custom-tools-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Custom\+View\+Tabs\+Plugin$" "https://plugins.jenkins.io/custom-view-tabs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Customize\+Build\+Now\+Plugin$" "https://plugins.jenkins.io/customize-build-now" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Customized\+Build\+Message\+Plugin$" "https://plugins.jenkins.io/customized-build-message" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CVS\+Plugin$" "https://plugins.jenkins.io/cvs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cygpath\+Plugin$" "https://plugins.jenkins.io/cygpath" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Cygwin\+Process\+Killer\+Plugin$" "https://plugins.jenkins.io/cygwin-process-killer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Daily\+Quote\+Plugin$" "https://plugins.jenkins.io/daily-quote" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Darcs\+Plugin$" "https://plugins.jenkins.io/darcs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dashboard\+View$" "https://plugins.jenkins.io/dashboard-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Database\+Plugin$" "https://plugins.jenkins.io/database" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Drizzle\(\+MySQL\)%20Database%20Plugin$" "https://plugins.jenkins.io/database-drizzle" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/H2\+Database\+Plugin$" "https://plugins.jenkins.io/database-h2" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MySQL\+Database\+Plugin$" "https://plugins.jenkins.io/database-mysql" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PostgreSQL\+Database\+Plugin$" "https://plugins.jenkins.io/database-postgresql" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SQLite\+Database\+Plugin$" "https://plugins.jenkins.io/database-sqlite" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Data\+Theorem\+Mobile\+App\+Security\+Plugin$" "https://plugins.jenkins.io/datatheorem-mobile-app-security" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Date\+Parameter\+Plugin$" "https://plugins.jenkins.io/date-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DaticalDB4Jenkins$" "https://plugins.jenkins.io/datical-db-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/dbCharts\+Plugin$" "https://plugins.jenkins.io/dbCharts" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dead\+Man%27s\+Snitch\+Plugin$" "https://plugins.jenkins.io/deadmanssnitch" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Debian\+Package\+Builder\+Plugin$" "https://plugins.jenkins.io/debian-package-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Debian\+Pbuilder\+Plugin$" "https://plugins.jenkins.io/debian-pbuilder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Delete\+log\+plugin$" "https://plugins.jenkins.io/delete-log-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Delivery\+Pipeline\+Plugin$" "https://plugins.jenkins.io/delivery-pipeline-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Delphix\+Plugin$" "https://plugins.jenkins.io/delphix" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Delta\+Cloud\+API\+plugin$" "https://plugins.jenkins.io/delta-cloud" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dependency\+Queue\+Plugin$" "https://plugins.jenkins.io/dependency-queue-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dependency\+Analyzer\+Plugin$" "https://plugins.jenkins.io/dependencyanalyzer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dependency\+Graph\+View\+Plugin$" "https://plugins.jenkins.io/depgraph-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Deploy\+Plugin$" "https://plugins.jenkins.io/deploy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Deploy\+WebSphere\+Plugin$" "https://plugins.jenkins.io/websphere-deployer" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/DeployDB\+Plugin$" "https://plugins.jenkins.io/deploydb" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Deployed\+on\+Column\+Plugin$" "https://plugins.jenkins.io/deployed-on-column" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Deployer\+Framework\+Plugin$" "https://plugins.jenkins.io/deployer-framework" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/XL\+Deploy\+Plugin$" "https://plugins.jenkins.io/deployit-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Deployment\+Notification\+Plugin$" "https://plugins.jenkins.io/deployment-notification" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Deployment\+Sphere\+Plugin$" "https://plugins.jenkins.io/deployment-sphere" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Description\+Column\+Plugin$" "https://plugins.jenkins.io/description-column-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Description\+Setter\+Plugin$" "https://plugins.jenkins.io/description-setter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Deveo\+Plugin$" "https://plugins.jenkins.io/deveo" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Device\+Watcher\+Plugin$" "https://plugins.jenkins.io/device-watcher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Devstack\+Plugin$" "https://plugins.jenkins.io/devstack" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Diagnostics\+Plugin$" "https://plugins.jenkins.io/diagnostics" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Diawi\+Upload\+Plugin$" "https://plugins.jenkins.io/diawi-upload" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DigitalOcean\+Plugin$" "https://plugins.jenkins.io/digitalocean-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dimensions\+Plugin$" "https://plugins.jenkins.io/dimensionsscm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dingding\+Json\+Pusher\+Plugin$" "https://plugins.jenkins.io/dingding-json-pusher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dingding\+Notification\+Plugin$" "https://plugins.jenkins.io/dingding-notifications" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Disable\+Failed\+Job\+Plugin$" "https://plugins.jenkins.io/disable-failed-job" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Disable\+GitHub\+Multibranch\+Status\+Plugin$" "https://plugins.jenkins.io/disable-github-multibranch-status" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Discard\+Old\+Build\+plugin$" "https://plugins.jenkins.io/discard-old-build" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Disk\+Usage\+Plugin$" "https://plugins.jenkins.io/disk-usage" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DiskCheck\+Plugin$" "https://plugins.jenkins.io/diskcheck" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Display\+Console\+Output\+Plugin$" "https://plugins.jenkins.io/display-console-output" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Display\+Upstream\+Changes\+Plugin$" "https://plugins.jenkins.io/display-upstream-changes" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Display\+URL\+API\+Plugin$" "https://plugins.jenkins.io/display-url-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/distTest\+Plugin$" "https://plugins.jenkins.io/distTest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DistFork\+Plugin$" "https://plugins.jenkins.io/distfork" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/D\+Listing\+Coverage\+Plugin$" "https://plugins.jenkins.io/dlisting-cov" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudBees\+Docker\+Build\+and\+Publish\+plugin$" "https://plugins.jenkins.io/docker-build-publish" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Docker\+build\+step\+plugin$" "https://plugins.jenkins.io/docker-build-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Docker\+Compose\+Build\+Step\+Plugin$" "https://plugins.jenkins.io/docker-compose-build-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudBees\+Docker\+Custom\+Build\+Environment\+Plugin$" "https://plugins.jenkins.io/docker-custom-build-environment" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Docker\+Java\+API\+Plugin$" "https://plugins.jenkins.io/docker-java-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Docker\+Plugin$" "https://plugins.jenkins.io/docker-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Docker\+Slaves\+Plugin$" "https://plugins.jenkins.io/docker-slaves" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Docker\+Swarm\+Plugin$" "https://plugins.jenkins.io/docker-swarm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudBees\+Docker\+Traceability$" "https://plugins.jenkins.io/docker-traceability" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudBees\+Docker\+Hub\+Notification$" "https://plugins.jenkins.io/dockerhub-notification" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DocLinks\+Plugin$" "https://plugins.jenkins.io/doclinks" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Doktor\+Plugin$" "https://plugins.jenkins.io/doktor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DOS\+Trigger$" "https://plugins.jenkins.io/dos-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DotNet\+as\+script\+plugin$" "https://plugins.jenkins.io/dotnet-as-script" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Downstream\+buildview\+plugin$" "https://plugins.jenkins.io/downstream-buildview" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Downstream\-Ext\+Plugin$" "https://plugins.jenkins.io/downstream-ext" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Doxygen\+Plugin$" "https://plugins.jenkins.io/doxygen" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/drmemory\+plugin$" "https://plugins.jenkins.io/drmemory-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DropDown\+ViewsTabBar\+Plugin$" "https://plugins.jenkins.io/dropdown-viewstabbar-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Drupal\+Developer\+Plugin$" "https://plugins.jenkins.io/drupal-developer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DryRun\+Plugin$" "https://plugins.jenkins.io/dry-run" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DTKit\+Plugin$" "https://plugins.jenkins.io/dtkit" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DTKit$" "https://plugins.jenkins.io/dtkit-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DumpInfo\+BuildWrapper\+Plugin$" "https://plugins.jenkins.io/dumpinfo-buildwrapper-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dumpling\+plugin$" "https://plugins.jenkins.io/dumpling" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DynamicAxis\+Plugin$" "https://plugins.jenkins.io/dynamic-axis" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dynamic\+Search\+View\+Plugin$" "https://plugins.jenkins.io/dynamic-search-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dynamic\+Extended\+Choice\+Parameter\+plugin$" "https://plugins.jenkins.io/dynamic_extended_choice_parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Dynatrace\+Plugin$" "https://plugins.jenkins.io/dynatrace-dashboard" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Eagle\+Tester\+Plugin$" "https://plugins.jenkins.io/eagle-tester" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Arxan\+MAM\+Publisher$" "https://plugins.jenkins.io/ease-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/EasyQA\+Plugin$" "https://plugins.jenkins.io/easyqa" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/EC2\+Cloud\+Axis$" "https://plugins.jenkins.io/ec2-cloud-axis" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/EC2\+Deployment\+Dashboard\+Plugin$" "https://plugins.jenkins.io/ec2-deployment-dashboard" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Amazon\+EC2\+Fleet\+Plugin$" "https://plugins.jenkins.io/ec2-fleet" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Eclipse\+Update\+Site\+Plugin$" "https://plugins.jenkins.io/eclipse-update-site" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ecs\-publisher\+Plugin$" "https://plugins.jenkins.io/ecs-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TraceTronic\+ECU\-TEST\+Plugin$" "https://plugins.jenkins.io/ecutest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/eggplant\-plugin$" "https://plugins.jenkins.io/eggplant-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/El\+Oyente\+Plugin$" "https://plugins.jenkins.io/elOyente" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ElasTest\+Plugin$" "https://plugins.jenkins.io/elastest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Elastic\+Axis$" "https://plugins.jenkins.io/elastic-axis" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ElasticBox\+CI$" "https://plugins.jenkins.io/elasticbox" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Elasticsearch\+Query\+Plugin$" "https://plugins.jenkins.io/elasticsearch-query" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Email\-ext\+plugin$" "https://plugins.jenkins.io/email-ext" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Email\+Ext\+Recipients\+Column\+Plugin$" "https://plugins.jenkins.io/email-ext-recipients-column" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Email\-ext\+Template\+Plugin$" "https://plugins.jenkins.io/emailext-template" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Emma\+Plugin$" "https://plugins.jenkins.io/emma" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Emma\+Coverage\+Column$" "https://plugins.jenkins.io/emmacoveragecolumn" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Emotional\+Jenkins\+Plugin$" "https://plugins.jenkins.io/emotional-jenkins-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Enhanced\+Old\+Build\+Discarder$" "https://plugins.jenkins.io/enhanced-old-build-discarder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Envfile\+Plugin$" "https://plugins.jenkins.io/envfile" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Environment\+dashboard\+plugin$" "https://plugins.jenkins.io/environment-dashboard" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Environment\+labels\+setter$" "https://plugins.jenkins.io/environment-labels-setter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Environment\+Manager\+Plugin$" "https://plugins.jenkins.io/environment-manager" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Environment\+Script\+Plugin$" "https://plugins.jenkins.io/environment-script" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Escaped\+Markup\+Plugin$" "https://plugins.jenkins.io/escaped-markup-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/My\+Plugin$" "https://plugins.jenkins.io/event-announcer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MicroNova\+EXAM\+Plugin$" "https://plugins.jenkins.io/exam" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Exclude\+flyweight\+tasks$" "https://plugins.jenkins.io/excludeMatrixParent" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Exclusive\+Execution\+Plugin$" "https://plugins.jenkins.io/exclusive-execution" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Exclusive\+label\+plugin$" "https://plugins.jenkins.io/exclusive-label-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Experitest\+Cloud\+Plugin$" "https://plugins.jenkins.io/experitest-cloud" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Export\+Parameters\+Plugin$" "https://plugins.jenkins.io/export-params" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Extended\+Choice\+Parameter\+plugin$" "https://plugins.jenkins.io/extended-choice-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Extensible\+Choice\+Parameter\+plugin$" "https://plugins.jenkins.io/extensible-choice-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Extension\+Filter\+Plugin$" "https://plugins.jenkins.io/extension-filter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ExtensiveTesting\+Plugin$" "https://plugins.jenkins.io/extensivetesting" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Monitoring\+external\+jobs$" "https://plugins.jenkins.io/external-monitor-job" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/External\+Workspace\+Manager\+Plugin$" "https://plugins.jenkins.io/external-workspace-manager" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Extra\+Columns\+Plugin$" "https://plugins.jenkins.io/extra-columns" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Extra\+Tool\+Installers\+Plugin$" "https://plugins.jenkins.io/extra-tool-installers" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Extreme\+Feedback\+Plugin$" "https://plugins.jenkins.io/extreme-feedback" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Extreme\+Notification\+Plugin$" "https://plugins.jenkins.io/extreme-notification" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/EZ\+Templates\+Plugin$" "https://plugins.jenkins.io/ez-templates" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/EzWall\+Plugin$" "https://plugins.jenkins.io/ezwall" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Fabric\+Beta\+Publisher\+Plugin$" "https://plugins.jenkins.io/fabric-beta-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Fail\+The\+Build\+Plugin$" "https://plugins.jenkins.io/fail-the-build-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FailedJobDeactivator\+Plugin$" "https://plugins.jenkins.io/failedJobDeactivator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Favorite\+Plugin$" "https://plugins.jenkins.io/favorite" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Favorite\+View\+Plugin$" "https://plugins.jenkins.io/favorite-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Feature\+Branch\+Notifier\+Plugin$" "https://plugins.jenkins.io/feature-branch-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Fedora\+Module\+Build\+System\+Plugin$" "https://plugins.jenkins.io/fedora-module-build-system" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Figlet\+plugin$" "https://plugins.jenkins.io/figlet-buildstep" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/File\+Leak\+Detector\+Plugin$" "https://plugins.jenkins.io/file-leak-detector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/File\+Operations\+Plugin$" "https://plugins.jenkins.io/file-operations" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Files\+Found\+Trigger$" "https://plugins.jenkins.io/files-found-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Filesystem\+List\+Parameter\+Plug\-in$" "https://plugins.jenkins.io/filesystem-list-parameter-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/File\+System\+SCM$" "https://plugins.jenkins.io/filesystem_scm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FireLine\+Plugin$" "https://plugins.jenkins.io/fireline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/HUDSON/Fitnesse\+Plugin$" "https://plugins.jenkins.io/fitnesse" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Flaky\+Test\+Handler\+Plugin$" "https://plugins.jenkins.io/flaky-test-handler" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FlashLog\+Plugin$" "https://plugins.jenkins.io/flashlog-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FlexDeploy\+Plugin$" "https://plugins.jenkins.io/flexdeploy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Flexible\+Publish\+Plugin$" "https://plugins.jenkins.io/flexible-publish" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FlexTeam\+Plugin$" "https://plugins.jenkins.io/flexteam" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Flock\+Plugin$" "https://plugins.jenkins.io/flock" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FLOW\+Plugin$" "https://plugins.jenkins.io/flow" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FluentD\+Plugin$" "https://plugins.jenkins.io/fluentd" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Flyway\+Runner\+Plugin$" "https://plugins.jenkins.io/flyway-runner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Fogbugz\+Plugin$" "https://plugins.jenkins.io/fogbugz" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Folder\+Properties\+Plugin$" "https://plugins.jenkins.io/folder-properties" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Form\+Element\+Path\+Plugin$" "https://plugins.jenkins.io/form-element-path" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Fortify\+Plugin$" "https://plugins.jenkins.io/fortify" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Frugal\+Testing\+plugin$" "https://plugins.jenkins.io/frugal-testing" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FSTrigger\+Plugin$" "https://plugins.jenkins.io/fstrigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ftp\+Rename\+Plugin$" "https://plugins.jenkins.io/ftp-rename" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FTP\-Publisher\+Plugin$" "https://plugins.jenkins.io/ftppublisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FxCop\+Runner\+Plugin$" "https://plugins.jenkins.io/fxcop-runner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gallio\+Plugin$" "https://plugins.jenkins.io/gallio" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gatling\+Plugin$" "https://plugins.jenkins.io/gatling" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gatling\+Check\+Plugin$" "https://plugins.jenkins.io/gatling-check" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Calendar\+Plugin$" "https://plugins.jenkins.io/gcal" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GCloud\+SDK\+Plugin$" "https://plugins.jenkins.io/gcloud-sdk" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gearman\+Plugin$" "https://plugins.jenkins.io/gearman-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gem\+Publisher\+Plugin$" "https://plugins.jenkins.io/gem-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GeneXus\+Plugin$" "https://plugins.jenkins.io/genexus" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gerrit\+Verify\+Status\+Reporter\+Plugin$" "https://plugins.jenkins.io/gerrit-verify-status-reporter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+pull\+request\+builder\+plugin$" "https://plugins.jenkins.io/ghprb" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Git\+Bisect$" "https://plugins.jenkins.io/git-bisect" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Git\+Chooser\+Alternative\+Plugin$" "https://plugins.jenkins.io/git-chooser-alternative" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/git\-notes\+Plugin$" "https://plugins.jenkins.io/git-notes" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Git\+Parameter\+Plugin$" "https://plugins.jenkins.io/git-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Git\+Plugin$" "https://plugins.jenkins.io/git" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Git\+Tag\+Message\+Plugin$" "https://plugins.jenkins.io/git-tag-message" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Git\+userContent\+Plugin$" "https://plugins.jenkins.io/git-userContent" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitBucket\+Plugin$" "https://plugins.jenkins.io/gitbucket" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gitcolony\+Plugin$" "https://plugins.jenkins.io/gitcolony-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gitea\+Plugin$" "https://plugins.jenkins.io/gitea" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gitee\+Plugin$" "https://plugins.jenkins.io/gitee" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gitflow\+Plugin$" "https://plugins.jenkins.io/gitflow" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Github\+Plugin$" "https://plugins.jenkins.io/github" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+and\+Stage\+Monitoring\+Plugin$" "https://plugins.jenkins.io/github-autostatus" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+Branch\+Source\+Plugin$" "https://plugins.jenkins.io/github-branch-source" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+Issues\+Plugin$" "https://plugins.jenkins.io/github-issues" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Github\+OAuth\+Plugin$" "https://plugins.jenkins.io/github-oauth" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+Organization\+Folder\+Plugin$" "https://plugins.jenkins.io/github-organization-folder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+PR\+Comment\+Build\+Plugin$" "https://plugins.jenkins.io/github-pr-comment-build" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+PR\+Coverage\+Status\+Plugin$" "https://plugins.jenkins.io/github-pr-coverage-status" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+Integration\+Plugin$" "https://plugins.jenkins.io/github-pullrequest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+Aged\+References\+SCM\+Filter\+Plugin$" "https://plugins.jenkins.io/github-scm-filter-aged-refs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+Jira\+Validator\+SCM\+Filter\+Plugin$" "https://plugins.jenkins.io/github-scm-filter-jira-validator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+Commit\+Skip\+SCM\+Behaviour\+Plugin$" "https://plugins.jenkins.io/github-scm-trait-commit-skip" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Github\+Custom\+Notification\+Context\+SCM\+Behaviour$" "https://plugins.jenkins.io/github-scm-trait-notification-context" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitHub\+SQS\+Plugin$" "https://plugins.jenkins.io/github-sqs-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gitlab\+Hook\+Plugin$" "https://plugins.jenkins.io/gitlab-hook" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gitlab\+Logo\+Plugin$" "https://plugins.jenkins.io/gitlab-logo" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gitlab\+Merge\+Request\+Builder\+Plugin$" "https://plugins.jenkins.io/gitlab-merge-request-jenkins" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gitlab\+OAuth\+Plugin$" "https://plugins.jenkins.io/gitlab-oauth" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitLab\+Plugin$" "https://plugins.jenkins.io/gitlab-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Global\+Build\+Stats\+Plugin$" "https://plugins.jenkins.io/global-build-stats" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Global\+Post\+Script\+Plugin$" "https://plugins.jenkins.io/global-post-script" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Global\+Slack\+Notifier\+Plugin$" "https://plugins.jenkins.io/global-slack-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Global\+Variable\+String\+Parameter\+Plugin$" "https://plugins.jenkins.io/global-variable-string-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gnat\+Plugin$" "https://plugins.jenkins.io/gnat" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gogs\+Webhook\+Plugin$" "https://plugins.jenkins.io/gogs-webhook" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Go\+Plugin$" "https://plugins.jenkins.io/golang" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Admin\+SDK\+Plugin$" "https://plugins.jenkins.io/google-admin-sdk" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Analytics\+Usage\+Reporter\+Plugin$" "https://plugins.jenkins.io/google-analytics-usage-reporter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+APIs\+Client\+Library$" "https://plugins.jenkins.io/google-api-client-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Chat\+Notification\+Plugin$" "https://plugins.jenkins.io/google-chat-notification" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Cloud\+Backup\+Plugin$" "https://plugins.jenkins.io/google-cloud-backup" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Health\+Check\+Plugin$" "https://plugins.jenkins.io/google-cloud-health-check" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Cloud\+Build\+Plugin$" "https://plugins.jenkins.io/google-cloudbuild" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Compute\+Engine\+Plugin$" "https://plugins.jenkins.io/google-compute-engine" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Container\+Registry\+Auth\+Plugin$" "https://plugins.jenkins.io/google-container-registry-auth" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Deployment\+Manager\+Plugin$" "https://plugins.jenkins.io/google-deployment-manager" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Git\+Notes\+Publisher\+Plugin$" "https://plugins.jenkins.io/google-git-notes-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Login\+Plugin$" "https://plugins.jenkins.io/google-login" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+OAuth\+Plugin$" "https://plugins.jenkins.io/google-oauth-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Source\+Plugin$" "https://plugins.jenkins.io/google-source-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Cloud\+Storage\+Plugin$" "https://plugins.jenkins.io/google-storage-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Analytics\+Plugin$" "https://plugins.jenkins.io/googleanalytics" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GPRbuild\+Plugin$" "https://plugins.jenkins.io/gprbuild" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gradle\+Repo\+Plugin$" "https://plugins.jenkins.io/gradle-repo" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Graphite\-plugin$" "https://plugins.jenkins.io/graphiteIntegrator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gravatar\+Plugin$" "https://plugins.jenkins.io/gravatar" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Green\+Balls$" "https://plugins.jenkins.io/greenballs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy\+plugin$" "https://plugins.jenkins.io/groovy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy%20Events%20Listener%20Plugin$" "https://plugins.jenkins.io/groovy-events-listener-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy%20Events%20Listener%20Plugin$" "https://plugins.jenkins.io/groovy-events-listener-plugin-master" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy\+Label\+Assignment\+plugin$" "https://plugins.jenkins.io/groovy-label-assignment" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy\+Postbuild\+Plugin$" "https://plugins.jenkins.io/groovy-postbuild" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy\+Remote\+Control\+Plugin$" "https://plugins.jenkins.io/groovy-remote" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Growl\+Plugin$" "https://plugins.jenkins.io/growl" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/H2\+API\+Plugin$" "https://plugins.jenkins.io/h2-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Habitat\+Plugin$" "https://plugins.jenkins.io/habitat" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Hadoop\+Plugin$" "https://plugins.jenkins.io/hadoop" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Handlebars\.js$" "https://plugins.jenkins.io/handlebars" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Handy\+Uri\+Templates\+2\+API\+Plugin$" "https://plugins.jenkins.io/handy-uri-templates-2-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Harvest\+Plugin$" "https://plugins.jenkins.io/harvest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Hckrnews\+Plugin$" "https://plugins.jenkins.io/hckrnews" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Heavy\+Job\+Plugin$" "https://plugins.jenkins.io/heavy-job" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Helix\+TeamHub\+Plugin$" "https://plugins.jenkins.io/helix-teamhub" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Help\+Editor\+Plugin$" "https://plugins.jenkins.io/help-editor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Heroku\+Plugin$" "https://plugins.jenkins.io/heroku-jenkins-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Hidden\+Parameter\+Plugin$" "https://plugins.jenkins.io/hidden-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HipChat\+Plugin$" "https://plugins.jenkins.io/hipchat" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Housekeeper\+Plugin$" "https://plugins.jenkins.io/housekeeper" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HP\+Operations\+Orchestration\+Automation\+Execution\+Plugin$" "https://plugins.jenkins.io/hp-operations-orchestration-automation-execution-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HP\+ALM\+Quality\+Center\+Plugin$" "https://plugins.jenkins.io/hp-quality-center" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HPE\+Network\+Virtualization\+Plugin$" "https://plugins.jenkins.io/hpe-network-virtualization" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HSTS\+Filter\+Plugin$" "https://plugins.jenkins.io/hsts-filter-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Html\+Audio\+Notifier$" "https://plugins.jenkins.io/html-audio-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HTML5\+Notifier\+Plugin$" "https://plugins.jenkins.io/html5-notifier-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HTML\+Publisher\+Plugin$" "https://plugins.jenkins.io/htmlpublisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HTMLResource\+Plugin$" "https://plugins.jenkins.io/htmlresource" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HTTP\+POST\+Plugin$" "https://plugins.jenkins.io/http-post" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HTTP\+Request\+Plugin$" "https://plugins.jenkins.io/http_request" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/huaweicloud\-credentials\-Plugin$" "https://plugins.jenkins.io/huaweicloud-credentials" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Hubot\+Steps\+Plugin$" "https://plugins.jenkins.io/hubot-steps" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Hudson\+Personal\+View$" "https://plugins.jenkins.io/hudson-pview-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Distributed\+Workspace\+Clean\+plugin$" "https://plugins.jenkins.io/hudson-wsclean-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/hue\-light\+Plugin$" "https://plugins.jenkins.io/hue-light" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Humbug\+Plugin$" "https://plugins.jenkins.io/humbug" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Humio\+Plugin$" "https://plugins.jenkins.io/humio" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Hyper\.sh\+Build\+Step\+Plugin$" "https://plugins.jenkins.io/hyper-build-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Hyper\.sh\+Commons\+Plugin$" "https://plugins.jenkins.io/hyper-commons" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Hyper\.sh\+Slaves\+Plugin$" "https://plugins.jenkins.io/hyper-slaves" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/IBM\+Application\+Security\+On\+Cloud\+Plugin$" "https://plugins.jenkins.io/ibm-application-security" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/IBM\+Cloud\+DevOps\+Plugin$" "https://plugins.jenkins.io/ibm-cloud-devops" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/IBM\+Continuous\+Release\+Plugin$" "https://plugins.jenkins.io/ibm-continuous-release" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/IBM\+AppScan\+Source\+Scanner\+Plugin$" "https://plugins.jenkins.io/ibm-security-appscansource-scanner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/IBM\+Security\+AppScan\+Standard\+Scanner\+Plugin$" "https://plugins.jenkins.io/ibm-security-appscanstandard-scanner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/iCEDQ\+Plugin$" "https://plugins.jenkins.io/icedq" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/iceScrum\+Plugin$" "https://plugins.jenkins.io/icescrum" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ICN\+Plugin\+Loader\+Plugin$" "https://plugins.jenkins.io/icn-plugin-loader" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Icon\+Shim\+Plugin$" "https://plugins.jenkins.io/icon-shim" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ICQ\+Notification\+Plugin$" "https://plugins.jenkins.io/icq-notification" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Idobata\+Notifier$" "https://plugins.jenkins.io/idobata-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/IFTTT\+Build\+Notifier$" "https://plugins.jenkins.io/ifttt-build-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ikachan\+Plugin$" "https://plugins.jenkins.io/ikachan" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Image\+Gallery\+Plugin$" "https://plugins.jenkins.io/image-gallery" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ImageComparison\+Plugin$" "https://plugins.jenkins.io/imagecomparison" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Implied\+Labels\+Plugin$" "https://plugins.jenkins.io/implied-labels" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/in\-toto\+Plugin$" "https://plugins.jenkins.io/in-toto" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/incapptic\+connect\+uploader$" "https://plugins.jenkins.io/incapptic-connect-uploader" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Inedo\+ProGet\+Plugin$" "https://plugins.jenkins.io/inedo-proget" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Spira\+Importer\+Plugin$" "https://plugins.jenkins.io/inflectra-spira-integration" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/InfluxDB\+Query\+Plugin$" "https://plugins.jenkins.io/influxdb-query" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Inodes\+Monitor\+Plugin$" "https://plugins.jenkins.io/inodes-monitor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/InsightAppSec\+Plugin$" "https://plugins.jenkins.io/insightappsec" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/InstallShield\+Plugin$" "https://plugins.jenkins.io/installshield" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Instant\+Messaging\+Plugin$" "https://plugins.jenkins.io/instant-messaging" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PTC\+Integrity\+Plugin$" "https://plugins.jenkins.io/integrity-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Internet\+Meme\+Plugin$" "https://plugins.jenkins.io/internetmeme" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/iOS\+Device\+Connector\+Plugin$" "https://plugins.jenkins.io/ios-device-connector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/IPMessenger\+Plugin$" "https://plugins.jenkins.io/ipmessenger-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/IRC\+Plugin$" "https://plugins.jenkins.io/ircbot" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ironmq\+Notifier$" "https://plugins.jenkins.io/ironmq-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Issue\+Link\+Plugin$" "https://plugins.jenkins.io/issue-link" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Spirent\+iTest\+Plugin$" "https://plugins.jenkins.io/itest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ivy\+Plugin$" "https://plugins.jenkins.io/ivy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ivy\+Report\+Plugin$" "https://plugins.jenkins.io/ivy-report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/IvyTrigger\+Plugin$" "https://plugins.jenkins.io/ivytrigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jabber\+Plugin$" "https://plugins.jenkins.io/jabber" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jabber\+Server\+Plugin$" "https://plugins.jenkins.io/jabber-server-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jackson\+Databind\+Plugin$" "https://plugins.jenkins.io/jackson-databind" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JaCoCo\+Plugin$" "https://plugins.jenkins.io/jacoco" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Japex\+Plugin$" "https://plugins.jenkins.io/japex" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Javadoc\+Plugin$" "https://plugins.jenkins.io/javadoc" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JavaNCSS\+Plugin$" "https://plugins.jenkins.io/javancss" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JavaTest\+Report\+Plugin$" "https://plugins.jenkins.io/javatest-report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JAXB\+Plugin$" "https://plugins.jenkins.io/jaxb" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JBoss\+Management\+Plugin$" "https://plugins.jenkins.io/jboss" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/jBPM\+workflow\+plugin$" "https://plugins.jenkins.io/jbpm-embedded-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/jBPM\+workflow\+plugin$" "https://plugins.jenkins.io/jbpm-workflow-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JCaptcha\+Plugin$" "https://plugins.jenkins.io/jcaptcha-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JDCloud\+CodeDeploy\+Plugin$" "https://plugins.jenkins.io/jdcloud-codedeploy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JDepend\+Plugin$" "https://plugins.jenkins.io/jdepend" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/AWS\+Cloudformation\+Plugin$" "https://plugins.jenkins.io/jenkins-cloudformation-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jenkins\+Design\+Language$" "https://plugins.jenkins.io/jenkins-design-language" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Flowdock\+Plugin$" "https://plugins.jenkins.io/jenkins-flowdock-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jira\+Issue\+Updater\+Plugin$" "https://plugins.jenkins.io/jenkins-jira-issue-updater" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Multijob\+Plugin$" "https://plugins.jenkins.io/jenkins-multijob-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jenkins\-Reviewbot$" "https://plugins.jenkins.io/jenkins-reviewbot" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tag\+Cloud\+Plugin$" "https://plugins.jenkins.io/jenkins-tag-cloud-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/testswarm\-plugin$" "https://plugins.jenkins.io/jenkins-testswarm-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Appspider\+Build\+Scanner\+Plugin$" "https://plugins.jenkins.io/jenkinsci-appspider-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JenkinsLint\+Plugin$" "https://plugins.jenkins.io/jenkinslint" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jenkinspider\+Plugin$" "https://plugins.jenkins.io/jenkinspider" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Wall\+Display\+Plugin$" "https://plugins.jenkins.io/jenkinswalldisplay" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JGiven\+Plugin$" "https://plugins.jenkins.io/jgiven" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jianliao\+Plugin$" "https://plugins.jenkins.io/jianliao" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jigomerge\+Plugin$" "https://plugins.jenkins.io/jigomerge" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jira\-Ext\+Plugin$" "https://plugins.jenkins.io/jira-ext" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JIRA\+Steps\+Plugin$" "https://plugins.jenkins.io/jira-steps" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JIRA\+Trigger\+Plugin$" "https://plugins.jenkins.io/jira-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JMH\+Report\+Plugin$" "https://plugins.jenkins.io/jmh-report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/jna\-posix\+API\+Plugin$" "https://plugins.jenkins.io/jna-posix-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/jnr\-posix\+API\+Plugin$" "https://plugins.jenkins.io/jnr-posix-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+Direct\+Mail\+Plugin$" "https://plugins.jenkins.io/job-direct-mail" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+DSL\+Plugin$" "https://plugins.jenkins.io/job-dsl" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+Exporter\+Plugin$" "https://plugins.jenkins.io/job-exporter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JobFanIn\+Plugin$" "https://plugins.jenkins.io/job-fan-in" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+Import\+Plugin$" "https://plugins.jenkins.io/job-import-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+Log\+Logger\+Plugin$" "https://plugins.jenkins.io/job-log-logger-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Node\+Stalker\+Plugin$" "https://plugins.jenkins.io/job-node-stalker" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+Parameter\+Summary\+Plugin$" "https://plugins.jenkins.io/job-parameter-summary" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+Poll\+Action\+Plugin$" "https://plugins.jenkins.io/job-poll-action-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+Restrictions\+Plugin$" "https://plugins.jenkins.io/job-restrictions" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+StrongAuthSimple\+Plugin$" "https://plugins.jenkins.io/job-strongauth-simple" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JobConfigHistory\+Plugin$" "https://plugins.jenkins.io/jobConfigHistory" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+Cacher\+Plugin$" "https://plugins.jenkins.io/jobcacher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jobcopy\+Builder\+plugin$" "https://plugins.jenkins.io/jobcopy-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JobDelete\+Builder\+Plugin$" "https://plugins.jenkins.io/jobdelete-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+Generator\+Plugin$" "https://plugins.jenkins.io/jobgenerator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JobRequeue\-Plugin$" "https://plugins.jenkins.io/jobrequeue" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JobRevision\+Plugin$" "https://plugins.jenkins.io/jobrevision" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/jobtemplates\+Plugin$" "https://plugins.jenkins.io/jobtemplates" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Job\+Type\+Column\+Plugin$" "https://plugins.jenkins.io/jobtype-column" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Join\+Plugin$" "https://plugins.jenkins.io/join" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JPRT\+Plugin$" "https://plugins.jenkins.io/jprt" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JQS\+Monitoring\+Plugin$" "https://plugins.jenkins.io/jqs-monitoring" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/jQuery\+Plugin$" "https://plugins.jenkins.io/jquery" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/jQuery\+Detached\+Plugin$" "https://plugins.jenkins.io/jquery-detached" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/jQuery\+UI\+Plugin$" "https://plugins.jenkins.io/jquery-ui" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JSch\+plugin$" "https://plugins.jenkins.io/jsch" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JSGames\+Plugin$" "https://plugins.jenkins.io/jsgames" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JSLint\+plugin$" "https://plugins.jenkins.io/jslint" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JSoup\+Plugin$" "https://plugins.jenkins.io/jsoup" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JSUnit\+Plugin$" "https://plugins.jenkins.io/jsunit" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JSWidgets\+Plugin$" "https://plugins.jenkins.io/jswidgets" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jucies\+plugin$" "https://plugins.jenkins.io/jucies" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JUnit\+Plugin$" "https://plugins.jenkins.io/junit" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JUnit\+Attachments\+Plugin$" "https://plugins.jenkins.io/junit-attachments" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JUnit\+Realtime\+Test\+Reporter\+Plugin$" "https://plugins.jenkins.io/junit-realtime-test-reporter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JWT\-Support\-Plugin$" "https://plugins.jenkins.io/jwt-support" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JX\+Pipelines\+Plugin$" "https://plugins.jenkins.io/jx-pipelines" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JX\+Resources\+Plugin$" "https://plugins.jenkins.io/jx-resources" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jython\+Plugin$" "https://plugins.jenkins.io/jython" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kafkalogs\+Plugin$" "https://plugins.jenkins.io/kafkalogs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kanboard\+Plugin$" "https://plugins.jenkins.io/kanboard" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Karaf\+Build\+Step\+Plugin$" "https://plugins.jenkins.io/karaf-build-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Katalon\+Plugin$" "https://plugins.jenkins.io/katalon" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Keep\+slave\+offline$" "https://plugins.jenkins.io/keepSlaveOffline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kerberos\+SSO\+Plugin$" "https://plugins.jenkins.io/kerberos-sso" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Keyboard\+Shortcuts\+Plugin$" "https://plugins.jenkins.io/keyboard-shortcuts-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/keycloak\-plugin$" "https://plugins.jenkins.io/keycloak" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kiuwan\+Plugin$" "https://plugins.jenkins.io/kiuwanJenkinsPlugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Klaros\-Testmanagement\+Plugin$" "https://plugins.jenkins.io/klaros-testmanagement" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Klocwork\+Community\+Plugin$" "https://plugins.jenkins.io/klocwork" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Keivox\+KMAP\+Private\+Mobile\+App\+Store\+Plugin$" "https://plugins.jenkins.io/kmap-jenkins" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Koji\+Plugin$" "https://plugins.jenkins.io/koji" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kotlin\+1\.x\+Standard\+Library\+for\+JDK\+8\+Plugin$" "https://plugins.jenkins.io/kotlin-v1-stdlib-jdk8" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Keychains\+and\+Provisioning\+Profiles\+Plugin$" "https://plugins.jenkins.io/kpp-management-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kubernetes\+Continuous\+Deploy\+Plugin$" "https://plugins.jenkins.io/kubernetes-cd" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kubernetes\+CI\+Plugin$" "https://plugins.jenkins.io/kubernetes-ci" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kubernetes\+Cli\+Plugin$" "https://plugins.jenkins.io/kubernetes-cli" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kubernetes\+Client\+API\+Plugin$" "https://plugins.jenkins.io/kubernetes-client-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kubernetes\+Pipeline\+Plugin$" "https://plugins.jenkins.io/kubernetes-pipeline-devops-steps" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Label\+Linked\+Jobs\+Plugin$" "https://plugins.jenkins.io/label-linked-jobs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/LabeledTestGroupsPublisher\+Plugin$" "https://plugins.jenkins.io/labeled-test-groups-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Lab\+Manager\+Plugin$" "https://plugins.jenkins.io/labmanager" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Lambda\+Test\+Runner\+Plugin$" "https://plugins.jenkins.io/lambda-test-runner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Last\+Changes\+Plugin$" "https://plugins.jenkins.io/last-changes" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Last\+Failure\+Version\+Column\+Plugin$" "https://plugins.jenkins.io/lastfailureversioncolumn" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Last\+Success\+Version\+Column\+Plugin$" "https://plugins.jenkins.io/lastsuccessversioncolumn" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/LDAP\+Plugin$" "https://plugins.jenkins.io/ldap" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/LDAP\+Email\+Plugin$" "https://plugins.jenkins.io/ldapemail" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Least\+Load\+Plugin$" "https://plugins.jenkins.io/leastload" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/leiningen\+plugin$" "https://plugins.jenkins.io/leiningen-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Lenient\+shutdown\+plugin$" "https://plugins.jenkins.io/lenientshutdown" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Libvirt\+Slaves\+Plugin$" "https://plugins.jenkins.io/libvirt-slave" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/LIFX\+notifier\+plugin$" "https://plugins.jenkins.io/lifx-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Line\+Numbers\+Plugin$" "https://plugins.jenkins.io/linenumbers" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/lingr\+Plugin$" "https://plugins.jenkins.io/lingr-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Link\+Column\+Plugin$" "https://plugins.jenkins.io/link-column" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/List\+Command\+Plugin$" "https://plugins.jenkins.io/list-command" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/List\+Git\+Branches\+Parameter\+Plugin$" "https://plugins.jenkins.io/list-git-branches-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Literate\+Plugin$" "https://plugins.jenkins.io/literate" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/LiveScreenshot\+Plugin$" "https://plugins.jenkins.io/livescreenshot" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/LoadComplete\+Support\+Plugin$" "https://plugins.jenkins.io/loadcomplete" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/loaderio$" "https://plugins.jenkins.io/loaderio-jenkins-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/LoadFocus\+Load\+Testing\+Plugin$" "https://plugins.jenkins.io/loadfocus-loadtest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Load\+Impact\+Plugin$" "https://plugins.jenkins.io/loadimpact-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Loadium\+Test\+Runner\+Plugin$" "https://plugins.jenkins.io/loadium" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/LoadNinja\+Plugin$" "https://plugins.jenkins.io/loadninja" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Locale\+Plugin$" "https://plugins.jenkins.io/locale" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Localization\+Support\+Plugin$" "https://plugins.jenkins.io/localization-support" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Locked\+Files\+Report\+Plugin$" "https://plugins.jenkins.io/locked-files-report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Log\+Parser\+Plugin$" "https://plugins.jenkins.io/log-parser" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Centralized\+Job\(Re\)Action\+Plugin$" "https://plugins.jenkins.io/logaction-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/LOGBack\+appender\+for\+NATS\+topic\+Plugin$" "https://plugins.jenkins.io/logback-nats-appender" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Logentries\+Plugin$" "https://plugins.jenkins.io/logentries" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Logfilesizechecker\+Plugin$" "https://plugins.jenkins.io/logfilesizechecker" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Logger\+Configuration$" "https://www.jenkins.io/doc/book/system-administration/viewing-logs" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Logging\+Plugin$" "https://plugins.jenkins.io/logging" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Logstash\+Plugin$" "https://plugins.jenkins.io/logstash" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Lotus\+Connections\+plugin$" "https://plugins.jenkins.io/lotus-connections-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Lucene\-Search$" "https://plugins.jenkins.io/lucene-search" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/M2\+Release\+Plugin$" "https://plugins.jenkins.io/m2release" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/mabl\+Integration$" "https://plugins.jenkins.io/mabl-integration" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mail\+Watcher\+Plugin$" "https://plugins.jenkins.io/mail-watcher-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mail\+Commander\+Plugin$" "https://plugins.jenkins.io/mailcommander" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mail\+Map\+Resolver$" "https://plugins.jenkins.io/mailmap-resolver" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Maintenance\+Jobs\+Scheduler\+Plugin$" "https://plugins.jenkins.io/maintenance-jobs-scheduler" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Managed\+Script\+Plugin$" "https://plugins.jenkins.io/managed-scripts" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mantis\+Plugin$" "https://plugins.jenkins.io/mantis" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MapDB\+API\+Plugin$" "https://plugins.jenkins.io/mapdb-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Marathon\+Plugin$" "https://plugins.jenkins.io/marathon" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mashup\+Portlets$" "https://plugins.jenkins.io/mashup-portlets-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mask\+Passwords\+Plugin$" "https://plugins.jenkins.io/mask-passwords" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mathworks\+Polyspace\+Plugin$" "https://plugins.jenkins.io/mathworks-polyspace" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/matrix\+combinations\+plugin$" "https://plugins.jenkins.io/matrix-combinations-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/matrix\+groovy\+execution\+strategy\+plugin$" "https://plugins.jenkins.io/matrix-groovy-execution-strategy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Matrix\+Project\+Plugin$" "https://plugins.jenkins.io/matrix-project" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Matrix\+Reloaded\+Plugin$" "https://plugins.jenkins.io/matrix-reloaded" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Matrix\+Tie\+Parent\+Plugin$" "https://plugins.jenkins.io/matrixtieparent" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mattermost\+Plugin$" "https://plugins.jenkins.io/mattermost" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Maven\+Artifact\+ChoiceListProvider\+Plugin$" "https://plugins.jenkins.io/maven-artifact-choicelistprovider" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Maven\+Dependency\+Update\+trigger$" "https://plugins.jenkins.io/maven-dependency-update-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Maven\+Deployment\+Linker$" "https://plugins.jenkins.io/maven-deployment-linker" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Maven\+Info\+Plugin$" "https://plugins.jenkins.io/maven-info" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Maven\+Invoker\+Plugin$" "https://plugins.jenkins.io/maven-invoker-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Maven\+Metadata\+Plugin$" "https://plugins.jenkins.io/maven-metadata-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Maven\+Project\+Plugin$" "https://plugins.jenkins.io/maven-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Maven\+Cascade\+Release\+Plugin$" "https://plugins.jenkins.io/maven-release-cascade" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Maven\+Repo\+Cleaner\+Plugin$" "https://plugins.jenkins.io/maven-repo-cleaner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mobile\+App\+Distribution\+%28MDT%29\+\+Plugin$" "https://plugins.jenkins.io/mdt-deployment" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Xamarin\+Studio\+Tool\+Runner\+Plugin$" "https://plugins.jenkins.io/mdtool" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Meme\+Generator\+Plugin$" "https://plugins.jenkins.io/memegen" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/memory\+map\+plugin$" "https://plugins.jenkins.io/memory-map" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Questa\+VRM\+Plugin$" "https://plugins.jenkins.io/mentor-questa-vrm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mercurial\+Plugin$" "https://plugins.jenkins.io/mercurial" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mesos\+Plugin$" "https://plugins.jenkins.io/mesos" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Metadata\+Plugin$" "https://plugins.jenkins.io/metadata" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Metrics\-Datadog\-Plugin$" "https://plugins.jenkins.io/metrics-datadog" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Metrics\+Disk\+Usage\+Plugin$" "https://plugins.jenkins.io/metrics-diskusage" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Metrics\+Ganglia\+Plugin$" "https://plugins.jenkins.io/metrics-ganglia" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Metrics\+Graphite\+Plugin$" "https://plugins.jenkins.io/metrics-graphite" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MICRODOCS\+INTEGRATION\+PLUGIN$" "https://plugins.jenkins.io/microdocs-integration" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Minio\+Storage\+Plugin$" "https://plugins.jenkins.io/minio-storage" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MISRA\+Compliance\+Report\+Plugin$" "https://plugins.jenkins.io/misra-compliance-report-generator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mission\+Control\+Plugin$" "https://plugins.jenkins.io/mission-control-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/mktmpio\+Plugin$" "https://plugins.jenkins.io/mktmpio" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mock\+Load\+Builder\+Plugin$" "https://plugins.jenkins.io/mock-load-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mock\+Security\+Realm\+Plugin$" "https://plugins.jenkins.io/mock-security-realm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mock\+Agent\+Plugin$" "https://plugins.jenkins.io/mock-slave" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Modern\+Status\+Plugin$" "https://plugins.jenkins.io/modernstatus" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Moment\.js$" "https://plugins.jenkins.io/momentjs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MongoDB\+Plugin$" "https://plugins.jenkins.io/mongodb" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MongoDB\+Document\+Upload\+Plugin$" "https://plugins.jenkins.io/mongodb-document-upload" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Monitor\+Pro\+Plugin$" "https://plugins.jenkins.io/monitor-pro" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MonKit\+Plugin$" "https://plugins.jenkins.io/monkit-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MQ\+Notifier\+Plugin$" "https://plugins.jenkins.io/mq-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MQTT\+Notification\+Plugin$" "https://plugins.jenkins.io/mqtt-notification-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MSBuild\+Plugin$" "https://plugins.jenkins.io/msbuild" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MsgInject\+Plugin$" "https://plugins.jenkins.io/msginject" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MSTest\+Plugin$" "https://plugins.jenkins.io/mstest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MSTestRunner\+Plugin$" "https://plugins.jenkins.io/mstestrunner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MTTR\+Plugin$" "https://plugins.jenkins.io/mttr" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Multi\-Branch\+Priority\+Sorter\+Plugin$" "https://plugins.jenkins.io/multi-branch-priority-sorter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Multi\-Branch\+Project\+Plugin$" "https://plugins.jenkins.io/multi-branch-project-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Multi\+Module\+Tests\+Publisher$" "https://plugins.jenkins.io/multi-module-tests-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Multi\+slave\+config\+plugin$" "https://plugins.jenkins.io/multi-slave-config-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Multibranch\+Build\+Strategy\+Extension\+Plugin$" "https://plugins.jenkins.io/multibranch-build-strategy-extension" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Multibranch\+Job\+Tear\+Down\+Plugin$" "https://plugins.jenkins.io/multibranch-job-tear-down" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Multibranch\+Scan\+Webhook\+Trigger\+Plugin$" "https://plugins.jenkins.io/multibranch-scan-webhook-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Multiple\+SCMs\+Plugin$" "https://plugins.jenkins.io/multiple-scms" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MySQL\+Connector\+Java\+Plugin$" "https://plugins.jenkins.io/mysql-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MyST\+Plugin$" "https://plugins.jenkins.io/myst-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Naginator\+Plugin$" "https://plugins.jenkins.io/naginator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NAnt\+Plugin$" "https://plugins.jenkins.io/nant" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NeoLoad\+Plugin$" "https://plugins.jenkins.io/neoload-jenkins-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nerrvana\+Plugin$" "https://plugins.jenkins.io/nerrvana-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nested\+View\+Plugin$" "https://plugins.jenkins.io/nested-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Netsparker\+Cloud\+Scan\+Plugin$" "https://plugins.jenkins.io/netsparker-cloud-scan" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Network\+Monitor\+Plugin$" "https://plugins.jenkins.io/network-monitor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NeuVector\+Vulnerability\+Scanner\+Plugin$" "https://plugins.jenkins.io/neuvector-vulnerability-scanner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/New\+Relic\+Deployment\+Notifier\+Plugin$" "https://plugins.jenkins.io/newrelic-deployment-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Next\+Build\+Number\+Plugin$" "https://plugins.jenkins.io/next-build-number" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nexus\+Artifact\+Uploader$" "https://plugins.jenkins.io/nexus-artifact-uploader" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nexus\+Platform\+Plugin$" "https://plugins.jenkins.io/nexus-jenkins-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nexus\+Task\+Runner\+Plugin$" "https://plugins.jenkins.io/nexus-task-runner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nirmata\+Plugin$" "https://plugins.jenkins.io/nirmata" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NIS\-notification\-lamp$" "https://plugins.jenkins.io/nis-notification-lamp" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/No\+Agent\+Job\+Purge\+Plugin$" "https://plugins.jenkins.io/no-agent-job-purge" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Node\+Iterator\+API\+Plugin$" "https://plugins.jenkins.io/node-iterator-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Node\+Sharing\+Plugin$" "https://plugins.jenkins.io/node-sharing-executor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NodeJS\+Plugin$" "https://plugins.jenkins.io/nodejs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NodeLabel\+Parameter\+Plugin$" "https://plugins.jenkins.io/nodelabelparameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Node\+Name\+Column\+Plugin$" "https://plugins.jenkins.io/nodenamecolumn" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NodePool\+Agents\+Plugin$" "https://plugins.jenkins.io/nodepool-agents" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nomad\+Plugin$" "https://plugins.jenkins.io/nomad" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TODO\+Plugin$" "https://plugins.jenkins.io/non-dynamic-hello-world" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/nopmdcheck\+Plugin$" "https://plugins.jenkins.io/nopmdcheck" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/nopmdverifytrac\+Plugin$" "https://plugins.jenkins.io/nopmdverifytrac" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Notification\+Plugin$" "https://plugins.jenkins.io/notification" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nouvola\+DiveCloud\+Plugin$" "https://plugins.jenkins.io/nouvola-divecloud" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NowSecure\+AUTO\+Jenkins\+Plugin$" "https://plugins.jenkins.io/nowsecure-auto-security-test" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NSIQ\+Collector\+Plugin$" "https://plugins.jenkins.io/nsiqcollector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nuget\+Plugin$" "https://plugins.jenkins.io/nuget/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Numeral\.js$" "https://plugins.jenkins.io/numeraljs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/NUnit\+Plugin$" "https://plugins.jenkins.io/nunit" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nutanix\+Calm\+Plugin$" "https://plugins.jenkins.io/nutanix-calm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Nvm\+Wrapper\+Plugin$" "https://plugins.jenkins.io/nvm-wrapper" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OctoPerf\+Plugin$" "https://plugins.jenkins.io/octoperf" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Offline\+Jenkins\+Installation$" "https://www.jenkins.io/doc/book/installing/#offline-jenkins-installation" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Offline\+Node\+On\+Failure\+Plugin$" "https://plugins.jenkins.io/offlineonfailure-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Openid\+Connect\+Authentication\+Plugin$" "https://plugins.jenkins.io/oic-auth" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/One\-Shot\+Executor$" "https://plugins.jenkins.io/one-shot-executor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Onesky\+Plugin$" "https://plugins.jenkins.io/onesky" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ontrack\+Plugin$" "https://plugins.jenkins.io/ontrack" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Open\+STF\+Plugin$" "https://plugins.jenkins.io/open-stf" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OpenJDK\+native\+installer\+plugin$" "https://plugins.jenkins.io/openJDK-native-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OpenEdge\+Plugin$" "https://plugins.jenkins.io/openedge" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OpenID\+Plugin$" "https://plugins.jenkins.io/openid" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OpenID4Java\+Plugin$" "https://plugins.jenkins.io/openid4java" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/openSCADA\+Exporter$" "https://plugins.jenkins.io/openscada-jenkins-exporter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OpenShift\+Client\+Plugin$" "https://plugins.jenkins.io/openshift-client" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OpenShift\+Deployer\+Plugin$" "https://plugins.jenkins.io/openshift-deployer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OpenShift\+Login\+Plugin$" "https://plugins.jenkins.io/openshift-login" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OpenShift\+Pipeline\+Plugin$" "https://plugins.jenkins.io/openshift-pipeline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OpenShift\+Sync\+Plugin$" "https://plugins.jenkins.io/openshift-sync" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Openstack\+Heat\+Plugin$" "https://plugins.jenkins.io/openstack-heat" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OpsGenie\+Plugin$" "https://plugins.jenkins.io/opsgenie" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Oracle\+Cloud\+Infrastructure\+Compute\+Plugin$" "https://plugins.jenkins.io/oracle-cloud-infrastructure-compute" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Oracle\+Cloud\+Infrastructure\+Compute\+Classic\+Plugin$" "https://plugins.jenkins.io/oracle-cloud-infrastructure-compute-classic" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OSF\+Builder\+Suite\+For\+Salesforce\+Commerce\+Cloud\+Credentials\+Plugin$" "https://plugins.jenkins.io/osf-builder-suite-for-sfcc-credentials" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OSF\+Builder\+Suite\+Standalone\+Sonar\+Linter\+Plugin$" "https://plugins.jenkins.io/osf-builder-suite-standalone-sonar-linter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OSF\+Builder\+Suite\+XML\+Linter\+Plugin$" "https://plugins.jenkins.io/osf-builder-suite-xml-linter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OSLC\+CM\+Plugin$" "https://plugins.jenkins.io/oslc-cm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OverOps\+Query\+Plugin$" "https://plugins.jenkins.io/overops-query" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ownership\+Plugin$" "https://plugins.jenkins.io/ownership" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/P4\+Plugin$" "https://plugins.jenkins.io/p4" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PaaSLane\+Estimate\+Plugin$" "https://plugins.jenkins.io/paaslane-estimate" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Package\+Drone\+Plugin$" "https://plugins.jenkins.io/package-drone" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Package\+Parameter\+Plugin$" "https://plugins.jenkins.io/package-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Packagecloud\+Plugin$" "https://plugins.jenkins.io/packagecloud" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Package\+Version\+Plugin$" "https://plugins.jenkins.io/packageversion" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Packer\+Plugin$" "https://plugins.jenkins.io/packer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PagerDuty\+Plugin$" "https://plugins.jenkins.io/pagerduty" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PAM\+Authentication\+Plugin$" "https://plugins.jenkins.io/pam-auth" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pangolin\+TestRail\+Connector$" "https://plugins.jenkins.io/pangolin-testrail-connector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Parallel\+Test\+Executor\+Plugin$" "https://plugins.jenkins.io/parallel-test-executor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Parallels\+Desktop\+Cloud\+Plugin$" "https://plugins.jenkins.io/parallels-desktop" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Parameter\+Pool\+Plugin$" "https://plugins.jenkins.io/parameter-pool" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Parameterized\+Scheduler\+Plugin$" "https://plugins.jenkins.io/parameterized-scheduler" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Parasoft\+Findings\+Plugin$" "https://plugins.jenkins.io/parasoft-findings" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Patry\+Parrot\+Status\+Plugin$" "https://plugins.jenkins.io/partyparrotstatus" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Patch\+Parameter\+Plugin$" "https://plugins.jenkins.io/patch-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pathignore\+Plugin$" "https://plugins.jenkins.io/pathignore" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PegDown\+Formatter\+Plugin$" "https://plugins.jenkins.io/pegdown-formatter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pending\+Changes\+Plugin$" "https://plugins.jenkins.io/pending-changes" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/People\+Redirector\+Plugin$" "https://plugins.jenkins.io/people-redirector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Percentage\+Disk\+Space\+Node\+Column\+Plugin$" "https://plugins.jenkins.io/percentage-du-node-column" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/MobileCloud\+for\+Jenkins\+Plugin$" "https://plugins.jenkins.io/perfectomobile" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Performance\+Plugin$" "https://plugins.jenkins.io/performance" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Performance\+Signature\+with\+Dynatrace\+Plugin$" "https://plugins.jenkins.io/performance-signature-dynatrace" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Performance\+Signature\+with\+Dynatrace\+Plugin$" "https://plugins.jenkins.io/performance-signature-dynatracesaas" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Performance\+Signature\+with\+Dynatrace\+Plugin$" "https://plugins.jenkins.io/performance-signature-ui" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Performance\+Signature\+with\+Dynatrace\+Plugin$" "https://plugins.jenkins.io/performance-signature-viewer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PerfPublisher\+Plugin$" "https://plugins.jenkins.io/perfpublisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Periodic\+Reincarnation\+Plugin$" "https://plugins.jenkins.io/periodic-reincarnation" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PeriodicBackup\+Plugin$" "https://plugins.jenkins.io/periodicbackup" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Permissive\+Script\+Security\+Plugin$" "https://plugins.jenkins.io/permissive-script-security" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Persistent\+Build\+Queue\+Plugin$" "https://plugins.jenkins.io/persistent-build-queue-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Persistent\+Parameter\+Plugin$" "https://plugins.jenkins.io/persistent-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Persona\+Plugin$" "https://plugins.jenkins.io/persona" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Phabricator\+Differential\+Plugin$" "https://plugins.jenkins.io/phabricator-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Phing\+Plugin$" "https://plugins.jenkins.io/phing" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Phoenix\+Autotest\+Plugin$" "https://plugins.jenkins.io/phoenix-autotest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PHP\+Plugin$" "https://plugins.jenkins.io/php" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PHP\+Built\-in\+Web\+Server\+Plugin$" "https://plugins.jenkins.io/php-builtin-web-server" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PikeTec\+TPT\+Plugin$" "https://plugins.jenkins.io/piketec-tpt" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Aggregator\+View$" "https://plugins.jenkins.io/pipeline-aggregator-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+API\+Plugin" "https://plugins.jenkins.io/workflow-api" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Pipeline\+AWS\+Plugin$" "https://plugins.jenkins.io/pipeline-aws" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Bamboo\+Plugin$" "https://plugins.jenkins.io/pipeline-bamboo" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Basic\+Steps\+Plugin" "https://plugins.jenkins.io/workflow-basic-steps/" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Pipeline\+CloudWatch\+Logs\+Plugin$" "https://plugins.jenkins.io/pipeline-cloudwatch-logs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Configuration\+History$" "https://plugins.jenkins.io/pipeline-config-history" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Dependency\+Walker\+Plugin$" "https://plugins.jenkins.io/pipeline-dependency-walker" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Deploymon\+Plugin$" "https://plugins.jenkins.io/pipeline-deploymon" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Github\+Plugin$" "https://plugins.jenkins.io/pipeline-github" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+GitHub\+Library\+Plugin$" "https://plugins.jenkins.io/pipeline-github-lib" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Githubnotify\+Step\+Plugin$" "https://plugins.jenkins.io/pipeline-githubnotify-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/GitStatusWrapper\+Plugin$" "https://plugins.jenkins.io/pipeline-gitstatuswrapper" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Graph\+Analysis\+Plugin$" "https://plugins.jenkins.io/pipeline-graph-analysis" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+HuaweiCloud\+Plugin$" "https://plugins.jenkins.io/pipeline-huaweicloud-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Input\+Step\+Plugin$" "https://plugins.jenkins.io/pipeline-input-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Maven\+Plugin$" "https://plugins.jenkins.io/pipeline-maven" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Milestone\+Step\+Plugin$" "https://plugins.jenkins.io/pipeline-milestone-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Model\+Definition\+Plugin$" "https://plugins.jenkins.io/pipeline-model-definition" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Multibranch\+Defaults\+Plugin$" "https://plugins.jenkins.io/pipeline-multibranch-defaults" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+NPM\+Plugin$" "https://plugins.jenkins.io/pipeline-npm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Stage\+View\+Plugin$" "https://plugins.jenkins.io/pipeline-rest-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Workflow\+restFul\+API\+Plugin$" "https://plugins.jenkins.io/pipeline-restful-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Stage\+Step\+Plugin$" "https://plugins.jenkins.io/pipeline-stage-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Stage\+View\+Plugin$" "https://plugins.jenkins.io/pipeline-stage-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+timeline$" "https://plugins.jenkins.io/pipeline-timeline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Utility\+Steps\+Plugin$" "https://plugins.jenkins.io/pipeline-utility-steps" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/pitmutation$" "https://plugins.jenkins.io/pitmutation" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Piwik\+Analytics\+Plugin$" "https://plugins.jenkins.io/piwikanalytics" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Plain\+Credentials\+Plugin$" "https://plugins.jenkins.io/plain-credentials" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PlasticSCM\+MergeBot\+plugin$" "https://plugins.jenkins.io/plasticscm-mergebot" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Play%21\+Framework\+Plugin$" "https://plugins.jenkins.io/play-autotest-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Plot\+Plugin$" "https://plugins.jenkins.io/plot" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Plugin\+Usage\+Plugin\+\(Community\)$" "https://plugins.jenkins.io/plugin-usage-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Polarion\+Plugin$" "https://plugins.jenkins.io/polarion" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PolicyCenter\+Gate\+Validator\+Plugin$" "https://plugins.jenkins.io/policycenter-gate-validator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Poll%20Mailbox%20Trigger%20Plugin$" "https://plugins.jenkins.io/poll-mailbox-trigger-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PollSCM\+Plugin$" "https://plugins.jenkins.io/pollscm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pom2Config\+Plugin$" "https://plugins.jenkins.io/pom2config" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Port\+Allocator\+Plugin$" "https://plugins.jenkins.io/port-allocator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Post\+Completed\+Build\+Result\+Plugin$" "https://plugins.jenkins.io/post-completed-build-result" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Post\+build\+task$" "https://plugins.jenkins.io/postbuild-task" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PostgreSQL\+API\+Plugin$" "https://plugins.jenkins.io/postgresql-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pragprog\+Plugin$" "https://plugins.jenkins.io/pragprog" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/pre\-scm\-buildstep$" "https://plugins.jenkins.io/preSCMbuildstep" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Prerequisite\+build\+step\+plugin$" "https://plugins.jenkins.io/prereq-buildstep" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pretested\+Integration\+Plugin$" "https://plugins.jenkins.io/pretested-integration" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Probely\+Security\+Scanner\+Plugin$" "https://plugins.jenkins.io/probely-security" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Process\+Cleaner\+Plugin$" "https://plugins.jenkins.io/proc-cleaner-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Progress\+Bar\+Column\+Plugin$" "https://plugins.jenkins.io/progress-bar-column-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Project\+Build\+Times$" "https://plugins.jenkins.io/project-build-times" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Project\+Description\+Setter\+Plugin$" "https://plugins.jenkins.io/project-description-setter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Project\+Health\+Report\+Plugin$" "https://plugins.jenkins.io/project-health-report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/inheritance\-plugin$" "https://plugins.jenkins.io/project-inheritance" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Project\+Statistics\+Plugin$" "https://plugins.jenkins.io/project-stats-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Prometheus\+Plugin$" "https://plugins.jenkins.io/prometheus" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Promoted\+Builds\+Simple\+Plugin$" "https://plugins.jenkins.io/promoted-builds-simple" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Protecode\+SC\+Plugin$" "https://plugins.jenkins.io/protecode-sc" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Proxmox\+Plugin$" "https://plugins.jenkins.io/proxmox" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pry\+Plugin$" "https://plugins.jenkins.io/pry" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Publish\+Over\+CIFS\+Plugin$" "https://plugins.jenkins.io/publish-over-cifs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Publish\+over\+Dropbox\+Plugin$" "https://plugins.jenkins.io/publish-over-dropbox" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Publish\+Over\+FTP\+Plugin$" "https://plugins.jenkins.io/publish-over-ftp" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Publish\+Over\+SSH\+Plugin$" "https://plugins.jenkins.io/publish-over-ssh" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Publish\+to\+Bitbucket\+Plugin$" "https://plugins.jenkins.io/publish-to-bitbucket" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PubSub\+Light\+Plugin$" "https://plugins.jenkins.io/pubsub-light" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Puppet\+Plugin$" "https://plugins.jenkins.io/puppet" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Purge\+Build\+Queue\+Plugin$" "https://plugins.jenkins.io/purge-build-queue-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PVCS\+SCM$" "https://plugins.jenkins.io/pvcs_scm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/pwauth$" "https://plugins.jenkins.io/pwauth" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pyenv\+Plugin$" "https://plugins.jenkins.io/pyenv" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pyenv\+Pipeline\+Plugin$" "https://plugins.jenkins.io/pyenv-pipeline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Python\+Plugin$" "https://plugins.jenkins.io/python" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Python\+Wrapper\+Plugin$" "https://plugins.jenkins.io/python-wrapper" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/HUDSON/Quality\+Center\+Plugin$" "https://plugins.jenkins.io/qc" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/QF\-Test\+Plugin$" "https://plugins.jenkins.io/qftest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/QMetry\+For\+Jira\+Test\+Management\+Plugin$" "https://plugins.jenkins.io/qmetry-for-jira-test-management" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/QMetry\+Test\+Managment\+Plugin$" "https://plugins.jenkins.io/qmetry-test-management" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/QRebel\+Plugin$" "https://plugins.jenkins.io/qrebel" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/qTest\+for\+Jenkins\+by\+Tricentis$" "https://plugins.jenkins.io/qtest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Quality\+Gates\+Plugin$" "https://plugins.jenkins.io/quality-gates" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Quay\.io\+Trigger\+Plugin$" "https://plugins.jenkins.io/quayio-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Queue\+Cleanup\+Plugin$" "https://plugins.jenkins.io/queue-cleanup" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Qy\+Wechat\+Notification\+Plugin$" "https://plugins.jenkins.io/qy-wechat-notification" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/R\+Plugin$" "https://plugins.jenkins.io/r" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RabbitMQ\+Build\+Trigger\+Plugin$" "https://plugins.jenkins.io/rabbitmq-build-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RabbitMQ\+Consumer\+Plugin$" "https://plugins.jenkins.io/rabbitmq-consumer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RabbitMQ\+Publisher\+Plugin$" "https://plugins.jenkins.io/rabbitmq-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RAD\+Builder\+Plugin$" "https://plugins.jenkins.io/rad-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RadarGun\+plugin$" "https://plugins.jenkins.io/radargun" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Radargun\-Reporting\+Plugin$" "https://plugins.jenkins.io/radargun-reporting" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Radiator\+View\+Plugin$" "https://plugins.jenkins.io/radiatorviewplugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Rake\+Plugin$" "https://plugins.jenkins.io/rake" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Rally\+plugin$" "https://plugins.jenkins.io/rally-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/rallyBuild$" "https://plugins.jenkins.io/rallyBuild" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Rancher\+Plugin$" "https://plugins.jenkins.io/rancher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Random\+Job\+Builder\+Plugin$" "https://plugins.jenkins.io/random-job-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Random\+String\+Parameter\+Plugin$" "https://plugins.jenkins.io/random-string-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Rapid7\+InsightVM\+Container\+Assessment\+Plugin$" "https://plugins.jenkins.io/rapid7-insightvm-container-assessment" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RapidDeploy\+Plugin$" "https://plugins.jenkins.io/rapiddeploy-jenkins" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Rbenv\+Plugin$" "https://plugins.jenkins.io/rbenv" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Read\-only\+configurations\+plugin$" "https://plugins.jenkins.io/read-only-configurations" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Readonly\+Parameter\+Plugin$" "https://plugins.jenkins.io/readonly-parameters" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Rebuild\+Plugin$" "https://plugins.jenkins.io/rebuild" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Recipe\+Plugin$" "https://plugins.jenkins.io/recipe" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Redgate\+SQL\+Change\+Automation\+Plugin$" "https://plugins.jenkins.io/redgate-sql-ci" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Redmine\+Plugin$" "https://plugins.jenkins.io/redmine" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Redmine\+Metrics\+Report\+Plugin$" "https://plugins.jenkins.io/redmine-metrics-report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/reFit\+Plugin$" "https://plugins.jenkins.io/refit" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Regression\+Report\+Plugin$" "https://plugins.jenkins.io/regression-report-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Release\+Plugin$" "https://plugins.jenkins.io/release" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Release\+Helper\+Plugin$" "https://plugins.jenkins.io/release-helper" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Relution\-Publisher$" "https://plugins.jenkins.io/relution-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Remote\+Jobs\+View\+Plugin$" "https://plugins.jenkins.io/remote-jobs-view-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Remote\+Terminal\+Access\+Plugin$" "https://plugins.jenkins.io/remote-terminal-access" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Report\+Info\+Plugin$" "https://plugins.jenkins.io/report-info" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ReportPortal\+Plugin$" "https://plugins.jenkins.io/reportportal" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jenkins\+Maven\+Repository\+Server$" "https://plugins.jenkins.io/repository" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Repository\+Connector\+Plugin$" "https://plugins.jenkins.io/repository-connector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Reqtify\+Plugin$" "https://plugins.jenkins.io/reqtify" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Requests\+Plugin$" "https://plugins.jenkins.io/requests" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Resource\+Disposer\+Plugin$" "https://plugins.jenkins.io/resource-disposer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Restricted\+Registration\+Plugin$" "https://plugins.jenkins.io/restricted-register" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Results\+Cache\+Plugin$" "https://plugins.jenkins.io/results-cache" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Reverse\+Proxy\+Auth\+Plugin$" "https://plugins.jenkins.io/reverse-proxy-auth-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Rich\+Text\+Publisher\+Plugin$" "https://plugins.jenkins.io/rich-text-publisher-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Rigor\+Optimization\+Plugin$" "https://plugins.jenkins.io/rigor-optimization" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RPi\+Build\+Status\+Plugin$" "https://plugins.jenkins.io/rpi-build-status" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RQM\+plugin$" "https://plugins.jenkins.io/rqm-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Request\+Rename\+Or\+Delete\+Plugin$" "https://plugins.jenkins.io/rrod" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ruby\+Runtime\+Plugin$" "https://plugins.jenkins.io/ruby-runtime" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RubyMetrics\+plugin$" "https://plugins.jenkins.io/rubyMetrics" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jenkins\+RubyMotion\+Plugin$" "https://plugins.jenkins.io/rubymotion" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Run\+Condition\+Plugin$" "https://plugins.jenkins.io/run-condition" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Run\+Condition\+Extras\+Plugin$" "https://plugins.jenkins.io/run-condition-extras" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RunDeck\+Plugin$" "https://plugins.jenkins.io/rundeck" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Runscope\+Plugin$" "https://plugins.jenkins.io/runscope" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Russian\+Salad\+Test\+Report\+Plugin$" "https://plugins.jenkins.io/rusalad-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/RVM\+Plugin$" "https://plugins.jenkins.io/rvm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/S3\+Plugin$" "https://plugins.jenkins.io/s3" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SafeRestart\+Plugin$" "https://plugins.jenkins.io/saferestart" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sahagin\+Plugin$" "https://plugins.jenkins.io/sahagin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Salesforce\+Migration\+Assistant\+Plugin$" "https://plugins.jenkins.io/salesforce-migration-assistant-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/saltstack\-plugin$" "https://plugins.jenkins.io/saltstack" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SameTime\+Plugin$" "https://plugins.jenkins.io/sametime" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SASUnit\+Plugin$" "https://plugins.jenkins.io/sasunit-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sauce\+OnDemand\+Plugin$" "https://plugins.jenkins.io/sauce-ondemand" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/sbt\+plugin$" "https://plugins.jenkins.io/sbt" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Scala\+JUnit\+Name\+Decoder\+Plugin$" "https://plugins.jenkins.io/scala-junit-name-decoder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Amazon\+EC2\+Container\+Service\+Plugin$" "https://plugins.jenkins.io/scalable-amazon-ecs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Schedule\+Build\+Plugin$" "https://plugins.jenkins.io/schedule-build" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SCM\+API\+Plugin$" "https://plugins.jenkins.io/scm-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SCM\+HttpClient\+Plugin$" "https://plugins.jenkins.io/scm-httpclient" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SCM\+SQS\+Plugin$" "https://plugins.jenkins.io/scm-sqs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SCM\+Sync\+configuration\+plugin$" "https://plugins.jenkins.io/scm-sync-configuration" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SCM2Job\+Plugin$" "https://plugins.jenkins.io/scm2job" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SCM\+Skip\+Plugin$" "https://plugins.jenkins.io/scmskip" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SCons\+Plugin$" "https://plugins.jenkins.io/scons" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Scoring\+Load\+Balancer\+plugin$" "https://plugins.jenkins.io/scoring-load-balancer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Scoverage\+Plugin$" "https://plugins.jenkins.io/scoverage" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SCP\+plugin$" "https://plugins.jenkins.io/scp" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Script\+Security\+Realm$" "https://plugins.jenkins.io/script-realm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Scripted\+Cloud\+plugin$" "https://plugins.jenkins.io/scripted-cloud-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Scriptler\+Plugin$" "https://plugins.jenkins.io/scriptler" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SDElements\+Plugin$" "https://plugins.jenkins.io/sdelements" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/All\+searched\+results\+plugin$" "https://plugins.jenkins.io/search-all-results-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/secondary\-timestamper\-plugin$" "https://plugins.jenkins.io/secondary-timestamper-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sectioned\+View\+Plugin$" "https://plugins.jenkins.io/sectioned-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Security\+Inspector\+Plugin$" "https://plugins.jenkins.io/security-inspector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Seed\+Plugin$" "https://plugins.jenkins.io/seed" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tests\+Selector\+Plugin$" "https://plugins.jenkins.io/selected-tests-executor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Selection\+Tasks\+Plugin$" "https://plugins.jenkins.io/selection-tasks-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Selenium\+Plugin$" "https://plugins.jenkins.io/selenium" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Selenium\+AES\+Plugin$" "https://plugins.jenkins.io/selenium-aes" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Selenium\+Axis\+Plugin$" "https://plugins.jenkins.io/selenium-axis" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Selenium\+Builder\+Plugin$" "https://plugins.jenkins.io/selenium-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/seleniumhtmlreport\+Plugin$" "https://plugins.jenkins.io/seleniumhtmlreport" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SeleniumRC\+Plugin$" "https://plugins.jenkins.io/seleniumrc-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Selfie\+Trigger\+Plugin$" "https://plugins.jenkins.io/selfie-trigger-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/semantic\-versioning\-plugin$" "https://plugins.jenkins.io/semantic-versioning-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Send\+stacktrace\+to\+eclipse\+plugin$" "https://plugins.jenkins.io/send-stacktrace-to-eclipse-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sensedia\+Api\+Platform\+Plugin$" "https://plugins.jenkins.io/sensedia-api-platform" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Serenity\+Plugin$" "https://plugins.jenkins.io/serenity" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Service\+Fabric\+Plugin$" "https://plugins.jenkins.io/service-fabric" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Service\+Now\+Plugin$" "https://plugins.jenkins.io/service-now" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SharedObjects\+Plugin$" "https://plugins.jenkins.io/shared-objects" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Shared\+workspace\+plugin$" "https://plugins.jenkins.io/shared-workspace" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Shelve\+Project\+Plugin$" "https://plugins.jenkins.io/shelve-project-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ShiningPanda\+Plugin$" "https://plugins.jenkins.io/shiningpanda" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Short\+Workspace\+Path\+Plugin$" "https://plugins.jenkins.io/short-workspace-path" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Show\+Build\+Parameters\+Plugin$" "https://plugins.jenkins.io/show-build-parameters" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SICCI\+for\+Xcode\+Plugin$" "https://plugins.jenkins.io/sicci_for_xcode" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sidebar\-Link\+Plugin$" "https://plugins.jenkins.io/sidebar-link" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sidebar\+Update\+Notification\+Plugin$" "https://plugins.jenkins.io/sidebar-update-notification" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Signal\+killer$" "https://plugins.jenkins.io/signal-killer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Silk\+Performer\+Plugin$" "https://plugins.jenkins.io/silk-performer-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Simple\+Build\+For\+Pipeline\+Plugin$" "https://plugins.jenkins.io/simple-build-for-pipeline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Simple\+Parameterized\+Builds\+Report\+plugin$" "https://plugins.jenkins.io/simple-parameterized-builds-report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TODO\+Plugin$" "https://plugins.jenkins.io/simple-pull-request-job" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Simple\+Theme\+Plugin$" "https://plugins.jenkins.io/simple-theme-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SimpleClearCase\-Plugin$" "https://plugins.jenkins.io/simpleclearcase" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SimpleUpdateSite\+Plugin$" "https://plugins.jenkins.io/simpleupdatesite" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Chef\+Sinatra\+Jenkins\+Plugin$" "https://plugins.jenkins.io/sinatra-chef-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Single\+Use\+Slave\+Plugin$" "https://plugins.jenkins.io/singleuseslave" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SiteMonitor\+Plugin$" "https://plugins.jenkins.io/sitemonitor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Skip\+Certificate\+Check\+plugin$" "https://plugins.jenkins.io/skip-certificate-check" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Skype\+Plugin$" "https://plugins.jenkins.io/skype-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Skytap\+Cloud\+CI\+Plugin$" "https://plugins.jenkins.io/skytap" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Slack\+File\+Uploader\+Plugin$" "https://plugins.jenkins.io/slack-uploader" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SLAdiator\+plugin$" "https://plugins.jenkins.io/sladiator-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Slave\+Prerequisites\+Plugin$" "https://plugins.jenkins.io/slave-prerequisites" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Slave\+HTTP\+Proxy\+Plugin$" "https://plugins.jenkins.io/slave-proxy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Slave\+Setup\+Plugin$" "https://plugins.jenkins.io/slave-setup" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Slave\+Squatter\+Plugin$" "https://plugins.jenkins.io/slave-squatter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/slave\-status$" "https://plugins.jenkins.io/slave-status" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Slave\+Utilization\+Plugin$" "https://plugins.jenkins.io/slave-utilization-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SLOCCount\+Plugin$" "https://plugins.jenkins.io/sloccount" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SmallTest\+Plugin$" "https://plugins.jenkins.io/smalltest" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Smart\+Jenkins$" "https://plugins.jenkins.io/smart-jenkins" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SmartFrog\+Plugin$" "https://plugins.jenkins.io/smartfrog-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SMS\+Notification$" "https://plugins.jenkins.io/sms" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SnowGlobe\+Plugin$" "https://plugins.jenkins.io/snowglobe" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Amazon\+SNS\+Notifier$" "https://plugins.jenkins.io/snsnotify" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Snyk\+Security\+Plugin$" "https://plugins.jenkins.io/snyk-security-scanner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sofy\.ai\+Plugin$" "https://plugins.jenkins.io/sofy-ai" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SonarQube\+plugin$" "https://plugins.jenkins.io/sonar" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sonar\+Gerrit$" "https://plugins.jenkins.io/sonar-gerrit" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sonargraph\+Integration\+Plugin$" "https://plugins.jenkins.io/sonargraph-integration" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sonargraph\+Plugin$" "https://plugins.jenkins.io/sonargraph-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jenkins\+Sounds\+plugin$" "https://plugins.jenkins.io/sounds" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SourceMonitor\+Plugin$" "https://plugins.jenkins.io/sourcemonitor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TurboScript\+Plugin$" "https://plugins.jenkins.io/spoonscript" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Spotinst\+Plugin$" "https://plugins.jenkins.io/spotinst" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Spring\+Initializr\+Plugin$" "https://plugins.jenkins.io/spring-initalzr" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SQLPlus\+Script\+Runner\+Plugin$" "https://plugins.jenkins.io/sqlplus-script-runner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Squash4Jenkins\+Plugin$" "https://plugins.jenkins.io/squashtm-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Serena\+Deploy\+Plugin$" "https://plugins.jenkins.io/sra-deploy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SourceClear\+Installer\+Plugin$" "https://plugins.jenkins.io/srcclr-installer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SSE\+Gateway\+Plugin$" "https://plugins.jenkins.io/sse-gateway" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SSH\+plugin$" "https://plugins.jenkins.io/ssh" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SSH\+Steps\+Plugin$" "https://plugins.jenkins.io/ssh-steps" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SSH2Easy\+Plugin$" "https://plugins.jenkins.io/ssh2easy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Stack\+Hammer\+Plugin$" "https://plugins.jenkins.io/stackhammer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Stackify\+Deployment\+Recorder\+Plugin$" "https://plugins.jenkins.io/stackify-deployment-recorder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/StarTeam$" "https://plugins.jenkins.io/starteam" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Started\-By\+Environment\+Variable\+Plugin$" "https://plugins.jenkins.io/started-by-envvar" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Startup\+Trigger$" "https://plugins.jenkins.io/startup-trigger-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+\(Stash\)\+Notifier\+Plugin$" "https://plugins.jenkins.io/stashNotifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Statistics\+Gatherer\+Plugin$" "https://plugins.jenkins.io/statistics-gatherer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Status\+Monitor\+Plugin$" "https://plugins.jenkins.io/statusmonitor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Step\+Counter\+Plugin$" "https://plugins.jenkins.io/stepcounter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/StoplightIO\+Report\+Plugin$" "https://plugins.jenkins.io/stoplightio-report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Storable\+Configs\+Plugin$" "https://plugins.jenkins.io/storable-configs-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Strawboss\+Plugin$" "https://plugins.jenkins.io/strawboss" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Structs\+plugin$" "https://plugins.jenkins.io/structs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Suite\+Test\+Groups\+Publisher$" "https://plugins.jenkins.io/suite-test-groups-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Summary\+Display\+Plugin$" "https://plugins.jenkins.io/summary_report" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sumologic\+Publisher\+Plugin$" "https://plugins.jenkins.io/sumologic-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Support\+Core\+Plugin$" "https://plugins.jenkins.io/support-core" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Suppress\+Stack\+Trace\+Plugin$" "https://plugins.jenkins.io/suppress-stack-trace" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SVN\+Partial\+Release\+Manager\+Plugin$" "https://plugins.jenkins.io/svn-partial-release-mgr" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SVN\+Revert\+Plugin$" "https://plugins.jenkins.io/svn-revert-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SVN\+Workspace\+Cleaner$" "https://plugins.jenkins.io/svn-workspace-cleaner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SVNCompat13\+Plugin$" "https://plugins.jenkins.io/svncompat13" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SVNCompat14\+Plugin$" "https://plugins.jenkins.io/svncompat14" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Subversion\+Merge\+Plugin$" "https://plugins.jenkins.io/svnmerge" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SWAMP\+Plugin$" "https://plugins.jenkins.io/swamp" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Swarm\+Plugin$" "https://plugins.jenkins.io/swarm" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SWEAGLE\+Plugin$" "https://plugins.jenkins.io/sweagle" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Synergy\+Plugin$" "https://plugins.jenkins.io/synergy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Synopsys\+Coverity\+Plugin$" "https://plugins.jenkins.io/synopsys-coverity" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Sysdig\+Secure\+Jenkins\+Plugin$" "https://plugins.jenkins.io/sysdig-secure" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Syslog\+Logger\+Plugin$" "https://plugins.jenkins.io/syslog-logger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/System\+Load\+Average\+Monitor\+Plugin$" "https://plugins.jenkins.io/systemloadaverage-monitor" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tag\+Profiler\+Plugin$" "https://plugins.jenkins.io/tag-profiler" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tanaguru\+plugin$" "https://plugins.jenkins.io/tanaguru" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TAP\+Plugin$" "https://plugins.jenkins.io/tap" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tattletale\+Plugin$" "https://plugins.jenkins.io/tattletale-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Team\+Views\+Plugin$" "https://plugins.jenkins.io/team-views" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Team\+Concert\+Plugin$" "https://plugins.jenkins.io/teamconcert" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Team\+Concert\+Git\+Plugin$" "https://plugins.jenkins.io/teamconcert-git" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Telegram\+Notification\+Plugin$" "https://plugins.jenkins.io/telegram-notifications" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Template\+Project\+Plugin$" "https://plugins.jenkins.io/template-project" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Template\+Workflows\+Plugin$" "https://plugins.jenkins.io/template-workflows" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Templating\+Engine\+Plugin$" "https://plugins.jenkins.io/templating-engine" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Terminal\+Plugin$" "https://plugins.jenkins.io/terminal" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ssh\+processes\+check\+plugin$" "https://plugins.jenkins.io/terminate-ssh-processes-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Terraform\+Plugin$" "https://plugins.jenkins.io/terraform" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Test\+Results\+Analyzer\+Plugin$" "https://plugins.jenkins.io/test-results-analyzer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Test\+stability\+plugin$" "https://plugins.jenkins.io/test-stability" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Test\+In\+Progress\+Plugin$" "https://plugins.jenkins.io/testInProgress" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Testability\+Explorer\+Plugin$" "https://plugins.jenkins.io/testabilityexplorer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TestComplete\+xUnit\+Plugin$" "https://plugins.jenkins.io/testcomplete-xunit" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TestComplete\+11\+and\+12\+xUnit\+Plugin$" "https://plugins.jenkins.io/testcomplete11-xunit" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbar\+Run\+In\+Cloud\+Plugin$" "https://plugins.jenkins.io/testdroid-run-in-cloud" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Testinium\+Plugin$" "https://plugins.jenkins.io/testinium" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TestLink\+Plugin$" "https://plugins.jenkins.io/testlink" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/testng\-plugin$" "https://plugins.jenkins.io/testng-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Test\-Odyssey\+Execution\+Plugin$" "https://plugins.jenkins.io/testodyssey-execution" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Testopia\+Plugin$" "https://plugins.jenkins.io/testopia" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TestProject\+Plugin$" "https://plugins.jenkins.io/testproject" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TestQuality\+Updater\+Plugin$" "https://plugins.jenkins.io/testquality-updater" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Progress\+TestStudio\+Plugin$" "https://plugins.jenkins.io/teststudio" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Progress\+TestStudio\+for\+API\+Plugin$" "https://plugins.jenkins.io/teststudioapitesting" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Progress\+MobileStudio\+Plugin$" "https://plugins.jenkins.io/teststudiomobiletesting" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TestWeaver\+Plugin$" "https://plugins.jenkins.io/testweaver" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Text\+File\+Operations\+Plugin$" "https://plugins.jenkins.io/text-file-operations" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Text\-finder\+Plugin$" "https://plugins.jenkins.io/text-finder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Text\+Finder\+Run\+Condition\+Plugin$" "https://plugins.jenkins.io/text-finder-run-condition" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Team\+Foundation\+Server\+Plugin$" "https://plugins.jenkins.io/tfs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Themis\+Plugin$" "https://plugins.jenkins.io/themis" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/thinBackup$" "https://plugins.jenkins.io/thinBackup" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Thread\+Dump\+Action\+Plugin$" "https://plugins.jenkins.io/thread-dump-action-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Threadfix\+Plugin$" "https://plugins.jenkins.io/threadfix" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Throttle\+Concurrent\+Builds\+Plugin$" "https://plugins.jenkins.io/throttle-concurrents" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Thucydides\+Plugin$" "https://plugins.jenkins.io/thucydides" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tibco\+Builder\+Plugin$" "https://plugins.jenkins.io/tibco-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Timestamper$" "https://plugins.jenkins.io/timestamper" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tinfoil\+Security\+Plugin$" "https://plugins.jenkins.io/tinfoil-scan" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Test\+Management\+for\+Jira$" "https://plugins.jenkins.io/tm4j-automation" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tmp\+Cleaner\+Plugin$" "https://plugins.jenkins.io/tmpcleaner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tool\+Labels\+Plugin$" "https://plugins.jenkins.io/tool-labels-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tool\+Environment\+Plugin$" "https://plugins.jenkins.io/toolenv" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/jenkins/Trac\+Plugin$" "https://plugins.jenkins.io/trac" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Trac\+Publisher\+Plugin$" "https://plugins.jenkins.io/trac-publisher-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tracking\+Git\+Plugin$" "https://plugins.jenkins.io/tracking-git" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tracking\+SVN\+Plugin$" "https://plugins.jenkins.io/tracking-svn" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Transifex\+Plugin$" "https://plugins.jenkins.io/transifex" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Translation\+Assistance\+Plugin$" "https://plugins.jenkins.io/translation" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Travis\+YML\+Plugin$" "https://plugins.jenkins.io/travis-yml" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Troubleshooting\+articles$" "https://www.jenkins.io/doc/book/getting-started" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tricentis\+Continuous\+Integration$" "https://plugins.jenkins.io/tricentis-ci" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Tuleap\+Git\+Branch\+Source\+Plugin$" "https://plugins.jenkins.io/tuleap-git-branch-source" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/TuxDroid\+Plugin$" "https://plugins.jenkins.io/tuxdroid" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Twitter\+Plugin$" "https://plugins.jenkins.io/twitter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Typetalk\+Plugin$" "https://plugins.jenkins.io/typetalk" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/UI\+Samples\+Plugin$" "https://plugins.jenkins.io/ui-samples-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/UI\+Test\+Capture\+Plugin$" "https://plugins.jenkins.io/ui-test-capture" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/UiPath\+Plugin$" "https://plugins.jenkins.io/uipath-automation-package" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Unicorn\+Validation\+Plugin$" "https://plugins.jenkins.io/unicorn" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Unique\+Id\+Plugin$" "https://plugins.jenkins.io/unique-id" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Unity3dBuilder\+Plugin$" "https://plugins.jenkins.io/unity3d-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Unleash\+Plugin$" "https://plugins.jenkins.io/unleash" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Unreliable\+slave\+plugin$" "https://plugins.jenkins.io/unreliable-slave-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/UpdateSites\+Manager\+plugin$" "https://plugins.jenkins.io/update-sites-manager" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Updatebot\+Plugin$" "https://plugins.jenkins.io/updatebot" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Upload\+Pgyer\+Plugin$" "https://plugins.jenkins.io/upload-pgyer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Upstream\+Downstream\+View\+Plugin$" "https://plugins.jenkins.io/upstream-downstream-view" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Uptime\+Plugin$" "https://plugins.jenkins.io/uptime" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/URL\+Auth\+SSO\+Plugin$" "https://plugins.jenkins.io/url-auth-sso" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/URLTrigger\+Plugin$" "https://plugins.jenkins.io/urltrigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/useMango\+Runner\+Plugin$" "https://plugins.jenkins.io/usemango-runner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/User1st\+uTester\+Plugin$" "https://plugins.jenkins.io/user1st-utester" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/utplsql\+Plugin$" "https://plugins.jenkins.io/utplsql" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VAddy\+Plugin$" "https://plugins.jenkins.io/vaddy-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Vagrant\-plugin$" "https://plugins.jenkins.io/vagrant" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Valgrind\+Plugin$" "https://plugins.jenkins.io/valgrind" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Validating\+String\+Parameter\+Plugin$" "https://plugins.jenkins.io/validating-string-parameter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VARIABLES\+REPLACE$" "https://plugins.jenkins.io/variables-replace-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Variant\+Plugin$" "https://plugins.jenkins.io/variant" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Vault\+Plugin$" "https://plugins.jenkins.io/vault-scm-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VBoxWrapper$" "https://plugins.jenkins.io/vboxwrapper" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VectorCAST\+Coverage\+Plugin$" "https://plugins.jenkins.io/vectorcast-coverage" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VectorCAST\+Execution\+Plugin$" "https://plugins.jenkins.io/vectorcast-execution" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VersionColumn\+Plugin$" "https://plugins.jenkins.io/versioncolumn" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Version\+Number\+Plugin$" "https://plugins.jenkins.io/versionnumber" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Vert\.x\+Embedder$" "https://plugins.jenkins.io/vertx" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Viber\+Notification\+Plugin$" "https://plugins.jenkins.io/viber-notification" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/View\+Cloner\+Plugin$" "https://plugins.jenkins.io/view-cloner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/View\+Job\+Filters$" "https://plugins.jenkins.io/view-job-filters" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/View26\+Test\-Reporting\+Plugin$" "https://plugins.jenkins.io/view26" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ViewVC\+Plugin$" "https://plugins.jenkins.io/viewVC" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Views\+Containing\+Job\+Plugin$" "https://plugins.jenkins.io/views-containing-job" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Violation\+Columns\+Plugin$" "https://plugins.jenkins.io/violation-columns" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Violations$" "https://plugins.jenkins.io/violations" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VirtualBox\+Plugin$" "https://plugins.jenkins.io/virtualbox" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Visualworks\+Smalltalk\+Store\+Plugin$" "https://plugins.jenkins.io/visualworks-store" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VMware\+vRealize\+Automation\+Plugin$" "https://plugins.jenkins.io/vmware-vrealize-automation-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Vmware\+vRealize\+CodeStream\+Plugin$" "https://plugins.jenkins.io/vmware-vrealize-codestream" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VMware\+vRealize\+Orchestrator\+Plugin$" "https://plugins.jenkins.io/vmware-vrealize-orchestrator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VncRecorder\+Plugin$" "https://plugins.jenkins.io/vncrecorder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VncViewer\+Plugin$" "https://plugins.jenkins.io/vncviewer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Visual\+Studio\+Code\+Metrics\+Plugin$" "https://plugins.jenkins.io/vs-code-metrics" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/vSphere\+Cloud\+Plugin$" "https://plugins.jenkins.io/vsphere-cloud" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Visual\+SourceSafe\+Plugin$" "https://plugins.jenkins.io/vss" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VsTestRunner\+Plugin$" "https://plugins.jenkins.io/vstestrunner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/VS\+Team\+Services\+Continuous\+Deployment\+Plugin$" "https://plugins.jenkins.io/vsts-cd" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Walti\+Plugin$" "https://plugins.jenkins.io/walti" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/WAPT\+Pro\+plugin$" "https://plugins.jenkins.io/waptpro" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Warrior\+Framework\+Plugin$" "https://plugins.jenkins.io/warrior" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/WAS\+Builder\+Plugin$" "https://plugins.jenkins.io/was-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Webhook\+Eventsource\+Plugin$" "https://plugins.jenkins.io/webhook-eventsource" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Webhook\+Step\+Plugin$" "https://plugins.jenkins.io/webhook-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/WebLOAD\+Plugin$" "https://plugins.jenkins.io/webload" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/WebLogic\+Deployer\+Plugin$" "https://plugins.jenkins.io/weblogic-deployer-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Websocket\+Plugin$" "https://plugins.jenkins.io/websocket" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Websocket\.in\+Notification\+Plugin$" "https://plugins.jenkins.io/websocketin-notification" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/WebSphere\+Deployer\+Plugin$" "https://plugins.jenkins.io/websphere-deployer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Weibo\+Plugin$" "https://plugins.jenkins.io/weibo" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Whitesource\+Plugin/$" "https://plugins.jenkins.io/whitesource" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/WildFly\+Deployer\+Plugin$" "https://plugins.jenkins.io/wildfly-deployer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Windocks\+Plugin$" "https://plugins.jenkins.io/windocks-start-container" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Windows\+Azure\+Storage\+Plugin$" "https://plugins.jenkins.io/windows-azure-storage" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Windows\+Exe\+Runner\+Plugin$" "https://plugins.jenkins.io/windows-exe-runner" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/WinRM\+Client\+Plugin$" "https://plugins.jenkins.io/winrm-client" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/WIX\+Toolset\+Plugin$" "https://plugins.jenkins.io/wix" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Plugin$" "https://plugins.jenkins.io/workflow-aggregator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Workflow\+Plugin$" "https://plugins.jenkins.io/workflow-aggregator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gerrit\+Trigger$" "https://plugins.jenkins.io/gerrit-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Shared\+Groovy\+Libraries\+Plugin$" "https://plugins.jenkins.io/workflow-cps-global-lib" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HTTP\+Shared\+Libraries\+Retriever\+plugin$" "https://plugins.jenkins.io/workflow-cps-global-lib-http" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Multibranch\+Plugin$" "https://plugins.jenkins.io/workflow-multibranch" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Remote\+Loader\+Plugin$" "https://plugins.jenkins.io/workflow-remote-loader" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Working\-Hours\-Plugin$" "https://plugins.jenkins.io/working-hours" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Workplace\+Notifier\+Plugin$" "https://plugins.jenkins.io/workplace-notifier" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Worksoft\+Execution\+Manager\+Plugin$" "https://plugins.jenkins.io/ws-execution-manager" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Workspace\+Whitespace\+Replacement\+Plugin$" "https://plugins.jenkins.io/ws-ws-replacement" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Writing\+an\+SCM\+plugin$" "https://www.jenkins.io/doc/developer/plugin-development/writing-an-scm-plugin" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/WSO2\+Oauth\+Plugin$" "https://plugins.jenkins.io/wso2id-oauth" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/WWPass\+Authentication\+Plugin$" "https://plugins.jenkins.io/wwpass-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/xCP\+CI\+Plugin$" "https://plugins.jenkins.io/xcp-ci" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/eXtreme\+Feedback\+Panel\+Plugin$" "https://plugins.jenkins.io/xfpanel" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/XFrame\+Filter\+Plugin$" "https://plugins.jenkins.io/xframe-filter-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/xFramium\+Plugin$" "https://plugins.jenkins.io/xframium" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/XL\+Release\+Plugin$" "https://plugins.jenkins.io/xlrelease-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/XLRelease\+Variables\+Setter\+Plugin$" "https://plugins.jenkins.io/xlrelease-var-setter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Xooa\+Plugin$" "https://plugins.jenkins.io/xooa" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/XPath\+Configuration\+Viewer$" "https://plugins.jenkins.io/xpath-config-viewer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/XP\-Dev\+Plugin$" "https://plugins.jenkins.io/xpdev" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/XShell\+Plugin$" "https://plugins.jenkins.io/xshell" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/xUnit\+Plugin$" "https://plugins.jenkins.io/xunit" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Xvfb\+Plugin$" "https://plugins.jenkins.io/xvfb" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Xvnc\+Plugin$" "https://plugins.jenkins.io/xvnc" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Yaml\+Axis\+Plugin$" "https://plugins.jenkins.io/yaml-axis" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/YAML\+Project\+Plugin$" "https://plugins.jenkins.io/yaml-project" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Yammer\+Plugin$" "https://plugins.jenkins.io/yammer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Yandex\+Metrica\+Plugin$" "https://plugins.jenkins.io/yandex-metrica" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Yet\+Another\+Docker\+Plugin$" "https://plugins.jenkins.io/yet-another-docker-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/YouTrack\+Plugin$" "https://plugins.jenkins.io/youtrack-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zanata\+Plugin$" "https://plugins.jenkins.io/zanata" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/zap\+plugin$" "https://plugins.jenkins.io/zap" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zap\+Pipeline\+Plugin$" "https://plugins.jenkins.io/zap-pipeline" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zapper\+Plugin$" "https://plugins.jenkins.io/zapper" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zentimestamp\+Plugin$" "https://plugins.jenkins.io/zentimestamp" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zephyr\+For\+Jira\+Test\+Management\+Plugin$" "https://plugins.jenkins.io/zephyr-for-jira-test-management" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/ZMQ\+Event\+Publisher\+Plugin$" "https://plugins.jenkins.io/zmq-event-publisher" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Zoom\+Plugin$" "https://plugins.jenkins.io/zoom" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/violation\+comments\+to\+gitlab\+Plugin$" "https://plugins.jenkins.io/violation-comments-to-gitlab" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/claim\+Plugin$" "https://plugins.jenkins.io/claim/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/App\+Center\+Plugin$" "https://plugins.jenkins.io/appcenter/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/XML\+Job\+to\+Job\+DSL$" "https://plugins.jenkins.io/xml-job-to-job-dsl/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/IBM\+zOS\+Connector$" "https://plugins.jenkins.io/zos-connector" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Zulip\+Plugin$" "https://plugins.jenkins.io/zulip" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Remove\+Git\+Plugin\+BuildsByBranch\+BuildData$" "https://plugins.jenkins.io/git/#remove-git-plugin-buildsbybranch-builddata-script" [NE,NC,L,QSA,R=301]
 
 ## from https://wiki.jenkins.io/.well-known/reports/top_urls.txt
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Parameterized\+Trigger\+Plugin$" "https://plugins.jenkins.io/parameterized-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Active\+Choices\+Plugin$" "https://plugins.jenkins.io/uno-choice" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Workspace\+Cleanup\+Plugin$" "https://plugins.jenkins.io/ws-cleanup" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/EnvInject\+Plugin$" "https://plugins.jenkins.io/envinject" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/EnvInject\+API\+Plugin$" "https://plugins.jenkins.io/envinject-api" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Credentials\+Plugin$" "https://plugins.jenkins.io/credentials" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Config\+File\+Provider\+Plugin$" "https://plugins.jenkins.io/config-file-provider" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Role\+Strategy\+Plugin$" "https://plugins.jenkins.io/role-strategy" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Slack\+Plugin$" "https://plugins.jenkins.io/slack" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Generic\+Webhook\+Trigger\+Plugin$" "https://plugins.jenkins.io/generic-webhook-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/JIRA\+Plugin$" "https://plugins.jenkins.io/jira" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SSH\+Agent\+Plugin$" "https://plugins.jenkins.io/ssh-agent" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gerrit\+Trigger$" "https://plugins.jenkins.io/gerrit-trigger" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Subversion\+Plugin$" "https://plugins.jenkins.io/subversion" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kubernetes\+Plugin$" "https://plugins.jenkins.io/kubernetes" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Warnings\+Next\+Generation\+Plugin$" "https://plugins.jenkins.io/warnings-ng" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Lockable\+Resources\+Plugin$" "https://plugins.jenkins.io/lockable-resources" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Warnings\+Plugin$" "https://plugins.jenkins.io/warnings" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^display/JENKINS/Bitbucket\+Branch\+Source\+Plugin$" "https://plugins.jenkins.io/cloudbees-bitbucket-branch-source" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Splunk\+Plugin\+for\+Jenkins$" "https://plugins.jenkins.io/splunk-devops" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PMD\+Plugin$" "https://plugins.jenkins.io/pmd" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Micro\+Focus\+Application\+Automation\+Tools$" "https://plugins.jenkins.io/hp-application-automation-tools-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Configure\+the\+Job$" "https://plugins.jenkins.io/zap" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Configuration\+as\+Code\+Plugin$" "https://plugins.jenkins.io/configuration-as-code" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Google\+Play\+Android\+Publisher\+Plugin$" "https://plugins.jenkins.io/google-play-android-publisher"
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ant\+Plugin$" "https://plugins.jenkins.io/ant" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/FindBugs\+Plugin$" "https://plugins.jenkins.io/findbugs" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CloudBees\+Folders\+Plugin$" "https://plugins.jenkins.io/cloudbees-folder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Metrics\+Plugin$" "https://plugins.jenkins.io/metrics" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/HashiCorp\+Vault\+Plugin$" "https://plugins.jenkins.io/hashicorp-vault-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PowerShell\+Plugin$" "https://plugins.jenkins.io/powershell" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SAML\+Plugin$" "https://plugins.jenkins.io/saml" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Purge\+Job\+History\+Plugin" "https://plugins.jenkins.io/purge-job-history" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Build\+Step\+Plugin" "https://plugins.jenkins.io/pipeline-build-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 # Perforce plugin no longer exists apparently, so redirect to p4
 RewriteRule "^/display/JENKINS/Perforce\+Plugin$" "https://plugins.jenkins.io/p4" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Xcode\+Plugin$" "https://plugins.jenkins.io/xcode-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Embeddable\+Build\+Status\+Plugin$" "https://plugins.jenkins.io/embeddable-build-status" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SSH\+Credentials\+Plugin$" "https://plugins.jenkins.io/ssh-credentials" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Groovy\+Plugin$" "https://plugins.jenkins.io/workflow-cps" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Git\+Changelog\+Plugin$" "https://plugins.jenkins.io/git-changelog" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Robot\+Framework\+Plugin$" "https://plugins.jenkins.io/robot" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SSH\+Slaves\+plugin$" "https://plugins.jenkins.io/ssh-slaves" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Push\+And\+Pull\+Request\+Plugin$" "https://plugins.jenkins.io/bitbucket-push-and-pull-request" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Checkstyle\+Plugin$" "https://plugins.jenkins.io/checkstyle" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Script\+Security\+Plugin$" "https://plugins.jenkins.io/script-security" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Git\+Client\+Plugin$" "https://plugins.jenkins.io/git-client" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gradle\+Plugin$" "https://plugins.jenkins.io/gradle" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Branch\+Source\+Plugin$" "https://plugins.jenkins.io/cloudbees-bitbucket-branch-source" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Docker\+Pipeline\+Plugin$" "https://plugins.jenkins.io/docker-workflow" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OWASP\+Dependency-Check\+Plugin$" "https://plugins.jenkins.io/dependency-check-jenkins-plugin" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Promoted\+Builds\+Plugin$" "https://plugins.jenkins.io/promoted-builds" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Amazon\+EC2\+Plugin$" "https://plugins.jenkins.io/ec2" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Kubernetes\+Credentials\+Provider\+Plugin$" "https://plugins.jenkins.io/kubernetes-credentials-provider" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/PostBuildScript\+Plugin$" "https://plugins.jenkins.io/postbuildscript" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Ansible\+Tower\+Plugin$" "https://plugins.jenkins.io/ansible-tower" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Token\+Root\+Plugin$" "https://plugins.jenkins.io/build-token-root" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Parameter\+Separator\+Plugin$" "https://plugins.jenkins.io/parameter-separator" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Stash\+PullRequest\+Builder\+Plugin$" "https://plugins.jenkins.io/stash-pullrequest-builder" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Token\+Macro\+Plugin$" "https://plugins.jenkins.io/token-macro" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Openstack\+Cloud\+Plugin$" "https://plugins.jenkins.io/openstack-cloud" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Bitbucket\+Server\+integration\+plugin\+for\+Jenkins$" "https://plugins.jenkins.io/atlassian-bitbucket-server-integration/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/DRY\+Plugin$" "https://plugins.jenkins.io/dry" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Mailer$" "https://plugins.jenkins.io/mailer" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/InfluxDB\+Plugin$" "https://plugins.jenkins.io/influxdb" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Task\+Scanner\+Plugin$" "https://plugins.jenkins.io/tasks" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Content\+Replace\+Plugin$" "https://plugins.jenkins.io/content-replace" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Gerrit\+Code\+Review\+Plugin$" "https://plugins.jenkins.io/gerrit-code-review" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Repo\+Plugin$" "https://plugins.jenkins.io/repo" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Analysis\+Collector\+Plugin$" "https://plugins.jenkins.io/analysis-collector" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Token\+Root\+Plugin$" "https://plugins.jenkins.io/build-token-root" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Task\+Scanner\+Plugin$" "https://plugins.jenkins.io/tasks" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Build\+Name\+Setter\+Plugin$" "https://plugins.jenkins.io/build-name-setter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Remote\+File\+Plugin$" "https://plugins.jenkins.io/remote-file" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Console\+Parser\+Plugin$" "https://plugins.jenkins.io/log-parser" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Windows\+Slaves\+Plugin$" "https://plugins.jenkins.io/windows-slaves" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/OWASP\+Markup\+Formatter\+Plugin$" "https://plugins.jenkins.io/antisamy-markup-formatter" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Pipeline\+Nodes\+and\+Processes\+Plugin$" "https://plugins.jenkins.io/workflow-durable-task-step" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Fortify\+On\+Demand\+Uploader\+Plugin$" "https://plugins.jenkins.io/fortify-on-demand-uploader" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/SoapUI\+Pro\+Functional\+Testing\+Plugin$" "https://plugins.jenkins.io/soapui-pro-functional-testing" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Matrix\+Authorization\+Strategy\+Plugin$" "https://plugins.jenkins.io/matrix-auth" [NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Matrix\+Configuration\+Parameter\+Plugin$" "https://plugins.jenkins.io/matrix-combinations-parameter/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Git$" "https://plugins.jenkins.io/git/" [NE,NC,L,QSA,R=301]
@@ -3035,23 +1541,14 @@ RewriteRule "^/display/JENKINS/Pipeline\+Job\+Plugin" "https://plugins.jenkins.i
 
 # Non plugin rewrites
 ## User Documentation
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Disable\+security$" "https://jenkins.io/doc/book/system-administration/security/#disabling-security" [NE,NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Securing\+Jenkins$" "https://jenkins.io/doc/book/system-administration/security/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Logo$" "https://jenkins.io/artwork/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Logging$" "https://jenkins.io/doc/book/system-administration/viewing-logs/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Jenkins\+Script\+Console$" "https://jenkins.io/doc/book/managing/script-console/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Starting\+and\+Accessing\+Jenkins$" "https://jenkins.io/doc/book/installing/#configuring-http" [NE,NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Features\+controlled\+by\+system\+properties$" "https://jenkins.io/doc/book/managing/system-properties/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Groovy\+Hook\+Script$" "https://jenkins.io/doc/book/managing/groovy-hook-scripts/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/CSRF\+Protection$" "https://jenkins.io/doc/book/managing/security/#cross-site-request-forgery" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/FreeBSD$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/FreeBSD\+4.9$" "https://jenkins.io/doc/book/installing/#freebsd" [NE,NC,L,QSA,R=301]
@@ -3096,31 +1593,21 @@ RewriteRule "^/display/JENKINS/I%27m\+getting\+OutOfMemoryError$" "https://www.j
 
 
 ## Developer documentation
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Adopt\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/adopt-a-plugin/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Deprecating\+a\+Plugin$" "https://jenkins.io/doc/developer/plugin-governance/deprecating-or-removing-plugin/" [NE,NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Extension\+points$" "https://jenkins.io/doc/developer/extensions/" [NE,NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Serialization\+of\+anonymous\+classes$" "https://jenkins.io/doc/developer/extensibility/serialization-of-anonymous-classes//" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Tips\+for\+optional\+dependencies$" "https://jenkins.io/doc/developer/plugin-development/optional-dependencies/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Post-initialization\+script$" "https://www.jenkins.io/doc/book/managing/groovy-hook-scripts/#post-initialization-script-init-hook" [NE,NC,L,QSA,R=301]
 
 ## Governance documentation
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Board\+Candidacy\+Process" "https://jenkins.io/project/board-election-process/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Board\+Election\+Process$" "https://jenkins.io/project/board-election-process/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Governance\+Board$" "https://jenkins.io/project/board/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Governance\+Document$" "https://jenkins.io/project/governance/" [NC,L,QSA,R=301]
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/JENKINS/Governance\+Meeting\+Agenda$" "https://jenkins.io/project/governance-meeting/" [NC,L,QSA,R=301]
 
 # Security advisories
-RewriteCond %{HTTP_USER_AGENT} !^jenkins-wiki-exporter/(.*)$
 RewriteRule "^/display/SECURITY/Jenkins\+Security\+Advisory\+([0-9]+)-([0-9]+)-([0-9]+)$" "https://jenkins.io/security/advisory/$1-$2-$3/" [NC,L,QSA,R=301]
 
 


### PR DESCRIPTION
Currently, the exception for the wiki-exporter has to be specified for every rule (due too RewriteCond only [applying to the next rule](http://httpd.apache.org/docs/2.2/mod/mod_rewrite.html#RewriteCond)) , which bloats the (already pretty large) file.

I propose this "magic" rule to (somewhat) restore the readability of the file.

I tried this on a local install of Apache 2.4.46, but since this is pretty basic usage of mod_rewrite, it should be okay on any recent Apache version.

The only danger I see in this change is that if sometimes in the future rewrite rules are added to, for example, "hide" something from the public, care must be taken or otherwise someone can circumvent this "protection" by posing as "jenkins-wiki-exporter"