### PR TITLE
Puppet code cleanup: chore and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,16 @@ This repo just manages and configures the deployments.
 
 The amount of testing that can be done locally is as follows:
 
- * `bundle install` - To get the necessary gems to run tests locally, if you're
-   unfamiliar with Ruby development you may want to use [RVM](http://rvm.io/)
-   to create an isolated Ruby environment
- * `./check` - Will run the
-   [rspec-puppet](http://rspec-puppet) unit tests and the
-   [puppet-lint](http://puppet-lint.com) style validation. If you intend to run
-   the rspec-puppet over and over, use `rake spec_standalone` to avoid
-   re-initializing the Puppet module fixtures every time.
+* `bundle install` - To get the necessary gems to run tests locally, if you're
+  unfamiliar with Ruby development you may want to use [RVM](http://rvm.io/)
+  to create an isolated Ruby environment
+* `./check` - Will run the
+  [rspec-puppet](http://rspec-puppet) unit tests and the
+  [puppet-lint](http://puppet-lint.com) style validation. If you intend to run
+  the rspec-puppet over and over, use `rake spec_standalone` to avoid
+  re-initializing the Puppet module fixtures every time.
 
 ### Vagrant-based testing
-
-#### Pre-requisites
-
- * Run the `./vagrant-bootstrap` script locally to make sure your local
-   environment is prepared for Vagranting
 
 #### Running server spec tests
 
@@ -64,10 +59,12 @@ testing. Combined with Vagrant, this allows us to create an acceptance test
 [per-role](dist/role/manifests) which provisions and tests an entire Puppet
 catalog on a VM.
 
-##### Pre-requisites
+##### Pre-requisites for Vagrant
 
 * Install [Vagrant](https://www.vagrantup.com)
 * Install Vagrant plugins: `vagrant plugin install vagrant-serverspec`
+* Run the `./vagrant-bootstrap` script locally to make sure your local
+  environment is prepared for Vagranting
 
 To launch a test instance, `vagrant up ROLE` where `ROLE` is [one of the defined roles](dist/role/manifests).
 You can rerun puppet and execute tests with `vagrant provision ROLE` repeatedly while the VM is up and running.
@@ -75,6 +72,7 @@ To just rerun serverspect without puppet, `vagrant provision --provision-with se
 When it's all done, deprovision the instance via `vagrant destroy ROLE`.
 
 ### Updating dependencies
+
 For reasons that Tyler will hopefully clarify at some point, this module maintains
 the list of Puppet module dependencies in `Puppetfile` and `.fixtures.yml`. They
 need to be kept in sync. When you modify them, you can have the local environment
@@ -85,8 +83,7 @@ reflect changes by running `bundle exec rake resolve`.
 The default branch of this repository is `staging` which is where pull requests
 should be applied to by default.
 
-
-```
+```text
 
 +----------------+
 | pull-request-1 |
@@ -139,6 +136,5 @@ See [this page](https://github.com/jenkins-infra/.github/blob/master/CONTRIBUTIN
 Channels:
 
 * `#jenkins-infra` on the [Freenode](http://freenode.net) IRC network
-*  [INFRA project](https://issues.jenkins-ci.org/browse/INFRA) in JIRA.
+* [INFRA project](https://issues.jenkins-ci.org/browse/INFRA) in JIRA.
 * [infra@lists.jenkins-ci.org](http://lists.jenkins-ci.org/mailman/listinfo/jenkins-infra)
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,11 +45,17 @@ Vagrant.configure("2") do |config|
         # doesn't quite work with the built-in puppet apply provisioner anymore,
         # so we're manually invoking Puppet too!
         node.vm.provision 'shell', :inline => <<-EOF
+            export DEBIAN_FRONTEND=noninteractive
             if [ ! -f "/apt-cached" ]; then
-              wget -q http://apt.puppetlabs.com/puppet-release-bionic.deb
-              dpkg -i puppet-release-bionic.deb
-              apt-get update && apt-get install -yq puppet-agent && touch /apt-cached;
-              /opt/puppetlabs/puppet/bin/gem install --no-document deep_merge
+                ubuntu_codename="$(grep UBUNTU_CODENAME /etc/os-release | cut -d= -f2)"
+                package_name="puppet-release-${ubuntu_codename}.deb"
+                wget -q "http://apt.puppetlabs.com/${package_name}"
+                dpkg -i "${package_name}"
+                rm -f "${package_name}"
+                apt-get update --quiet
+                apt-get install --no-install-recommends --yes --quiet puppet-agent
+                /opt/puppetlabs/puppet/bin/gem install --no-document deep_merge
+                touch /apt-cached
             fi
 
             cd /vagrant
@@ -60,13 +66,13 @@ Vagrant.configure("2") do |config|
             export FACTER_clientcert=#{veggie}
             export FACTER_hiera_role=#{veggie}
             exec /opt/puppetlabs/bin/puppet apply \
-                  --modulepath=dist:modules \
-                  --hiera_config=spec/fixtures/hiera.yaml \
-                  --execute 'include profile::vagrant\n include role::#{veggie}'
+                --modulepath=dist:modules \
+                --hiera_config=spec/fixtures/hiera.yaml \
+                --execute 'include profile::vagrant\n include role::#{veggie}'
             EOF
 
             node.vm.provision :serverspec do |spec|
-              spec.pattern = "spec/server/#{specfile}/*.rb"
+                spec.pattern = "spec/server/#{specfile}/*.rb"
             end
         end
     end

--- a/dist/profile/files/buildmaster/idempotent-cli
+++ b/dist/profile/files/buildmaster/idempotent-cli
@@ -1,3 +1,15 @@
-#!/bin/sh -x
+#!/bin/bash
 
-exec /usr/bin/docker exec -u jenkins jenkins java -jar /var/jenkins_home/war/WEB-INF/jenkins-cli.jar -s http://localhost:8080  "$@"
+set -eux -o pipefail
+
+## URL to reach Jenkins from INSIDE the container
+jenkins_url="http://127.0.0.1:8080"
+
+## Array of argument to bake the commands to execute within the container
+# Note that we use the default container's user as it's not always the "jenkins"'s container user
+docker_cmd=("/usr/bin/docker" "exec" "jenkins")
+
+## Always download the jenkins-cli to ensure that versions are the same
+cli_host_path="$("${docker_cmd[@]}" find /var/jenkins_home/war/WEB-INF/lib -type f -name 'cli-*.jar' | head -n1 `# Only use the first item returned from find`)"
+
+exec "${docker_cmd[@]}" java -jar "${cli_host_path}" -s "${jenkins_url}" "$@"

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -24,6 +24,7 @@ class profile::buildmaster(
   $plugins                         = undef,
   $proxy_port                      = 443,
   $jenkins_home                    = '/var/lib/jenkins',
+  $container_jenkins_home          = '/var/jenkins_home',
   $groovy_init_enabled             = false,
   $groovy_d_enable_ssh_port        = 'absent',
   $groovy_d_set_up_git             = 'absent',
@@ -32,7 +33,7 @@ class profile::buildmaster(
   $groovy_d_lock_down_jenkins      = 'absent',
   $groovy_d_terraform_credentials  = 'absent',
   $memory_limit                    = '1g',
-  $java_opts                       = '-XshowSettings:vm -server -Xloggc:/var/jenkins_home/gc-%t.log -XX:NumberOfGCLogFiles=5 -XX:+UseGCLogFileRotation -XX:GCLogFileSize=20m -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCCause -XX:+PrintTenuringDistribution -XX:+PrintReferenceGC -XX:+PrintAdaptiveSizePolicy -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1 -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2'
+  $java_opts                       = "-XshowSettings:vm -server -Xloggc:${container_jenkins_home}/gc-%t.log -XX:NumberOfGCLogFiles=5 -XX:+UseGCLogFileRotation -XX:GCLogFileSize=20m -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCCause -XX:+PrintTenuringDistribution -XX:+PrintReferenceGC -XX:+PrintAdaptiveSizePolicy -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1 -Duser.home=${container_jenkins_home} -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2"
 ) {
   include ::stdlib
   include ::apache
@@ -236,7 +237,7 @@ class profile::buildmaster(
     # https://github.com/jenkinsci/azure-slave-plugin/issues/56
     # Quote inside env variable must be escaped as puppet generate a bash script
     env              => [
-      "HOME=${jenkins_home}",
+      "HOME=${container_jenkins_home}",
       'USER=jenkins',
       "JAVA_OPTS=${java_opts}",
       'JENKINS_OPTS=--httpKeepAliveTimeout=60000',

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -26,10 +26,17 @@ class profile::docker {
     }
   }
 
+  file { '/etc/docker':
+    ensure  => directory,
+    mode    => '0700',
+    recurse => true,
+  }
+
   file { '/etc/docker/daemon.json':
-    ensure => present,
-    source => "puppet:///modules/${module_name}/docker/daemon.json",
-    mode   => '0644',
-    notify => Service['docker'],
+    ensure  => file,
+    require => File['/etc/docker'],
+    source  => "puppet:///modules/${module_name}/docker/daemon.json",
+    mode    => '0600',
+    notify  => Service['docker'],
   }
 }

--- a/dist/profile/manifests/jenkinsplugin.pp
+++ b/dist/profile/manifests/jenkinsplugin.pp
@@ -7,12 +7,14 @@ define profile::jenkinsplugin (
   validate_string($name)
 
   exec { "install-plugin-${name}":
+    ## Check for plugin presence on the HOST (e.g. with the jenkins home in "/var/lib/jenkins" on the filesystem)
+    unless    => "/usr/bin/test -f /var/lib/jenkins/plugins/${name}.jpi || /usr/bin/test -f /var/lib/jenkins/plugins/${name}.hpi",
+    require   => Docker::Run['jenkins'],
+    ## Install the plugin (if needed) in the container, e.g. with the jenkins home mounted in /var/jenkins_home
     command   => "/usr/share/jenkins/idempotent-cli install-plugin ${name}",
     tries     => 10,
     try_sleep => 10,
     path      => ['/bin', '/usr/bin'],
-    unless    => "/usr/bin/test -f /var/lib/jenkins/plugins/${name}.jpi",
-    require   => Docker::Run['jenkins'],
     notify    => Exec['safe-restart-jenkins-via-ssh-cli'],
   }
 }

--- a/hieradata/README.md
+++ b/hieradata/README.md
@@ -1,4 +1,4 @@
-### Hieradata
+# Hieradata
 
 The yaml contained here uses the hiera-eyaml gem to store sensitive information.
 

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -53,6 +53,7 @@ profile::buildmaster::plugins:
   - github-checks
   - github-branch-source
   - groovy
+  - kubernetes
   - jobConfigHistory
   - junit-attachments
   - junit-realtime-test-reporter

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -7,6 +7,45 @@ profile::accountapp::smtp_password: 'smtp_password_example'
 profile::accountapp::jira_password: 'jira_password_example'
 
 profile::buildmaster::memory_limit: '1536m'
+profile::buildmaster::plugins:
+  - amazon-ecs
+  - ansicolor
+  - azure-container-agents
+  - azure-vm-agents
+  - blueocean
+  - build-timeout
+  - buildtriggerbadge
+  - cloudbees-folder
+  - code-coverage-api
+  - credentials
+  - credentials-binding
+  - docker-workflow
+  - ec2
+  - embeddable-build-status
+  - git-client
+  - git
+  - github
+  - github-checks
+  - github-branch-source
+  - groovy
+  - kubernetes
+  - jobConfigHistory
+  - junit-attachments
+  - junit-realtime-test-reporter
+  - ldap
+  - lockable-resources
+  - mailer
+  - parallel-test-executor
+  - pipeline-githubnotify-step
+  - pipeline-stage-view
+  - pipeline-utility-steps
+  - ssh-agent
+  - throttle-concurrents
+  - timestamper
+  - toolenv
+  - warnings-ng
+  - workflow-aggregator
+  - workflow-multibranch
 
 ### Stuff for IRC jenkins-admin bot
 # access to GitHub (for creating repos, etc)

--- a/spec/classes/profile/docker_spec.rb
+++ b/spec/classes/profile/docker_spec.rb
@@ -4,4 +4,6 @@ describe 'profile::docker' do
   it { should contain_class 'docker' }
   it { should contain_class 'datadog_agent::integrations::docker_daemon' }
   it { should contain_firewall('010 allow inter-docker traffic').with_action('accept').with_iniface('docker0') }
+  it { should contain_file('/etc/docker').with('ensure' => 'directory')}
+  it { should contain_file('/etc/docker/daemon.json')}
 end

--- a/vagrant-bootstrap
+++ b/vagrant-bootstrap
@@ -2,7 +2,6 @@
 
 
 echo "> Installing gems.."
-bundle install
+bundle install --path vendor/bundle
 echo "> Installing Puppet modules into modules/"
 r10k puppetfile install
-


### PR DESCRIPTION
While working on #1807, I stumbled upon a lot of minor issues which scope is unrelated to JCasc.

The goal of this PR is to contributes theses issues as soon as posible:

- (major) Fix path issues for the jenkins controllers, where the path used for the default user in the container is the path of the Jenkins Home on the host (while the Jenkins containers are using `/var/jenkins-home` as path). ⚠️ this might have an impact on the user behavior in production
- (major) Ensure that all the required plugins are specified through hieradata
- (medium) Fix the Jenkins' `idempotent_cli` not working by updating the script to use the correct `CLI` jar file in the container
- (medium) fix an issue on the `docker` role which throw an error about `/etc/docker` not existing when running an initial puppet agent run on a scratch machine + missing unit tests for this
- (minor) allow contributors to run vagrant on non admin VMs
- (minor) fully support @olblak 's work to have Ubuntu 20.04 compliance, by fully supporting it on the Vagrant tooling
- (minor) Markdown linting of  `README`