### PR TITLE
Remove jira from edamame

### DIFF
--- a/dist/role/manifests/edamame.pp
+++ b/dist/role/manifests/edamame.pp
@@ -6,5 +6,4 @@ class role::edamame {
   include profile::sudo::osu
   include profile::bind
   include profile::apachecert
-  include profile::jira
 }


### PR DESCRIPTION
So manual cleanup must to be done, it will be faster to do it once manually than using puppet