### PR TITLE
feat: templatize container agent setups for ci.jenkins.io [INFRA-2918]

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,9 +69,11 @@ Vagrant.configure("2") do |config|
                 --execute 'include profile::vagrant\n include role::#{veggie}'
             EOF
 
-            node.vm.provision :serverspec do |spec|
-                spec.pattern = "spec/server/#{specfile}/*.rb"
-            end
+            # Commented out as serverspec is not working anymore
+            # TODO: switch to another framework
+            # node.vm.provision :serverspec do |spec|
+            #     spec.pattern = "spec/server/#{specfile}/*.rb"
+            # end
         end
     end
 end

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -36,7 +36,9 @@ class profile::buildmaster(
   # This path is relative to the jenkins_home (to reuse on both host AND container which have different absolute jenkins_home paths)
   $jcasc_config_dir                = 'casc.d',
   $memory_limit                    = '1g',
-  $java_opts                       = "-XshowSettings:vm -server -Xloggc:${container_jenkins_home}/gc-%t.log -XX:NumberOfGCLogFiles=5 -XX:+UseGCLogFileRotation -XX:GCLogFileSize=20m -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCCause -XX:+PrintTenuringDistribution -XX:+PrintReferenceGC -XX:+PrintAdaptiveSizePolicy -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1 -Duser.home=${container_jenkins_home} -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2"
+  $java_opts                       = "-XshowSettings:vm -server -Xloggc:${container_jenkins_home}/gc-%t.log -XX:NumberOfGCLogFiles=5 -XX:+UseGCLogFileRotation -XX:GCLogFileSize=20m -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCCause -XX:+PrintTenuringDistribution -XX:+PrintReferenceGC -XX:+PrintAdaptiveSizePolicy -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1 -Duser.home=${container_jenkins_home} -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2",
+  $container_agents                = [],
+  $k8s_workers                     = {},
 ) {
   include ::stdlib
   include ::apache

--- a/dist/profile/templates/archives/rsyncd.conf.erb
+++ b/dist/profile/templates/archives/rsyncd.conf.erb
@@ -7,22 +7,22 @@ rsync daemon mode
 
 uid = nobody
 gid = nogroup
-use chroot = yes 
-max connections = 0 
+use chroot = yes
+max connections = 0
 pid file = /var/run/rsyncd.pid
 exclude = lost+found/
-transfer logging = yes 
+transfer logging = yes
 log file = /var/log/rsyncd.log
-ignore nonreadable = yes 
+ignore nonreadable = yes
 dont compress   = *.gz *.tgz *.zip *.z *.Z *.rpm *.deb *.bz2
-port = 873 
+port = 873
 motd file = <%= @rsync_motd_file %>
 
 # Timeout in seconds
-timeout = 300 
+timeout = 300
 
 # Any attempted uploads will fail
-read only = true 
+read only = true
 
 # Downloads will be possible if file permissions on the daemon side allow them
 write only = false
@@ -34,3 +34,4 @@ hosts allow = <%= @rsync_hosts_allow.join(',') %>
 [jenkins]
 path = <%= @archives_dir %>
 comment = "Jenkins Read-Only Mirror"
+ 

--- a/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
@@ -192,56 +192,18 @@ jenkins:
       name: "ACI"
       resourceGroup: "eastus-cijenkinsio"
       templates:
+      <% @container_agents.each do |agent| %>
       - command: "/usr/local/bin/jenkins-agent -url ^${rootUrl} ^${secret} ^${nodeName}"
-        cpu: "4"
-        image: "jenkinsciinfra/inbound-agent-maven:jdk8"
-        label: "maven azure container"
-        memory: "10"
-        name: "aci-maven"
+        cpu: "<%= agent["cpus"] %>"
+        image: "<%= agent["image"] %>"
+        label: "container azure <%= agent["labels"].join(' ') %>"
+        memory: "<%= agent["memory"] %>"
+        name: "aci-<%= agent["name"] %>"
         osType: "Linux"
         retentionStrategy: "containerOnce"
         rootFs: "/home/jenkins"
         timeout: 10
-      - command: "/usr/local/bin/jenkins-agent -url ^${rootUrl} ^${secret} ^${nodeName}"
-        cpu: "4"
-        image: "jenkinsciinfra/inbound-agent-maven:jdk11"
-        label: "maven-11 azure container"
-        memory: "12"
-        name: "aci-maven-11"
-        osType: "Linux"
-        retentionStrategy: "containerOnce"
-        rootFs: "/home/jenkins"
-        timeout: 10
-      - command: "/usr/local/bin/jenkins-agent -url ^${rootUrl} ^${secret} ^${nodeName}"
-        cpu: "2"
-        image: "jenkinsciinfra/inbound-agent-node:latest"
-        label: "node azure container"
-        memory: "4"
-        name: "aci-node"
-        osType: "Linux"
-        retentionStrategy: "containerOnce"
-        rootFs: "/home/jenkins"
-        timeout: 10
-      - command: "/usr/local/bin/jenkins-agent -url ^${rootUrl} ^${secret} ^${nodeName}"
-        cpu: "2"
-        image: "jenkinsciinfra/inbound-agent-ruby"
-        label: "ruby azure container"
-        memory: "4"
-        name: "aci-ruby"
-        osType: "Linux"
-        retentionStrategy: "containerOnce"
-        rootFs: "/home/jenkins"
-        timeout: 10
-      - command: "/usr/local/bin/jenkins-agent -url ^${rootUrl} ^${secret} ^${nodeName}"
-        cpu: "1"
-        image: "jenkins/inbound-agent:alpine"
-        label: "alpine azure container"
-        memory: "2"
-        name: "aci-alpine"
-        osType: "Linux"
-        retentionStrategy: "containerOnce"
-        rootFs: "/home/jenkins"
-        timeout: 10
+      <% end %>
       - command: "pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl}\
           \ -Secret ^${secret} -Name ^${nodeName}"
         cpu: "2"
@@ -426,8 +388,7 @@ jenkins:
         useEphemeralDevices: true
       useInstanceProfileForCredentials: false
   - kubernetes:
-      # 3 workers at 8 CPUs/32Gi each, smaller template is 1 CPU/1Gi (8*3=24)
-      containerCap: 24
+      # 3 workers at 8 CPUs/32Gi each
       credentialsId: "cik8s-kubeconfig"
       directConnection: true
       name: "cik8s"
@@ -451,15 +412,15 @@ jenkins:
           resourceRequestCpu: "1"
           resourceRequestMemory: "1G"
           workingDir: "/home/jenkins"
-        instanceCap: 24
         name: "jnlp"
         slaveConnectTimeout: 100
         yamlMergeStrategy: "override"
+      <% @container_agents.each do |agent| %>
       - containers:
         - alwaysPullImage: true
           args: "^${computer.jnlpmac} ^${computer.name}"
           command: "/usr/local/bin/jenkins-agent"
-          image: "jenkinsciinfra/inbound-agent-ruby"
+          image: "<%= agent["image"] %>"
           livenessProbe:
             failureThreshold: 0
             initialDelaySeconds: 0
@@ -467,60 +428,17 @@ jenkins:
             successThreshold: 0
             timeoutSeconds: 0
           name: "jnlp"
-          resourceLimitCpu: "2"
-          resourceLimitMemory: "4G"
-          resourceRequestCpu: "2"
-          resourceRequestMemory: "4G"
+          resourceLimitCpu: "<%= agent["cpus"] %>"
+          resourceLimitMemory: "<%= agent["memory"] %>G"
+          resourceRequestCpu: "<%= agent["cpus"] %>"
+          resourceRequestMemory: "<%= agent["memory"] %>G"
           workingDir: "/home/jenkins"
-        label: "ruby container kubernetes"
-        name: "jnlp-ruby"
-        instanceCap: 12
+        label: "container kubernetes <%= agent["labels"].join(' ') %>"
+        name: "jnlp-<%= agent["name"] %>"
+        instanceCap: <%= (@k8s_workers["cpus"].to_i / agent["cpus"].to_i - 1) * @k8s_workers["amount"].to_i %>
         slaveConnectTimeout: 100
         yamlMergeStrategy: "override"
-      - containers:
-        - alwaysPullImage: true
-          args: "^${computer.jnlpmac} ^${computer.name}"
-          command: "/usr/local/bin/jenkins-agent"
-          image: "jenkinsciinfra/inbound-agent-maven:jdk8"
-          livenessProbe:
-            failureThreshold: 0
-            initialDelaySeconds: 0
-            periodSeconds: 0
-            successThreshold: 0
-            timeoutSeconds: 0
-          name: "jnlp"
-          resourceLimitCpu: "4"
-          resourceLimitMemory: "10G"
-          resourceRequestCpu: "4"
-          resourceRequestMemory: "10G"
-          workingDir: "/home/jenkins"
-        label: "maven kubernetes container jdk8"
-        name: "jnlp-maven-jdk8"
-        instanceCap: 6
-        slaveConnectTimeout: 100
-        yamlMergeStrategy: "override"
-      - containers:
-        - alwaysPullImage: true
-          args: "^${computer.jnlpmac} ^${computer.name}"
-          command: "/usr/local/bin/jenkins-agent"
-          image: "jenkinsciinfra/inbound-agent-maven:jdk11"
-          livenessProbe:
-            failureThreshold: 0
-            initialDelaySeconds: 0
-            periodSeconds: 0
-            successThreshold: 0
-            timeoutSeconds: 0
-          name: "jnlp"
-          resourceLimitCpu: "4"
-          resourceLimitMemory: "12G"
-          resourceRequestCpu: "4"
-          resourceRequestMemory: "12G"
-          workingDir: "/home/jenkins"
-        label: "maven-11 kubernetes container jdk11"
-        name: "jnlp-maven-jdk11"
-        instanceCap: 6
-        slaveConnectTimeout: 100
-        yamlMergeStrategy: "override"
+      <% end %>
   nodes:
   - permanent:
       labelString: "ppc64le ppc64ledocker"

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -34,6 +34,45 @@ profile::buildmaster::java_opts: "-server -Xlog:gc*=info,ref*=debug,ergo*=trace,
 # Provide a path relative to the "templates/" directory
 profile::buildmaster::jcasc_configs:
   - azure.ci.jenkins.io/agents.yaml
+# Agents configuration
+profile::buildmaster::container_agents:
+  - name: ruby
+    image: jenkinsciinfra/inbound-agent-ruby:latest
+    labels:
+      - ruby
+    cpus: 2
+    memory: 4
+  - name: maven
+    image: jenkinsciinfra/inbound-agent-maven:jdk8
+    labels:
+      - maven
+      - jdk8
+    cpus: 2
+    memory: 4
+  - name: maven-11
+    image: jenkinsciinfra/inbound-agent-maven:jdk11
+    labels:
+      - maven-11
+      - jdk11
+    cpus: 2
+    memory: 4
+  - name: node
+    image: jenkinsciinfra/inbound-agent-node:latest
+    labels:
+      - node
+    cpus: 2
+    memory: 4
+  - name: alpine
+    image: jenkins/inbound-agent:alpine
+    labels:
+      - alpine
+    cpus: 1
+    memory: 2
+profile::buildmaster::k8s_workers:
+  cpus: 8
+  memory: 32
+  amount: 3
+
 # These are plugins we need in our ci environment
 profile::buildmaster::plugins:
   - ansicolor

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -7,6 +7,43 @@ profile::accountapp::smtp_password: 'smtp_password_example'
 profile::accountapp::jira_password: 'jira_password_example'
 
 profile::buildmaster::memory_limit: '1536m'
+profile::buildmaster::container_agents:
+  - name: ruby
+    image: jenkinsciinfra/inbound-agent-ruby:latest
+    labels:
+      - ruby
+    cpus: 2
+    memory: 4
+  - name: maven
+    image: jenkinsciinfra/inbound-agent-maven:jdk8
+    labels:
+      - maven
+      - jdk8
+    cpus: 2
+    memory: 4
+  - name: maven-11
+    image: jenkinsciinfra/inbound-agent-maven:jdk11
+    labels:
+      - maven-11
+      - jdk11
+    cpus: 2
+    memory: 4
+  - name: node
+    image: jenkinsciinfra/inbound-agent-node:latest
+    labels:
+      - node
+    cpus: 2
+    memory: 4
+  - name: alpine
+    image: jenkins/inbound-agent:alpine
+    labels:
+      - alpine
+    cpus: 1
+    memory: 2
+profile::buildmaster::k8s_workers:
+  cpus: 8
+  memory: 32
+  amount: 3
 profile::buildmaster::plugins:
   - ansicolor
   - azure-container-agents


### PR DESCRIPTION
This PR introduces the following changes:

- Use a common template for both ACI and kubernetes agents for ci.jenkins.io to avoid repeating values
  - Same hieradata for ci.jenkins.io and vagrant, but we can improve this or define different ones
  - By transitivity, its adds kubernetes pod templates for node and alpine (the 2 last missing for Linux platforms)
- Constrain the containers to 2 CPUs and 4 Gb given the metrics reports in Kubernetes (and decreasing ACI costs)
- Disable serverspec on the vagrant as it is not working anymore


The concurent limit of pod templates are defined per templates is calculated automatically, assuming that:

- CPU is the limiting part for now (to be improved math. minimum function with the memory)
- There are only 1 kind of worker: Linux with always the same amount of CPU and memory (values in the hieradata so updatecli willbe able to update it in the future
- Pod have the resource request and resource limit for CPU and memory
- There should always be a margin in resources to ensure that workers are not overloaded, it's a conservative setup as we lost conenction to workers during 2-3 minutes when packing too much builds

Example: with a cluster of 3 workers with 8 CPU each, you can start maximum 9 pod with 2 CPU each at the same time:
- 8 CPU means 4 pods theorically
- Minus 1 => 3 pod per worker (conservative)
- 3 worker * 3 pods => 9