### PR TITLE
feat: define a new capacity for kubernetes agents on ci.jenkins.io [INFRA-2918]

### DIFF
--- a/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
@@ -376,7 +376,8 @@ jenkins:
         useEphemeralDevices: true
       useInstanceProfileForCredentials: false
   - kubernetes:
-      # 3 workers at 8 CPUs/32Gi each
+      # Max 50 workers (8 CPU / 32 G) with 3 pods (2 CPU / 4G) each
+      containerCap: 150
       credentialsId: "cik8s-kubeconfig"
       directConnection: true
       name: "cik8s"
@@ -386,6 +387,7 @@ jenkins:
       - containers:
         - alwaysPullImage: true
           command: "/usr/local/bin/jenkins-agent"
+          args: ""
           image: "jenkins/inbound-agent:latest-jdk11"
           livenessProbe:
             failureThreshold: 0
@@ -415,6 +417,8 @@ jenkins:
             successThreshold: 0
             timeoutSeconds: 0
           name: "jnlp"
+          command: "/usr/local/bin/jenkins-agent"
+          args: ""
           resourceLimitCpu: "<%= agent["cpus"] %>"
           resourceLimitMemory: "<%= agent["memory"] %>G"
           resourceRequestCpu: "<%= agent["cpus"] %>"
@@ -422,8 +426,8 @@ jenkins:
           workingDir: "/home/jenkins"
         label: "container kubernetes <%= agent["labels"].join(' ') %>"
         name: "jnlp-<%= agent["name"] %>"
-        inheritFrom: "jnlp"
-        instanceCap: <%= (@k8s_workers["cpus"].to_i / agent["cpus"].to_i - 1) * @k8s_workers["amount"].to_i %>
+        imagePullSecrets:
+        - name: "jenkins-dockerhub"
         slaveConnectTimeout: 100
         yamlMergeStrategy: "override"
       <% end %>


### PR DESCRIPTION
This PR updates the kubernetes agents configuration on ci.jenkins.io:

- Following https://github.com/jenkins-infra/aws/pull/26 which defines the upper limit of worker nodes to 50, an overall capacity of 150 pods (e.g. average of 3 pods per node) is defined.
- Fixing an issue where the default command of a given container's pod was set to "sleep 99999" when not explictly defined
- Remove pod template inheritance to avoid unwanted behaviors.