### PR TITLE
Do not install Intel Java on Arm processors

### DIFF
--- a/dist/profile/templates/azure.ci.jenkins.io/tools.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/tools.yaml.erb
@@ -17,7 +17,7 @@ tool:
       - installSource:
           installers:
           - zip:
-              label: "linux"
+              label: "linux && amd64"
               subdir: "jdk<%= @tools["jdk8"]["version"] %>"
               url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_x64_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
           - zip:
@@ -25,7 +25,7 @@ tool:
               subdir: "jdk<%= @tools["jdk8"]["version"] %>"
               url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_x64_windows_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.zip"
           - zip:
-              label: "arm64"
+              label: "linux && arm64"
               subdir: "jdk<%= @tools["jdk8"]["version"] %>"
               url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_aarch64_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
           - zip:
@@ -37,7 +37,7 @@ tool:
       - installSource:
           installers:
           - zip:
-              label: "linux"
+              label: "linux && amd64"
               subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
               url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_x64_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
           - zip:
@@ -45,7 +45,7 @@ tool:
               subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
               url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_x64_windows_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.zip"
           - zip:
-              label: "arm64"
+              label: "linux && arm64"
               subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
               url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_aarch64_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
           - zip:


### PR DESCRIPTION
## Don't install Intel Java on Arm

Previously was configured to install Intel Java (x64) on any agent with the label "linux".  Since we have agents running Linux on Arm64, PowerPC 64LE, and s390x, we need to more precisely declare that the Intel Java is targeted at Intel architecture.

Also made it clear that Arm64 Java is targeted at Arm on Linux.  Microsoft is now selling Arm based computers with Windows, but they don't have anything in the Azure cloud with Windows on Arm as far as I know.

Did not adjust ppc64le or s390x because they do not yet have the linux label yet, even though they are running Linux.
