### PR TITLE
Fix JenkinsRule test failures - install fontconfig pkg

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -76,7 +76,7 @@ profile::buildmaster::container_agents:
 profile::buildmaster::ec2_agents:
   - description: "Ubuntu 20.04 LTS"
     maxInstances: 5
-    amiId: "ami-008a58d505497af7d"
+    amiId: "ami-07f1fc1d40738a4af"
     instanceType: T3aLarge
     os: "linux"
     architecture: "amd64"
@@ -103,7 +103,7 @@ profile::buildmaster::ec2_agents:
       - docker
   - description: "ARM64 ubuntu 20.04"
     maxInstances: 2
-    amiId: "ami-0caa36941c409bfd0"
+    amiId: "ami-0b00f8b197dbe48a3"
     instanceType: A1Xlarge
     os: "linux"
     architecture: "arm64"


### PR DESCRIPTION
## Fix JenkinsRule test failures - install fontconfig pkg

The JDK reports a null pointer exception during some JenkinsRule tests if the fontconfig package is not installed on Linux computers.  See the git plugin, git client plugin, platformlabeler plugin, and others for examples.  The fontconfig package is installed in our Docker controller and agent images.  https://github.com/jenkins-infra/packer-images/pull/86 added it to the packer image definition files.  The https://ci.jenkins.io/job/Infra/job/packer-images/job/main/189/ job built that image using https://github.com/jenkins-infra/packer-images/commit/421f74a2a889242fd8934c6589c9d91c42f632c1

This pull request extracted the AMI ID from the packer-images job and inserted it for the amd64 and arm64 images.
