### PR TITLE
feat: [ci.jenkins.io] change Azure VM sizing 

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -46,7 +46,7 @@ jenkins:
         templateDesc: "Dynamically provisioned <%= agent["description"] %> machine"
         templateDisabled: false
         templateName: "<%= agent["name"] %>"
-        usageMode: "Use this node as much as possible"
+        usageMode: "<%= agent["useAsMuchAsPosible"] == true ? 'Use this node as much as possible' : 'Only build jobs with label expressions matching this node' %>"
         usePrivateIP: false
         virtualMachineSize: "<%= agent["instanceType"] %>"
     <%- end -%>

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -121,7 +121,7 @@ profile::buildmaster::cloud_agents:
         os: "ubuntu"
         storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEA05ciDWdydYYcaHSCRxPVWUFhxuqe1c+odQBXXv1ccdKG7tiUWr5+uIIUn2ZWTVc7wKwwT+Y+QuBP3wWP+j9Y42w6WKTGOqB3iZkfe8eY+kYr4/ISMBCktfWuUe6/EML5z6TbZ3cMyMirx6Sl2SgZfIuTRi/C0Z9hErCXDZS0jNQYkZ799t31dNKEkDQkX0K377LPmRfB5WGGyjquLYGB1pHq6z283Nq25sa/ePAXJ5s7K0AI5a1IrhcNbj6+XLvAmWpRvYAar4R5Q9G43M6Y2wR3wQdbT/UvLNmoJyckOjNUHVnjICoqVAqlRk//pH5MA4Kfvm6CUlPPX6bFqQmUfjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDrpvHjhf8cEEo+DN/KoRu7gCCHoOVwkjNG9DdwFioWyKiCu2+8f0iBM6FkdnbwpE3AWg==]
         location: "East US 2"
-        instanceType: Standard_DS4
+        instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
         architecture: amd64
         labels:
           - java
@@ -129,13 +129,14 @@ profile::buildmaster::cloud_agents:
           - docker
         idleTerminationMinutes: 5
         maxInstances: 10
+        useAsMuchAsPosible: true
       - name: "ubuntu-20-highmem"
         description: "Ubuntu 20.04 LTS Highmem"
         imageDefinition: jenkins-agent-ubuntu-20
         os: "ubuntu"
         storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEA05ciDWdydYYcaHSCRxPVWUFhxuqe1c+odQBXXv1ccdKG7tiUWr5+uIIUn2ZWTVc7wKwwT+Y+QuBP3wWP+j9Y42w6WKTGOqB3iZkfe8eY+kYr4/ISMBCktfWuUe6/EML5z6TbZ3cMyMirx6Sl2SgZfIuTRi/C0Z9hErCXDZS0jNQYkZ799t31dNKEkDQkX0K377LPmRfB5WGGyjquLYGB1pHq6z283Nq25sa/ePAXJ5s7K0AI5a1IrhcNbj6+XLvAmWpRvYAar4R5Q9G43M6Y2wR3wQdbT/UvLNmoJyckOjNUHVnjICoqVAqlRk//pH5MA4Kfvm6CUlPPX6bFqQmUfjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDrpvHjhf8cEEo+DN/KoRu7gCCHoOVwkjNG9DdwFioWyKiCu2+8f0iBM6FkdnbwpE3AWg==]
         location: "East US 2"
-        instanceType: Standard_D16_v4
+        instanceType: Standard_D16s_v3 # 16 vCPUS / 64 Gb
         architecture: amd64
         labels:
           - linux
@@ -145,18 +146,20 @@ profile::buildmaster::cloud_agents:
           - docker
         idleTerminationMinutes: 5
         maxInstances: 10
-      - name: "windows-2019"
+        useAsMuchAsPosible: false
+      - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
         description: "Windows 2019"
         imageDefinition: jenkins-agent-windows-2019
         os: "windows"
         storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAFzRCKUXn+sqnS8toXrOWHCY6sUCgbaF9C8nLhuk1lAThsANcJpA1AVGvNx8UlwOvND8hr7MBsiKbJ1y1XVUfz6+SHF+HoXLqLdM+gqhcuDk6XRujZbqcZ3nI0VE/KtcBSfcBSQIcF4ClQeP9j3Pq4UqMoUhfzTqUj2ZOj4tvonEoY+H8glNpKytgY3Ysu2hiPm+0a4o6G6zCYuRaDy12gzU9Fizw/4xwROf4pCwSss6wV6O0MR81wJb8yK0wf7jRRTzxnwk1J53h3H9/ExIqiHNKhWkUCCusj/M+rAzH4z3lquvPbp/NCdtcwb6QzCvy7gfUiKYmyvR89eAIKiKCNzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBavWhbfJHjls5kGE4uWTAggCCDnUYqBwxDKQMn071k+GA7+sikbhAro6sMtoG+Cdh5sg==]
         location: "East US 2"
-        instanceType: Standard_DS4_v2
+        instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
         architecture: amd64
         labels:
           - windock
         idleTerminationMinutes: 30
         maxInstances: 10
+        useAsMuchAsPosible: true
   azure-container-agents:
     aci-windows:
       resource_group: eastus-cijenkinsio

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -96,7 +96,7 @@ profile::buildmaster::cloud_agents:
         os: "ubuntu"
         storageAccount: SuperSecretThatShouldBeEncryptedInProduction
         location: "East US 2"
-        instanceType: Standard_DS4
+        instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
         architecture: amd64
         labels:
           - java
@@ -104,13 +104,14 @@ profile::buildmaster::cloud_agents:
           - docker
         idleTerminationMinutes: 5
         maxInstances: 10
+        useAsMuchAsPosible: true
       - name: "ubuntu-20-highmem"
         description: "Ubuntu 20.04 LTS Highmem"
         imageDefinition: jenkins-agent-ubuntu-20
         os: "ubuntu"
         storageAccount: SuperSecretThatShouldBeEncryptedInProduction
         location: "East US 2"
-        instanceType: Standard_D16_v4
+        instanceType: Standard_D16s_v3 # 16 vCPUS / 64 Gb
         architecture: amd64
         labels:
           - linux
@@ -120,18 +121,20 @@ profile::buildmaster::cloud_agents:
           - docker
         idleTerminationMinutes: 5
         maxInstances: 10
-      - name: "windows-2019"
+        useAsMuchAsPosible: false
+      - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
         description: "Windows 2019"
         imageDefinition: jenkins-agent-windows-2019
         os: "windows"
         storageAccount: SuperSecretThatShouldBeEncryptedInProduction
         location: "East US 2"
-        instanceType: Standard_DS4_v2
+        instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
         architecture: amd64
         labels:
           - windock
         idleTerminationMinutes: 30
         maxInstances: 10
+        useAsMuchAsPosible: true
   azure-container-agents:
     aci-windows:
       resource_group: eastus-cijenkinsio


### PR DESCRIPTION
To ensure that quota are ok (we can change it if we select another generation) and that ephemeral disks can be used.

Tested in https://ci.jenkins.io/blue/organizations/jenkins/Infra%2Fterraform/detail/jenkins/257/pipeline/8

[edit]

- Adding comments in the YAML to ease reading of instance sizes
- Define the highmem (for azure) instance to be used only if there is a label (not as much as possible) to avoid using this expensive instancez for tiny builds (incoming PR for the same in EC2)