### PR TITLE
Add 2 new 150G disks to extend data volume on okra

### DIFF
--- a/hieradata/clients/okra.yaml
+++ b/hieradata/clients/okra.yaml
@@ -9,5 +9,5 @@ lvm::volume_groups:
       - /dev/xvdg
     logical_volumes:
       releases:
-        size: 749G
+        size: 739G
         mountpath: /srv/releases

--- a/hieradata/clients/okra.yaml
+++ b/hieradata/clients/okra.yaml
@@ -5,7 +5,9 @@ lvm::volume_groups:
       - /dev/xvdb
       - /dev/xvdd
       - /dev/xvde1
+      - /dev/xvdf
+      - /dev/xvdg
     logical_volumes:
       releases:
-        size: 449G
+        size: 749G
         mountpath: /srv/releases


### PR DESCRIPTION
Ref. https://matrix.to/#/!cddybYRxFljbtgddGf:matrix.org/$1621165994471138xWemR:matrix.org?via=matrix.org&via=g4v.dev

This PR is only updating the puppet code, but the operation had been done manually on the VM as documented on the runbook.

State on the machine after the operation:

```shell
root@okra:~# df -h /srv/releases
Filesystem                     Size  Used Avail Use% Mounted on
/dev/mapper/archives-releases  739G  402G  304G  57% /srv/releases
```