### PR TITLE
fix: Set resources to 4 CPUs and 8 Gb per Kubernetes agent on ci.jenkins.io

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -38,7 +38,6 @@ class profile::buildmaster(
   $memory_limit                    = '1g',
   $java_opts                       = "-XshowSettings:vm -server -Xloggc:${container_jenkins_home}/gc-%t.log -XX:NumberOfGCLogFiles=5 -XX:+UseGCLogFileRotation -XX:GCLogFileSize=20m -XX:+PrintGC -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCCause -XX:+PrintTenuringDistribution -XX:+PrintReferenceGC -XX:+PrintAdaptiveSizePolicy -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:G1NewSizePercent=20 -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1 -Duser.home=${container_jenkins_home} -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2",
   $container_agents                = [],
-  $k8s_workers                     = {},
 ) {
   include ::stdlib
   include ::apache

--- a/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
@@ -376,8 +376,8 @@ jenkins:
         useEphemeralDevices: true
       useInstanceProfileForCredentials: false
   - kubernetes:
-      # Max 50 workers (8 CPU / 32 G) with 3 pods (2 CPU / 4G) each
-      containerCap: 150
+      # Max 50 workers (8 CPU / 32 G) with 2 pods (4 CPU / 8G) each
+      containerCap: 100
       credentialsId: "cik8s-kubeconfig"
       directConnection: true
       name: "cik8s"

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -68,10 +68,6 @@ profile::buildmaster::container_agents:
       - alpine
     cpus: 1
     memory: 2
-profile::buildmaster::k8s_workers:
-  cpus: 8
-  memory: 32
-  amount: 3
 
 # These are plugins we need in our ci environment
 profile::buildmaster::plugins:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -12,38 +12,34 @@ profile::buildmaster::container_agents:
     image: jenkinsciinfra/inbound-agent-ruby:latest
     labels:
       - ruby
-    cpus: 2
-    memory: 4
+    cpus: 4
+    memory: 8
   - name: maven
     image: jenkinsciinfra/inbound-agent-maven:jdk8
     labels:
       - maven
       - jdk8
-    cpus: 2
-    memory: 4
+    cpus: 4
+    memory: 8
   - name: maven-11
     image: jenkinsciinfra/inbound-agent-maven:jdk11
     labels:
       - maven-11
       - jdk11
-    cpus: 2
-    memory: 4
+    cpus: 4
+    memory: 8
   - name: node
     image: jenkinsciinfra/inbound-agent-node:latest
     labels:
       - node
-    cpus: 2
-    memory: 4
+    cpus: 4
+    memory: 8
   - name: alpine
     image: jenkins/inbound-agent:alpine
     labels:
       - alpine
-    cpus: 1
-    memory: 2
-profile::buildmaster::k8s_workers:
-  cpus: 8
-  memory: 32
-  amount: 3
+    cpus: 4
+    memory: 8
 profile::buildmaster::plugins:
   - ansicolor
   - azure-container-agents


### PR DESCRIPTION
This PR comes from https://github.com/jenkinsci/jenkins/pull/5667 (see. https://issues.jenkins.io/browse/INFRA-2918 for context on the Kubernetes agents).


It introduces the following new (empirical) changes:

* Set the resources of each pod template to 4 vCPUs and 8Gb to avoid timeouting on the Jenkins Core jobs
* Update the maximum pod limit accordingly (as we have 50 worker nodes max. See inline comment for the formula)
* Cleanup Puppet code remnants of previous PRs in this area


[DDU] Setting to draft as local vagrant test are currently being run