### PR TITLE
fix: plugin github organization folder is deprecated in favor of github-branch-sources

### DIFF
--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -35,7 +35,6 @@ profile::buildmaster::plugins:
   - git
   - github
   - github-branch-source
-  - github-organization-folder
   - groovy
   - jobConfigHistory
   - ldap

--- a/hieradata/clients/trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/trusted.ci.jenkins.io.yaml
@@ -36,7 +36,6 @@ profile::buildmaster::plugins:
   - git
   - github
   - github-branch-source
-  - github-organization-folder
   - groovy
   - jobConfigHistory
   - ldap


### PR DESCRIPTION
Fixes the following error:

```shell
puppet-agent[28328]: '/usr/share/jenkins/idempotent-cli install-plugin github-organization-folder' returned 1 instead of one of [0]
puppet-agent[28328]: (/Stage[main]/Profile::Buildmaster/Profile::Jenkinsplugin[github-organization-folder]/Exec[install-plugin-github-organization-folder]/returns) change from 'notrun' to ['0'] failed: '/usr/share/jenkins/idempotent-cli install-plugin github-organization-folder' returned 1 instead of one of [0]
```

