### PR TITLE
Fix okra's LV size

### DIFF
--- a/hieradata/clients/okra.yaml
+++ b/hieradata/clients/okra.yaml
@@ -9,5 +9,5 @@ lvm::volume_groups:
       - /dev/xvdg
     logical_volumes:
       releases:
-        size: 739G
+        size: 749.98G
         mountpath: /srv/releases


### PR DESCRIPTION
I did a miscalculation on #1761 on the final size: I used the filesystem's reported size instead of the LVM's reported size for the logical volume.

This PR fixes the following errors from the puppet agent:

```
May 17 13:32:53 okra puppet-agent[26460]: Decreasing the size requires manual intervention (739G < 749.98G)
May 17 13:32:53 okra puppet-agent[26460]: (/Stage[main]/Lvm/Lvm::Volume_group[archives]/Lvm::Logical_volume[releases]/Logical_volume[releases]/size) change from '749.98G' to '739G' failed: Decreasing the size requires manual intervention (739G < 749.98G)
```

and for next time, the value should be retrieved from the command `lvdisplay`:

```
root@okra:~# lvdisplay 
  --- Logical volume ---
  LV Path                /dev/archives/releases
  LV Name                releases
  VG Name                archives
  LV UUID                Rxpa5j-n8qg-IGSB-8H9z-xIQt-G4qK-9gaSMV
  LV Write Access        read/write
  LV Creation host, time , 
  LV Status              available
  # open                 1
  LV Size                749.98 GiB
  Current LE             191995
  Segments               6
  Allocation             inherit
  Read ahead sectors     auto
  - currently set to     256
  Block device           253:0
```