### PR TITLE
Increase archives.jenkins.io network bandwith limit

### DIFF
--- a/dist/profile/templates/archives/vhost.conf
+++ b/dist/profile/templates/archives/vhost.conf
@@ -8,8 +8,11 @@ CustomLog "|/usr/bin/rotatelogs /var/log/apache2/archives.jenkins-ci.org/access.
 #
 # 1000KB/sec constant transfer is equivalent of 2600GB/month transfer.
 # At $0.12/GB, that costs about $300/month
+#
+# As of the 15th of November 2020, the current sponsoring plan
+# with Rackspace allows us to increase the limit.
 
 BandwidthModule On
 ForceBandWidthModule On
-Bandwidth all 1024000
+Bandwidth all 4096000
 MinBandwidth all 0


### PR DESCRIPTION
As of the 15th of November 2020, the current sponsoring plan with Rackspace allows us to increase the limit.
The purpose of this is to use archives.jenkins.io as a fallback service for get.jenkins.io

Signed-off-by: Olivier Vernin <olivier@vernin.me>