### PR TITLE
[INFRA-2961] Add rsync configuration to archives.jenkins.io

### DIFF
--- a/dist/profile/files/archives/jenkins.motd
+++ b/dist/profile/files/archives/jenkins.motd
@@ -1,0 +1,7 @@
+========================
+==== JENKINS MIRROR ====
+========================
+
+**Read Only**
+
+Feel free to reach out on Libera.chat, IRC, channel #jenkins-infra with any question you may have

--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -143,7 +143,7 @@ class profile::archives (
 
   firewall { '100 all inbound rsync':
     proto  => 'tcp',
-    dport   => '873',
+    dport  => '873',
     action => 'accept'
   }
 

--- a/dist/profile/templates/archives/rsyncd.conf.erb
+++ b/dist/profile/templates/archives/rsyncd.conf.erb
@@ -1,0 +1,36 @@
+# /etc/rsyncd: configuration file for
+rsync daemon mode
+
+# See rsyncd.conf man page for more options.
+
+# configuration example:
+
+uid = nobody
+gid = nogroup
+use chroot = yes 
+max connections = 0 
+pid file = /var/run/rsyncd.pid
+exclude = lost+found/
+transfer logging = yes 
+log file = /var/log/rsyncd.log
+ignore nonreadable = yes 
+dont compress   = *.gz *.tgz *.zip *.z *.Z *.rpm *.deb *.bz2
+port = 873 
+motd file = <%= @rsync_motd_file %>
+
+# Timeout in seconds
+timeout = 300 
+
+# Any attempted uploads will fail
+read only = true 
+
+# Downloads will be possible if file permissions on the daemon side allow them
+write only = false
+
+<% unless @rsync_hosts_allow.empty? -%>
+hosts allow = <%= @rsync_hosts_allow.join(',') %>
+<% end -%>
+
+[jenkins]
+path = <%= @archives_dir %>
+comment = "Jenkins Read-Only Mirror"

--- a/spec/classes/profile/archives_spec.rb
+++ b/spec/classes/profile/archives_spec.rb
@@ -15,4 +15,11 @@ describe 'profile::archives' do
 
   it { should contain_apache__mod 'bw' }
   it { should contain_apache__vhost 'archives.jenkins-ci.org' }
+
+  it { should contain_package('rsync') }
+  it { should contain_service('rsync').with(:ensure => 'running') }
+  it { should contain_file('/etc/rsyncd.conf').with(
+    :ensure => 'present',
+    :owner  => 'root',
+    :mode   => '0600')}
 end


### PR DESCRIPTION
Rsync is needed by Mirrorbits to access file metadata.
It's a requirement to use archives.jenkins.io as a fallback mirror from get.jenkins.io