### PR TITLE
Remove linux ACI agents, they are too unstable right now

### DIFF
--- a/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
@@ -192,18 +192,6 @@ jenkins:
       name: "ACI"
       resourceGroup: "eastus-cijenkinsio"
       templates:
-      <% @container_agents.each do |agent| %>
-      - command: "/usr/local/bin/jenkins-agent -url ^${rootUrl} ^${secret} ^${nodeName}"
-        cpu: "<%= agent["cpus"] %>"
-        image: "<%= agent["image"] %>"
-        label: "container azure <%= agent["labels"].join(' ') %>"
-        memory: "<%= agent["memory"] %>"
-        name: "aci-<%= agent["name"] %>"
-        osType: "Linux"
-        retentionStrategy: "containerOnce"
-        rootFs: "/home/jenkins"
-        timeout: 10
-      <% end %>
       - command: "pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl}\
           \ -Secret ^${secret} -Name ^${nodeName}"
         cpu: "2"


### PR DESCRIPTION
Numerous examples of 'missing workspace' recently

https://ci.jenkins.io/job/Tools/job/bom/job/PR-423/

Failed 7 times in a row, first build on kubernetes agents passed.

Jenkins core PRs are very unreliable too right now