### PR TITLE
hotfix: trusted-ci failed because buildmaster profile code not considering non-Casced instances

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -262,11 +262,8 @@ class profile::buildmaster(
         notify  => Exec['perform-jcasc-reload'],
       }
     }
-  } else {
-    $jcasc_java_opt = ''
-  }
 
-  exec { 'perform-jcasc-reload':
+    exec { 'perform-jcasc-reload':
     require     => [
       Exec['install-plugin-configuration-as-code'],
     ],
@@ -276,6 +273,9 @@ class profile::buildmaster(
     try_sleep   => 10,
     refreshonly => true,
     logoutput   => true,
+  }
+  } else {
+    $jcasc_java_opt = ''
   }
 
   ##############################################################################


### PR DESCRIPTION
Puppet agent fails on trusted.ci with the following error:

```
Aug 17 10:05:17 ip-172-31-50-95 puppet-agent[2910]: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Could not find resource 'Exec[install-plugin-configuration-as-code]' in parameter 'require' (file: /etc/puppetlabs/code/environments/production/dist/profile/manifests/buildmaster.pp, line: 270) on node trusted-ci
```

It's related to the PR #1830 which did not considered the case of controller wihtout the casc plugin + config.

The fix here is naive but enough, as we will add plugin and config to ALL instances soon.

