### PR TITLE
Allow to use arm64 agent with ubuntu 20.04

### DIFF
--- a/dist/profile/manifests/puppetmaster.pp
+++ b/dist/profile/manifests/puppetmaster.pp
@@ -15,7 +15,7 @@ class profile::puppetmaster {
   # https://puppet.com/docs/pe/2019.8/installing_agents.html
   # Agent packages can be found on the primary server in
   # /opt/puppetlabs/server/data/packages/public/<PE VERSION>/
-  class pe_repo::platform::ubuntu_2004_aarch644 {
+  class pe_repo::platform::ubuntu_2004_aarch64 {
   }
 
   # If we're inside of Vagrant we don't have the Service[pe-puppetserver]

--- a/dist/profile/manifests/puppetmaster.pp
+++ b/dist/profile/manifests/puppetmaster.pp
@@ -1,6 +1,7 @@
 #
 # profile::puppetmaster is a governing what a Jenkins puppetmaster should look
 # like
+#
 class profile::puppetmaster {
   # pull in all our secret stuff, and install eyaml
   include ::jenkins_keys
@@ -10,13 +11,13 @@ class profile::puppetmaster {
   include ::irc
   include datadog_agent
 
+  include pe_repo::platform::ubuntu_2004_aarch64
+
   # Install ubuntu 20.04 repo package for aarch64
   # required for running ubuntu 20.04 on arm64 instance
   # https://puppet.com/docs/pe/2019.8/installing_agents.html
   # Agent packages can be found on the primary server in
   # /opt/puppetlabs/server/data/packages/public/<PE VERSION>/
-  class pe_repo::platform::ubuntu_2004_aarch64 {
-  }
 
   # If we're inside of Vagrant we don't have the Service[pe-puppetserver]
   # resource defined since that comes with Puppet Enterprise. We'll define a

--- a/dist/profile/manifests/puppetmaster.pp
+++ b/dist/profile/manifests/puppetmaster.pp
@@ -10,6 +10,14 @@ class profile::puppetmaster {
   include ::irc
   include datadog_agent
 
+  # Install ubuntu 20.04 repo package for aarch64
+  # required for running ubuntu 20.04 on arm64 instance
+  # https://puppet.com/docs/pe/2019.8/installing_agents.html
+  # Agent packages can be found on the primary server in
+  # /opt/puppetlabs/server/data/packages/public/<PE VERSION>/
+  class pe_repo::platform::ubuntu_2004_aarch644 {
+  }
+
   # If we're inside of Vagrant we don't have the Service[pe-puppetserver]
   # resource defined since that comes with Puppet Enterprise. We'll define a
   # simple one just to make things 'work'


### PR DESCRIPTION
While trying to configure the agent on the new oracle arm64 machine, it complained about missing packages for ubunt 20.04 on arm64. 
 
```
The agent packages needed to support ubuntu-20.04-aarch64 are not present on your primary.     To add them, apply the pe_repo::platform::ubuntu_2004_aarch64 class to your primary node and then run Puppet.     The required agent packages should be retrieved when puppet runs on the primary, after which you can run the install.bash script again.
```

I currently don't have a way to test this PR

Signed-off-by: Olivier Vernin <olivier@vernin.me>