### PR TITLE
Fix: [ci.jenkins.io] Define Kubernetes agents imagePullPolicy to 'IfNotPresent' [INFRA-3036]

### DIFF
--- a/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
@@ -384,28 +384,6 @@ jenkins:
       namespace: "jenkins-agents"
       serverUrl: "<%= @agents_kubernetes_cik8s_url %>"
       templates:
-      - containers:
-        - alwaysPullImage: false
-          command: "/usr/local/bin/jenkins-agent"
-          args: ""
-          image: "jenkins/inbound-agent:latest-jdk11"
-          livenessProbe:
-            failureThreshold: 0
-            initialDelaySeconds: 0
-            periodSeconds: 0
-            successThreshold: 0
-            timeoutSeconds: 0
-          name: "jnlp"
-          resourceLimitCpu: "1"
-          resourceLimitMemory: "1G"
-          resourceRequestCpu: "1"
-          resourceRequestMemory: "1G"
-          workingDir: "/home/jenkins"
-        name: "jnlp"
-        imagePullSecrets:
-        - name: "jenkins-dockerhub"
-        slaveConnectTimeout: 100
-        yamlMergeStrategy: "override"
       <% @container_agents.each do |agent| %>
       - containers:
         - alwaysPullImage: false
@@ -425,7 +403,7 @@ jenkins:
           resourceRequestMemory: "<%= agent["memory"] %>G"
           workingDir: "/home/jenkins"
         label: "container kubernetes <%= agent["labels"].join(' ') %>"
-        name: "jnlp-<%= agent["name"] %>"
+        name: "<%= agent["name"] %>"
         imagePullSecrets:
         - name: "jenkins-dockerhub"
         slaveConnectTimeout: 100

--- a/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
@@ -385,7 +385,7 @@ jenkins:
       serverUrl: "<%= @agents_kubernetes_cik8s_url %>"
       templates:
       - containers:
-        - alwaysPullImage: true
+        - alwaysPullImage: false
           command: "/usr/local/bin/jenkins-agent"
           args: ""
           image: "jenkins/inbound-agent:latest-jdk11"
@@ -408,7 +408,7 @@ jenkins:
         yamlMergeStrategy: "override"
       <% @container_agents.each do |agent| %>
       - containers:
-        - alwaysPullImage: true
+        - alwaysPullImage: false
           image: "<%= agent["image"] %>"
           livenessProbe:
             failureThreshold: 0

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -35,38 +35,45 @@ profile::buildmaster::jcasc_configs:
 profile::buildmaster::jcasc_reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAywKTuF4pmWjFgHZyW+wo4D5MDYRf7gVelgeLcIsZJy8t+Sw17vWA96vGIaAD2tklGILSn6snhskSYroQHkdv13gQGW1zcpP5N9wqhMOoA5nXrh9Gnb1F5JlPGlQyUxTA5gi+zjV8+B6athfjpKbkvK91RDkOPMMOkqBALp5E1xlsBpicri5Q1znik9shGPzccONvRw+wWsm0jPquoEdO1EnR17yqN60BOk1ZelY3AV9grLR6OZrRg8M6hl4JcI5SMfm9XUPB0BWQhHwZHlIW8sAmnR9aC7bsCEk16DH82V/HrBaJBYa8GiAr3LBFzy2jiNB0F/oK7XdVsN8AQyW6UjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDf4FrZNE5uqT3JiM8XUcSRgCCf8HyZFe7GPU+5puax+7Q50f+jT99rOmyBZg20AQTJeQ==]
 # Agents configuration
 profile::buildmaster::container_agents:
-  - name: ruby
+  - name: jnlp-ruby
     image: jenkinsciinfra/inbound-agent-ruby:latest
     labels:
       - ruby
     cpus: 2
     memory: 4
-  - name: maven
+  - name: jnlp-maven-8
     image: jenkinsciinfra/inbound-agent-maven:jdk8
     labels:
       - maven
       - jdk8
     cpus: 2
     memory: 4
-  - name: maven-11
+  - name: jnlp-maven-11
     image: jenkinsciinfra/inbound-agent-maven:jdk11
     labels:
       - maven-11
       - jdk11
     cpus: 2
     memory: 4
-  - name: node
+  - name: jnlp-node
     image: jenkinsciinfra/inbound-agent-node:latest
     labels:
       - node
     cpus: 2
     memory: 4
-  - name: alpine
+  - name: jnlp-alpine
     image: jenkins/inbound-agent:alpine
     labels:
       - alpine
     cpus: 1
     memory: 2
+  - name: jnlp
+    image: jenkins/inbound-agent:latest-jdk11
+    labels:
+      - default
+    cpus: 1
+    memory: 1
+
 
 # These are plugins we need in our ci environment
 profile::buildmaster::plugins:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -10,38 +10,44 @@ profile::buildmaster::docker_image: 'jenkins/jenkins'
 profile::buildmaster::docker_tag: 'lts-jdk11'
 profile::buildmaster::memory_limit: '1536m'
 profile::buildmaster::container_agents:
-  - name: ruby
+  - name: jnlp-ruby
     image: jenkinsciinfra/inbound-agent-ruby:latest
     labels:
       - ruby
-    cpus: 4
-    memory: 8
-  - name: maven
+    cpus: 2
+    memory: 4
+  - name: jnlp-maven-8
     image: jenkinsciinfra/inbound-agent-maven:jdk8
     labels:
       - maven
       - jdk8
-    cpus: 4
-    memory: 8
-  - name: maven-11
+    cpus: 2
+    memory: 4
+  - name: jnlp-maven-11
     image: jenkinsciinfra/inbound-agent-maven:jdk11
     labels:
       - maven-11
       - jdk11
-    cpus: 4
-    memory: 8
-  - name: node
+    cpus: 2
+    memory: 4
+  - name: jnlp-node
     image: jenkinsciinfra/inbound-agent-node:latest
     labels:
       - node
-    cpus: 4
-    memory: 8
-  - name: alpine
+    cpus: 2
+    memory: 4
+  - name: jnlp-alpine
     image: jenkins/inbound-agent:alpine
     labels:
       - alpine
-    cpus: 4
-    memory: 8
+    cpus: 1
+    memory: 2
+  - name: jnlp
+    image: jenkins/inbound-agent:latest-jdk11
+    labels:
+      - default
+    cpus: 1
+    memory: 1
 profile::buildmaster::plugins:
   - ansicolor
   - azure-container-agents


### PR DESCRIPTION
This PR is related to INFRA-3036.

It's goal is to limit the amount of Kubernetes Agents for ci.jenkins.io to stay in state "ErrImagePullBackOff".

By setting up the image pull policy to `IfNotPresent`, it ensures that the pod images are only pulled one time on the worker nodes.

The consequence is that a new Docker image published under the tag `latest` won't be used unless on a new worker node.
This issue will be fixed in a subsequent PRs, but there is a commit here to lay the foundation by moving ALL the kubernetes pod templates into Hieradata.