### PR TITLE
feat: add ruby kubernetes agent template on ci.jenkins.io [INFRA-2918] 

### DIFF
--- a/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
@@ -426,8 +426,8 @@ jenkins:
         useEphemeralDevices: true
       useInstanceProfileForCredentials: false
   - kubernetes:
-      containerCap: 10
-      containerCapStr: "10"
+      # 3 workers at 8 CPUs/32Gi each, smaller template is 1 CPU/1Gi (8*3=24)
+      containerCap: 24
       credentialsId: "cik8s-kubeconfig"
       directConnection: true
       name: "cik8s"
@@ -446,11 +446,28 @@ jenkins:
             successThreshold: 0
             timeoutSeconds: 0
           name: "jnlp"
-          workingDir: "/home/jenkins/agent"
+          workingDir: "/home/jenkins"
         id: "f79567d4-f550-44b3-a9ce-70cf291910e6"
         name: "jnlp"
         slaveConnectTimeout: 100
-        slaveConnectTimeoutStr: "100"
+        yamlMergeStrategy: "override"
+      - containers:
+        - alwaysPullImage: true
+          args: "^${computer.jnlpmac} ^${computer.name}"
+          command: "/usr/local/bin/jenkins-agent"
+          image: "jenkinsciinfra/inbound-agent-ruby"
+          livenessProbe:
+            failureThreshold: 0
+            initialDelaySeconds: 0
+            periodSeconds: 0
+            successThreshold: 0
+            timeoutSeconds: 0
+          name: "jnlp"
+          workingDir: "/home/jenkins"
+        id: "f79567d4-f550-44b3-a9ce-70cf291910e6"
+        label: "ruby container kubernetes"
+        name: "jnlp-ruby"
+        slaveConnectTimeout: 100
         yamlMergeStrategy: "override"
   nodes:
   - permanent:

--- a/dist/profile/templates/vagrant/agents.yaml.erb
+++ b/dist/profile/templates/vagrant/agents.yaml.erb
@@ -33,3 +33,48 @@ jenkins:
             key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
       remoteFS: "/home/jenkins/ci.jenkins.io-agent"
       retentionStrategy: "always"
+  clouds:
+  - kubernetes:
+      # 3 workers at 8 CPUs/32Gi each, smaller template is 1 CPU/1Gi (8*3=24)
+      containerCap: 24
+      credentialsId: "cik8s-kubeconfig"
+      directConnection: true
+      name: "cik8s"
+      namespace: "jenkins-agents"
+      serverUrl: "<%= @agents_kubernetes_cik8s_url %>"
+      templates:
+      - containers:
+        - alwaysPullImage: true
+          args: "1d"
+          command: "sleep"
+          image: "jenkins/inbound-agent:latest-jdk11"
+          livenessProbe:
+            failureThreshold: 0
+            initialDelaySeconds: 0
+            periodSeconds: 0
+            successThreshold: 0
+            timeoutSeconds: 0
+          name: "jnlp"
+          workingDir: "/home/jenkins"
+        id: "f79567d4-f550-44b3-a9ce-70cf291910e6"
+        name: "jnlp"
+        slaveConnectTimeout: 100
+        yamlMergeStrategy: "override"
+      - containers:
+        - alwaysPullImage: true
+          args: "^${computer.jnlpmac} ^${computer.name}"
+          command: "/usr/local/bin/jenkins-agent"
+          image: "jenkinsciinfra/inbound-agent-ruby"
+          livenessProbe:
+            failureThreshold: 0
+            initialDelaySeconds: 0
+            periodSeconds: 0
+            successThreshold: 0
+            timeoutSeconds: 0
+          name: "jnlp"
+          workingDir: "/home/jenkins"
+        id: "f79567d4-f550-44b3-a9ce-70cf291910e6"
+        label: "ruby container kubernetes"
+        name: "jnlp-ruby"
+        slaveConnectTimeout: 100
+        yamlMergeStrategy: "override"


### PR DESCRIPTION
This PR is a part of INFRA-2918.

Its goal is to start using kubernetes pods seamlessly to handle part of the containerized agents workload on ci.jenkins.io.

It adds a Kubernetes template for standalone ruby agents (e.g. a pod template named `jnlp-ruby`).

Please note that there is a basic example for vagrant to allow local testing. We can do better such as yaml-linting the template, but it's a start.

This PR is intented to be the first of a serie: the ruby agent is a use case for the `jenkins-infra/jenkins-infra` repository (which has been tested on this example).