### PR TITLE
fix: [ci.jenkins.io] remove unsupported JDK8 tools installations

### DIFF
--- a/dist/profile/templates/azure.ci.jenkins.io/tools.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/tools.yaml.erb
@@ -38,23 +38,23 @@ tool:
           installers:
           - zip:
               label: "linux"
-              subdir: "jdk-<%= @tools["jdk8"]["version"] %>"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
               url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_x64_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
           - zip:
               label: "windows"
-              subdir: "jdk-11.0.6+10"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
               url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_x64_windows_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.zip"
           - zip:
               label: "arm64"
-              subdir: "jdk-11.0.6+10"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
               url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_aarch64_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
           - zip:
               label: "ppc64le"
-              subdir: "jdk-11.0.6+10"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
               url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_ppc64le_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
           - zip:
               label: "s390x"
-              subdir: "jdk-11.0.6+10"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
               url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_s390x_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
   maven:
     installations:

--- a/dist/profile/templates/azure.ci.jenkins.io/tools.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/tools.yaml.erb
@@ -25,10 +25,6 @@ tool:
               subdir: "jdk<%= @tools["jdk8"]["version"] %>"
               url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_x64_windows_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.zip"
           - zip:
-              label: "windowspacker"
-              subdir: "jdk<%= @tools["jdk8"]["version"] %>"
-              url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_x64_windows_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.zip"
-          - zip:
               label: "arm64"
               subdir: "jdk<%= @tools["jdk8"]["version"] %>"
               url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_aarch64_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
@@ -36,10 +32,6 @@ tool:
               label: "ppc64le"
               subdir: "jdk<%= @tools["jdk8"]["version"] %>"
               url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_ppc64le_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
-          - zip:
-              label: "s390x"
-              subdir: "jdk<%= @tools["jdk8"]["version"] %>"
-              url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>_openj9-0.26.0/OpenJDK8U-jdk_s390x_linux_openj9_<%= @tools["jdk8"]["version"].gsub('-', '') %>_openj9-0.26.0.tar.gz"
     - name: "jdk11"
       properties:
       - installSource:


### PR DESCRIPTION
After #1848 was merged and deployed, the ci.jenkins.io UI show the errror and warning below.

<img width="1696" alt="Capture d’écran 2021-09-01 à 08 36 56" src="https://user-images.githubusercontent.com/1522731/131624343-9c1a4b4a-af73-46c0-bc01-e4ff49093c36.png">

<img width="1678" alt="Capture d’écran 2021-09-01 à 08 37 01" src="https://user-images.githubusercontent.com/1522731/131624354-30ee9b96-467c-4529-874e-e7b4d1611101.png">


This PR removes the tools installations that are triggering this 2 messages:

- The `windowspacker` agent does not exist anymore
- OpenJDK8 is not provided for s390x by Adoptium project *except* for the Docker image: https://hub.docker.com/_/eclipse-temurin/


THis PR also fixes the configuration errors in the JDK11 tool configuration that were introduded in #1848 