### PR TITLE
Add the ability to force a mirror synchronization from archives

### DIFF
--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -153,25 +153,25 @@ class profile::archives (
 
   # Install a script to trigger mirror synchronization
   #
-  file { "/var/log/mirrorsync":
-    ensure     => "directory",
-    group      => $group,
-    owner      => $owner,
-    mode       => '0750',
+  file { '/var/log/mirrorsync':
+    ensure  => 'directory',
+    group   => $group,
+    owner   => $owner,
+    mode    => '0750',
     require => File['/usr/bin/mirrorsync']
   }
 
-  file { "/usr/bin/mirrorsync":
-    content    => template("${module_name}/archives/mirrorsync.erb"),
-    group      => $group,
-    owner      => $owner,
-    mode       => '0755',
+  file { '/usr/bin/mirrorsync':
+    content => template("${module_name}/archives/mirrorsync.erb"),
+    group   => $group,
+    owner   => $owner,
+    mode    => '0755',
   }
 
-  cron { "mirrorsync":
-    command     => "/usr/bin/mirrorsync",
-    user        => $owner,
-    minute      => 30,
-    require     => File['/usr/bin/mirrorsync'],
+  cron { 'mirrorsync':
+    command => '/usr/bin/mirrorsync',
+    user    => $owner,
+    minute  => 30,
+    require => File['/usr/bin/mirrorsync'],
   }
 }

--- a/dist/profile/templates/archives/mirrorsync.erb
+++ b/dist/profile/templates/archives/mirrorsync.erb
@@ -1,0 +1,17 @@
+#!/bin/bash 
+set -euxo pipefail
+
+TIME=$(/bin/date --iso-8601=seconds --utc)
+
+sync(){
+  /usr/bin/time /usr/bin/rsync -avz rsync://<%= @source_mirror_endpoint %><%= @source_mirror_directory %> <%= @archives_dir %>
+  # Record logs
+  echo "$TIME - <%= @source_mirror_endpoint %> successfully synchronized" >> /var/log/mirrorsync/mirrorsync.log
+}
+
+# Ensure we run this script as user <%= @owner %>
+if [ "$(/usr/bin/whoami)" != "<%= @owner %>" ]; then 
+  exec /usr/bin/sudo --user="<%= @owner %>" /usr/bin/mirrorsync 
+else 
+  time sync
+fi


### PR DESCRIPTION
This pull request introduces a new script that can be either trigger manually or triggered by a cronjob.
This introduces a new approach to keep archives content up to date by having a pull approach instead of a push.
In the current state, pkg.jenkins.io (the machine) is responsible for regularly publishing files to archives.jenkins.io.
What I am proposing is to just assume that pkg.jenkins.io publishes files to ftp-osl.osuosl.org and then each mirror is responsible to to retrieve its data with an option to trigger a scan when needed.

`/var/log/mirrorsync` would keep track of when the script was execute

```
+--------------------------+                        +-------------------------+
|                          |     push files         |                         |
| pkg.jenkins.io: sync.sh  +----------------------->|  ftp-osl.osuosl.org     |
|                          |                        |                         |
+--------------------------+                        +-------------------------+
                                                                  ^
                                                                  |
                                                                  |
                        +-----------------------+                 |
                        |                       |      pull from  |
                        |  archives.jenkins.io  +-----------------+
                        |                       |
                        +-----------------------+
```

In order to test this, you need to run the following command once your testing environment is ready 

```
vagrant up -d archives
vagrant ssh archives
mirrorsync
# Ensure that some files exist in /srv/releases/
# Ensure that /var/log/mirrorsync/mirrorsync.log has at least one entry
```