### PR TITLE
feat: [buildmaster] trigger a jcasc-reload instead of safe-restart when there is a configuration change

### DIFF
--- a/dist/profile/manifests/jenkinsplugin.pp
+++ b/dist/profile/manifests/jenkinsplugin.pp
@@ -16,6 +16,6 @@ define profile::jenkinsplugin (
     tries     => 10,
     try_sleep => 10,
     path      => ['/bin', '/usr/bin'],
-    notify    => Exec['safe-restart-jenkins-via-ssh-cli'],
+    notify    => Exec['safe-restart-jenkins'],
   }
 }

--- a/spec/classes/profile/buildmaster_spec.rb
+++ b/spec/classes/profile/buildmaster_spec.rb
@@ -52,6 +52,10 @@ describe 'profile::buildmaster' do
     context 'JCasC' do
       it { is_expected.to contain_file('/var/lib/jenkins/casc.d').with('ensure' => 'directory')}
       it { is_expected.to contain_file('/var/lib/jenkins/casc.d/agents.yaml')}
+      it { should contain_exec('install-plugin-configuration-as-code') }
+      it { should contain_exec('jcasc-reload-jenkins') }
+      it { should contain_exec('perform-jcasc-reload') }
+      it { should contain_exec('safe-restart-jenkins') }
     end
 
 


### PR DESCRIPTION
This PR comes from a recommendation from @timja (https://github.com/jenkins-infra/jenkins-infra/pull/1807#discussion_r675660959) when JCasc was enabled.

* It ensures that only a JCasc reload is triggered if only the JCasc configuration is changed (to avoid interrupting the service)
  * Implementation relies on a 2 steps exec (tricky): the CLI command `reload-jcasc-configuration` is only available if the JCasc plugin is installed AND if Jenkins has been (safe) restarted to enable the plugin. There is a "dummy" resource that requires both the plugin and safe-restart, and which **retries** because Jenkins could be restarting with the CLI not available (erreur HTTP/503)
* It also rename the exec resource `safe-restart-jenkins-via-ssh-cli` to `safe-restart-jenkins` (naming should be driven by implementation)



Note: Related PR on the JCasc documentation: https://github.com/jenkinsci/configuration-as-code-plugin/pull/1648.