### PR TITLE
Allow the new publick8s outbount IPs

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -112,6 +112,7 @@ profile::archives::rsync_hosts_allow:
   - localhost
   - archives.jenkins.io
   - 52.177.88.13 # publick8s outbound IP
+  - 20.75.10.224/29 # publick8s additionnal outboun IP range
   - pkg.origin.jenkins.io
   - get.jenkins.io
 # BIND container to deploy.


### PR DESCRIPTION
We added a range of outbound IPs on publick8s which now need to be allowed from archives.

Signed-off-by: Olivier Vernin <olivier@vernin.me>