### PR TITLE
Update archives node name in the site manifest

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -32,7 +32,7 @@ node default {
 }
 
 # archives
-node 'archives' {
+node 'archives.jenkins.io' {
   sshkeyman::hostkey { ['archives.jenkins-ci.org', 'archives.jenkins.io']: }
   include role::archives
 }


### PR DESCRIPTION
Update archives node name to match the one configured in the puppet master and machine hostname