### PR TITLE
feat: [ci.jenkins.io] remove imagePullSecret from kubernetes agents

### DIFF
--- a/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
@@ -404,8 +404,6 @@ jenkins:
           workingDir: "/home/jenkins"
         label: "container kubernetes <%= agent["labels"].join(' ') %>"
         name: "<%= agent["name"] %>"
-        imagePullSecrets:
-        - name: "jenkins-dockerhub"
         slaveConnectTimeout: 100
         yamlMergeStrategy: "override"
       <% end %>


### PR DESCRIPTION
As per INFRA-3036, now that we have defined the image pull policy to `IfNot present` + enabled autoscaling, the DockerHub API limit should not be reached anymore (or at least not on 80% of the builds).

This PR removes the pullsecret so it's one credential less to maintain.