### PR TITLE
Update archives directory permission

### DIFF
--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -81,7 +81,7 @@ class profile::archives (
     ensure  => directory,
     owner   => $apache_owner,
     group   => $apache_group,
-    mode    => '0750',
+    mode    => '0775',
     require => Package['httpd'],
   }
 


### PR DESCRIPTION
I update archive directory permission from 0750 to 0775 as the latter one is the one defined on every other mirror so each time we do a mirror synchronization we changed back from 0750 to 0775
 
Signed-off-by: Olivier Vernin <olivier@vernin.me>