### PR TITLE
Redirect popular nginx wiki page to official nginx documentation

### DIFF
--- a/dist/profile/templates/confluence/vhost.conf
+++ b/dist/profile/templates/confluence/vhost.conf
@@ -3082,6 +3082,7 @@ RewriteRule "^/display/JENKINS/Running\+Jenkins\+behind\+HAProxy$" "https://www.
 RewriteRule "^/display/JENKINS/Running\+Jenkins\+behind\+Squid$" "https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-squid" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Running\+Jenkins\+behind\+IIS$" "https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-iis" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Running\+Jenkins\+behind\+Nginx$" "https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-nginx" [NE,NC,L,QSA,R=301]
+RewriteRule "^/display/JENKINS/Jenkins\+behind\+an\+NGinX\+reverse\+proxy$" "https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-with-jenkins/#running-jenkins-behind-nginx" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Thanks\+for\+using\+Windows\+Installer$" "https://www.jenkins.io/download/thank-you-downloading-windows-installer/" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Executor\+Starvation$" "https://www.jenkins.io/doc/book/using/executor-starvation" [NE,NC,L,QSA,R=301]
 RewriteRule "^/display/JENKINS/Configuring\+Content\+Security\+Policy$" "https://www.jenkins.io/doc/book/system-administration/security/configuring-content-security-policy" [NE,NC,L,QSA,R=301]


### PR DESCRIPTION
According to https://wiki.jenkins.io/.well-known/reports/top_urls.txt there is a quite "popular" wiki page describing how to run Jenkins behind a nginx reverse proxy.

As an nginx user I found nothing on that page which isn't covered by the official documentation, so redirect to that instead.

(Quite on the contrary: The official documentation contains support for modern features like websockets, whereas the configs in the wiki page do not)