### PR TITLE
feat: [ci.jenkins.io] change AWS EC2 sizing 

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -106,7 +106,7 @@ jenkins:
         maxTotalUses: 30
         minimumNumberOfInstances: 0
         minimumNumberOfSpareInstances: 0
-        mode: NORMAL
+        mode: <%= agent["useAsMuchAsPosible"] == true ? 'NORMAL' : 'EXCLUSIVE' %>
         monitoring: false
         numExecutors: 1
         remoteAdmin: "<%= @agents_setup[agent["os"].to_s]["remoteAdmin"] %>"

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -80,23 +80,25 @@ profile::buildmaster::cloud_agents:
       agent_definitions:
         - description: "Ubuntu 20.04 LTS"
           maxInstances: 5
-          instanceType: T3aLarge
+          instanceType: T3Xlarge # 8 vCPUs / 16 Gb
           os: "ubuntu"
           architecture: "amd64"
           labels:
             - java
             - docker
             - linux
+          useAsMuchAsPosible: true
         - description: "Windows 2019"
           maxInstances: 10
-          instanceType: T3Xlarge
+          instanceType: T3Xlarge # 8 vCPUs / 16 Gb
           os: "windows"
           architecture: "amd64"
           labels:
             - windock
+          useAsMuchAsPosible: true
         - description: "High memory ubuntu 20.04"
           maxInstances: 20
-          instanceType: M5ad4xlarge
+          instanceType: M54xlarge # 16 vCPUS / 64 Gb
           os: "ubuntu"
           architecture: "amd64"
           labels:
@@ -104,14 +106,16 @@ profile::buildmaster::cloud_agents:
             - highram
             - docker
             - linux
+          useAsMuchAsPosible: false
         - description: "ARM64 ubuntu 20.04"
           maxInstances: 2
-          instanceType: A1Xlarge
+          instanceType: A1Xlarge # 4 vCPUs / 8 Gb
           os: "ubuntu"
           architecture: "arm64"
           labels:
             - arm64docker
             - linux
+          useAsMuchAsPosible: false
   azure-vm-agents:
     resource_group: eastus-cijenkinsio
     agent_definitions:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -55,23 +55,25 @@ profile::buildmaster::cloud_agents:
       agent_definitions:
         - description: "Ubuntu 20.04 LTS"
           maxInstances: 5
-          instanceType: T3aLarge
+          instanceType: T3Xlarge # 8 vCPUs / 16 Gb
           os: "ubuntu"
           architecture: "amd64"
           labels:
             - java
             - docker
             - linux
+          useAsMuchAsPosible: true
         - description: "Windows 2019"
           maxInstances: 10
-          instanceType: T3Xlarge
+          instanceType: T3Xlarge # 8 vCPUs / 16 Gb
           os: "windows"
           architecture: "amd64"
           labels:
             - windock
+          useAsMuchAsPosible: true
         - description: "High memory ubuntu 20.04"
           maxInstances: 20
-          instanceType: M5ad4xlarge
+          instanceType: M54xlarge # 16 vCPUS / 64 Gb
           os: "ubuntu"
           architecture: "amd64"
           labels:
@@ -79,14 +81,16 @@ profile::buildmaster::cloud_agents:
             - highram
             - docker
             - linux
+          useAsMuchAsPosible: false
         - description: "ARM64 ubuntu 20.04"
           maxInstances: 2
-          instanceType: A1Xlarge
+          instanceType: A1Xlarge # 4 vCPUs / 8 Gb
           os: "ubuntu"
           architecture: "arm64"
           labels:
             - arm64docker
             - linux
+          useAsMuchAsPosible: false
   azure-vm-agents:
     resource_group: eastus-cijenkinsio
     agent_definitions:


### PR DESCRIPTION
- decrease highmem cost by using instances with same amount of vCPUs and memory, but EBS instead of expensive local NVMe
- Homogeneize small instances to map with Azure's and containers (4 vCPUs)
- Ensure that highmem instances are only used for job requesting their label
