### PR TITLE
Remove sshkeyman for the new archives.jenkins.io

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -33,7 +33,6 @@ node default {
 
 # archives
 node 'archives.jenkins.io' {
-  sshkeyman::hostkey { ['archives.jenkins-ci.org', 'archives.jenkins.io']: }
   include role::archives
 }
 


### PR DESCRIPTION
Remove sshkeyman for the new archives.jenkins.io for the new node.
I can't find a good reason for that setting and it prevents us to have different node using the same role