### PR TITLE
[INFRA-3018] Upgrade Docker CE to 20.10 globally

### DIFF
--- a/dist/profile/files/docker/daemon.json
+++ b/dist/profile/files/docker/daemon.json
@@ -1,0 +1,8 @@
+{
+  "storage-driver": "overlay2",
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-file": "2",
+    "max-size": "100m"
+  }
+}

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -32,7 +32,7 @@ class profile::buildmaster(
   $groovy_d_lock_down_jenkins      = 'absent',
   $groovy_d_terraform_credentials  = 'absent',
   $memory_limit                    = '1g',
-  $java_opts                       = '-server -Xloggc:/var/jenkins_home/gc-%t.log -XX:NumberOfGCLogFiles=5 -XX:+UseGCLogFileRotation -XX:GCLogFileSize=20m -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCCause -XX:+PrintTenuringDistribution -XX:+PrintReferenceGC -XX:+PrintAdaptiveSizePolicy -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1 -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2'
+  $java_opts                       = '-XshowSettings:vm -server -Xloggc:/var/jenkins_home/gc-%t.log -XX:NumberOfGCLogFiles=5 -XX:+UseGCLogFileRotation -XX:GCLogFileSize=20m -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCCause -XX:+PrintTenuringDistribution -XX:+PrintReferenceGC -XX:+PrintAdaptiveSizePolicy -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1 -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2'
 ) {
   include ::stdlib
   include ::apache

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -25,4 +25,11 @@ class profile::docker {
       ensure => 'purged',
     }
   }
+
+  file { '/etc/docker/daemon.json':
+    ensure => present,
+    source => "puppet:///modules/${module_name}/docker/daemon.json",
+    mode   => '0644',
+    notify => Service['docker'],
+  }
 }

--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -6,9 +6,6 @@ accounts:
         key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC3oj0NN9UL1dIfBP44JDsOj/bGX/DG/GIv82imhgWbCQvsKcPczb32+W+zVo+OF3mADX4EoBG681GGopjYCKLreo8D3nFSP/+kdAt0lEqbufzoLvSyyxa0RUHDwzVQIiMiNlzDiWqLRkF2TdeFDl5u+bbdPTYCGil5/qZ3Ro8sG9ayWXMxh+f+s0MAU9qFIwau838RF2R9OCMjmPodW/zf+Mcq+SqrbZyYfYha5jOWxoN8IdrGuAOQeYks7mrXC6qq5N9ojUtMKONvayFwNOsuC0U8PYUtukkHVnm2IK9KM1A38HDlV9eTF8ac7yCUHLlttmoIBdLUuLJAw72BQkK/
     groups:
       - sudo
-docker::version: '5:20.10.7~3-0~ubuntu-bionic'
-docker::log_opt::max-size: '100m'
-docker::log_opt::max-file: 2
 profile::buildmaster::ci_fqdn: 'trusted.ci.jenkins.io'
 profile::buildmaster::proxy_port: 1443
 profile::buildmaster::anonymous_access: false

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -301,8 +301,6 @@ usage_ssh_privkey: 'usage_ssh_privkey'
 osuosl_mirroring_privkey: ''
 archives_mirroring_privkey: ''
 docker::version: '5:20.10.7~3-0~ubuntu-bionic'
-docker::log_opt::max-size: '100m'
-docker::log_opt::max-file: 2
 # profile::pluginsite::image_tag is deprecated as pluginsite is now deployed on kubernetes
 # you should instead update profile::kubernetes::resources:pluginsite::image_tag
 profile::pluginsite::image_tag: '50-8a166d'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -300,7 +300,9 @@ usage_ssh_pubkey: 'AAAAB3NzaC1yc2EAAAADAQABAAACAQD66Xfd/5HgBkc6lGGqCrhJ/LBIWOTQ5
 usage_ssh_privkey: 'usage_ssh_privkey'
 osuosl_mirroring_privkey: ''
 archives_mirroring_privkey: ''
-docker::version: '5:18.09.0~3-0~ubuntu-bionic'
+docker::version: '5:20.10.7~3-0~ubuntu-bionic'
+docker::log_opt::max-size: '100m'
+docker::log_opt::max-file: 2
 # profile::pluginsite::image_tag is deprecated as pluginsite is now deployed on kubernetes
 # you should instead update profile::kubernetes::resources:pluginsite::image_tag
 profile::pluginsite::image_tag: '50-8a166d'

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -20,10 +20,6 @@ profile::kubernetes::resources::chatbot_jenkinsadmin::jira_password: 'jiratoken'
 profile::kubernetes::resources::chatbot_jenkinsadmin::nick_password: 'ircpassword'
 profile::jira::database_url: mysql://jira:raji@db/jiradb
 
-docker::version: '5:20.10.7~3-0~ubuntu-bionic'
-docker::log_opt::max-size: '100m'
-docker::log_opt::max-file: 2
-
 profile::ldap::ssl_key: |
   -----BEGIN RSA PRIVATE KEY-----
   MIICXAIBAAKBgQCw/CwMBPVJtUbvtJY7XxrwN0o5Bkus3U2E9AuZR7Ge4Ap5xQmh


### PR DESCRIPTION
This PR bumps the Docker CE Engines from 18.09 to 20.10(.7).

It's been 3 days since #1787 was merged and deployed with this upgrade specifically for trusted.ci with no issues.

Please note that a `daemon.json` file is now provided to configure the Docker Engine because the puppet module does not handle daemon's setup (only a few items and it's a joke). The file is generic for all services, but if we need per-VM setups in the future, we can turn it into a template (but it's not needed now: let's keep things simple).

All Docker CE Engine will be setup (through daemon.json) with:
- overlayFS for the storage driver (for layerd Docker images, NOT for volumes => no risk for the data). When upgrading, Docker migrates the existing images from AUFS to overlay but it should not restart the container, based on what we saw on trusted.ci. The risk is not zero: expect maybe a container restart.
- Log rotation is handled by Docker Engine: max 2 archive files of 100Mb each. That should be enough for now (we do not run log rotation today). Please note that the `json-driver` for logs is kept to avoid breaking any log collection we could (journalctl, loki, datadog, etc.).

Finally, a tiny gift for @daniel-beck (and us as well): the Jenkins Controllers managed by this puppet manifests is now using the JVM flag `-XshowSettings:vm` (JDK8 and JDK11) which prints 4 lines of log at the beginning, showing the estimated heap size and memory size at startup: nice tool to validate future assumption about memory limits by just checking the logs).