### PR TITLE
Updatecli check that docker image tag exist

### DIFF
--- a/updatecli/updatecli.d/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/jenkins-lts.yaml
@@ -30,6 +30,11 @@ conditions:
         username: "{{ .github.username }}"
         branch: "{{ .github.branch }}"
 
+  testDockerImageExist:
+    kind: dockerImage
+    spec:
+      image: "jenkins/jenkins"
+
 targets:
   imageTag:
     name: "Update Docker Image Digest for jenkins/jenkins:lts"


### PR DESCRIPTION
Ensure that updatecli test that the new docker image exist before updating the hieradata

### Signed-off-by: Olivier Vernin <olivier@vernin.me>