### PR TITLE
feat: manage clouds and tools with Casc on trusted.ci.jenkins.io

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -240,6 +240,10 @@ class profile::buildmaster(
     ],
     config_dir =>     'casc.d', # Relative to the jenkins_home
   }
+
+  ### Deep merge the different sources (because hieradata 3 fails at deep merge, but with hieradata 5 we will be able to delegate)
+  $tools = deep_merge($default_tools, $additional_tools)
+
   $jcasc_final_config = $jcasc_default_config + $jcasc
 
   if $jcasc_final_config["enabled"] {

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -38,7 +38,8 @@ class profile::buildmaster(
   $cloud_setups                    = {},
   $agents_setup                    = {},
   $agent_images                    = {},
-  $tools                           = {},
+  $additional_tools                = {},
+  $default_tools                   = {},
   $memory_limit                    = '1g',
   $java_opts = "-server \
 -Xlog:gc*=info,ref*=debug,ergo*=trace,age*=trace:file=${container_jenkins_home}/gc/gc.log::filecount=5,filesize=40M \

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -233,7 +233,10 @@ class profile::buildmaster(
     enabled =>        false, # Disabled by default to avoid messing up with unmanaged instances
     custom_configs => [],
     reload_token =>   '',
-    common_configs => ['buildmaster/casc/clouds.yaml.erb'],
+    common_configs => [ # Configurations shared by all Jenkins controllers. There are hieradata attribute to really fill the configs (as an additional step for opt-in)
+      'buildmaster/casc/clouds.yaml.erb',
+      'buildmaster/casc/tools.yaml.erb',
+    ],
     config_dir =>     'casc.d', # Relative to the jenkins_home
   }
   $jcasc_final_config = $jcasc_default_config + $jcasc

--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -5,7 +5,7 @@ jenkins:
 <%- # Creating one cloud per template because there is no "maxVirtualMachinesLimit" directive applicable for a single template -%>
   <%- @cloud_agents["azure-vm-agents"]["agent_definitions"].each do |agent| -%>
   - azureVM:
-      azureCredentialsId: "azure-credentials"
+      azureCredentialsId: "<%= @cloud_agents["azure-vm-agents"]["azureCredentialsId"] %>"
       cloudName: "azure-<%= agent["name"] %>"
       configurationStatus: "pass"
       deploymentTimeout: 1200
@@ -14,7 +14,7 @@ jenkins:
       vmTemplates:
       - agentLaunchMethod: "SSH"
         agentWorkspace: "<%= @agents_setup[agent["os"]]["agentDir"] %>"
-        credentialsId: "jenkinsvmagents-userpass"
+        credentialsId: "<%= agent["credentialsId"] %>"
         diskType: "managed"
         doNotUseMachineIfInitFails: true
         enableMSI: false
@@ -54,7 +54,7 @@ jenkins:
 <%- if @cloud_agents["azure-container-agents"] && !@cloud_agents["azure-container-agents"].empty? -%>
   <%- @cloud_agents["azure-container-agents"].each do |aci_cloud_name, aci_cloud_setup| -%>
   - aci:
-      credentialsId: "azure-credentials"
+      credentialsId: "<%= @cloud_agents["azure-container-agents"]["azureCredentialsId"] %>"
       name: "<%= aci_cloud_name %>"
       resourceGroup: "<%= aci_cloud_setup["resource_group"] %>"
       templates:
@@ -76,13 +76,13 @@ jenkins:
   <%- @cloud_agents["ec2"].each do |ec2_cloud_name, ec2_cloud_setup| -%>
   - amazonEC2:
       cloudName: <%= ec2_cloud_name %>
-      credentialsId: "aws-credentials"
+      credentialsId: "<%= ec2_cloud_setup["credentialsId"] %>"
       <%- $maxEC2Vms = 0; ec2_cloud_setup["agent_definitions"].each do |agent| -%>
         <%- $maxEC2Vms = agent["maxInstances"] + $maxEC2Vms -%>
       <%- end -%>
       instanceCapStr: "<%= $maxEC2Vms %>"
       region: "<%= ec2_cloud_setup["region"] %>"
-      sshKeysCredentialsId: "ec2-agent-ssh-2021-06"
+      sshKeysCredentialsId: "<%= ec2_cloud_setup["sshKeysCredentialsId"] %>"
       useInstanceProfileForCredentials: false
       templates:
       <%- ec2_cloud_setup["agent_definitions"].each do |agent| -%>
@@ -133,7 +133,7 @@ jenkins:
   - kubernetes:
       name: "<%= k8s_name %>"
       containerCap: <%= k8s_setup["max_capacity"] %>
-      credentialsId: "cik8s-kubeconfig"
+      credentialsId: "<%= k8s_setup["credentialsId"] %>"
       directConnection: true
       namespace: "jenkins-agents"
       serverUrl: "<%= k8s_setup["url"] %>"

--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -41,7 +41,7 @@ jenkins:
         preInstallSsh: false
         retentionStrategy:
           azureVMCloudRetentionStrategy:
-            idleTerminationMinutes: 5
+            idleTerminationMinutes: "<%= agent["idleTerminationMinutes"] %>"
         shutdownOnIdle: false
         templateDesc: "Dynamically provisioned <%= agent["description"] %> machine"
         templateDisabled: false
@@ -99,7 +99,7 @@ jenkins:
         ebsEncryptRootVolume: DEFAULT
         ebsOptimized: false
         hostKeyVerificationStrategy: ACCEPT_NEW
-        idleTerminationMinutes: "30"
+        idleTerminationMinutes: "<%= agent["idleTerminationMinutes"] %>"
         instanceCapStr: "<%= agent["maxInstances"] %>"
         labelString: "<%= agent["os"] %> <%= agent["architecture"] %> aws ec2 vm <%= agent["labels"].join(' ') %>"
         launchTimeoutStr: "1000"

--- a/dist/profile/templates/buildmaster/casc/tools.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/tools.yaml.erb
@@ -1,15 +1,18 @@
+<%- if @tools && !@tools.empty? -%>
 tool:
   git:
     installations:
     - name: "jgit"
   groovy:
     installations:
-    - name: "groovy"
+    <%- @tools["groovy"].each do |name, setup| %>
+    - name: "<%= name %>"
       properties:
       - installSource:
           installers:
           - groovyInstaller:
-              id: "<%= @tools["groovy"]["version"] %>"
+              id: "<%= setup["version"] %>"
+    <%- end -%>
   jdk:
     installations:
     - name: "jdk8"
@@ -82,12 +85,15 @@ tool:
               url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_s390x_linux_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.tar.gz"
   maven:
     installations:
-    - name: "mvn"
+    <%- @tools["maven"].each do |name, setup| -%>
+    - name: "<%= name %>"
       properties:
       - installSource:
           installers:
           - maven:
-              id: "<%= @tools["maven"]["version"] %>"
+              id: "<%= setup["version"] %>"
+    <%- end -%>
   mavenGlobalConfig:
     globalSettingsProvider: "standard"
     settingsProvider: "standard"
+<%- end -%>

--- a/dist/profile/templates/trusted.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/trusted.ci.jenkins.io/agents.yaml.erb
@@ -1,0 +1,23 @@
+---
+jenkins:
+  # No builds on controller
+  numExecutors: 0
+  agentProtocols:
+  - "JNLP4-connect"
+  - "Ping"
+  nodes:
+  - permanent:
+      labelString: "updatecenter census"
+      launcher:
+        ssh:
+          credentialsId: "0e73a07a-5f72-4a90-bcce-5dcfcd10aea8"
+          host: "172.31.5.190"
+          maxNumRetries: 0
+          port: 22
+          retryWaitTime: 0
+          sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+      mode: EXCLUSIVE
+      name: "agent-1"
+      numExecutors: 2
+      remoteFS: "/mnt/jenkins/agent-workspace"
+      retentionStrategy: "always"

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -32,7 +32,6 @@ profile::buildmaster::jcasc:
   enabled: true
   custom_configs:
     - azure.ci.jenkins.io/agents.yaml.erb
-    - azure.ci.jenkins.io/tools.yaml.erb
   reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAywKTuF4pmWjFgHZyW+wo4D5MDYRf7gVelgeLcIsZJy8t+Sw17vWA96vGIaAD2tklGILSn6snhskSYroQHkdv13gQGW1zcpP5N9wqhMOoA5nXrh9Gnb1F5JlPGlQyUxTA5gi+zjV8+B6athfjpKbkvK91RDkOPMMOkqBALp5E1xlsBpicri5Q1znik9shGPzccONvRw+wWsm0jPquoEdO1EnR17yqN60BOk1ZelY3AV9grLR6OZrRg8M6hl4JcI5SMfm9XUPB0BWQhHwZHlIW8sAmnR9aC7bsCEk16DH82V/HrBaJBYa8GiAr3LBFzy2jiNB0F/oK7XdVsN8AQyW6UjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDf4FrZNE5uqT3JiM8XUcSRgCCf8HyZFe7GPU+5puax+7Q50f+jT99rOmyBZg20AQTJeQ==]
 profile::buildmaster::cloud_agents:
   kubernetes:
@@ -182,20 +181,6 @@ profile::buildmaster::cloud_agents:
           memory: 8
           labels:
             - maven-11-window
-profile::buildmaster::tools:
-  jdk8:
-    version: "8u302-b08"
-    sourceURL: https://github.com/adoptium/temurin8-binaries/releases/download
-  jdk11:
-    version: "11.0.12+7"
-    sourceURL: https://github.com/adoptium/temurin11-binaries/releases/download
-  jdk17:
-    version: "17+35"
-    sourceURL: https://github.com/adoptium/temurin17-binaries/releases/download
-  maven:
-    version: "3.8.1"
-  groovy:
-    version: "2.4.7"
 # These are plugins we need in our ci environment
 profile::buildmaster::plugins:
   - ansicolor

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -36,6 +36,7 @@ profile::buildmaster::jcasc:
 profile::buildmaster::cloud_agents:
   kubernetes:
     cik8s:
+      credentialsId: "cik8s-kubeconfig"
       max_capacity: 100 # Max 50 workers (8 CPU / 32 G) with 2 pods (4 CPU / 8G) each
       url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAF1QzoLi/6iki6G5iXpZPTQfRhQMUg/+gnz/0mBSPjyKmN2FJO4Q0AvEB64cR0geLnNdQB4Nylkm5Yxyy633TG6iRFokFiBf2L/jx1hCFXWESpRZv3Jcqm4Lb4LlhNdmV3w5pQcBdEFeqvqUM8MB+25eVMnapR2Cj9B5ozJuMmAarp17hKOZmzDXvS/eX09ybvQt5WZckMbHch1iUBtCqWy8Ze0LEN2LuyEtR3kyRBbSGknUzS763AsVTw5sZ32MdYkGVHuEZTZ+GIW9WQWj7xhCeGfoVMGvhC+v24s+KycoDXRVkjNRkECc0QY7Brp8XjqxgYeJtlRzfJn1wVbtD5TB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBC4DXAv9aHddQFOkb7bSms0gFAEf+Cgob9UbWdKJmgrSdyol3A/+NwNpUJI0OaZAWllKc0NBqPeQE6qor407wYQobMPpbeebr/scI+NkU5wInwuWDlqlra1XrRdYJ+6b2/83g==]
       agent_definitions:
@@ -76,6 +77,8 @@ profile::buildmaster::cloud_agents:
   ec2:
     aws-us-east-2:
       region: us-east-2
+      credentialsId: "aws-credentials"
+      sshKeysCredentialsId: "ec2-agent-ssh-2021-06"
       agent_definitions:
         - description: "Ubuntu 20.04 LTS"
           maxInstances: 5
@@ -116,6 +119,7 @@ profile::buildmaster::cloud_agents:
             - linux
           useAsMuchAsPosible: false
   azure-vm-agents:
+    azureCredentialsId: "azure-credentials"
     resource_group: eastus-cijenkinsio
     agent_definitions:
       - name: "ubuntu-20"
@@ -133,6 +137,7 @@ profile::buildmaster::cloud_agents:
         idleTerminationMinutes: 5
         maxInstances: 10
         useAsMuchAsPosible: true
+        credentialsId: "jenkinsvmagents-userpass"
       - name: "ubuntu-20-highmem"
         description: "Ubuntu 20.04 LTS Highmem"
         imageDefinition: jenkins-agent-ubuntu-20
@@ -150,6 +155,7 @@ profile::buildmaster::cloud_agents:
         idleTerminationMinutes: 5
         maxInstances: 10
         useAsMuchAsPosible: false
+        credentialsId: "jenkinsvmagents-userpass"
       - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
         description: "Windows 2019"
         imageDefinition: jenkins-agent-windows-2019
@@ -163,7 +169,9 @@ profile::buildmaster::cloud_agents:
         idleTerminationMinutes: 30
         maxInstances: 10
         useAsMuchAsPosible: true
+        credentialsId: "jenkinsvmagents-userpass"
   azure-container-agents:
+    credentialsId: "azure-credentials"
     aci-windows:
       resource_group: eastus-cijenkinsio
       agent_definitions:

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -90,6 +90,7 @@ profile::buildmaster::cloud_agents:
             - docker
             - linux
           useAsMuchAsPosible: true
+          idleTerminationMinutes: 5 # Quick deallocation as Linux is billed per minute
         - description: "Windows 2019"
           maxInstances: 10
           instanceType: T3Xlarge # 8 vCPUs / 16 Gb
@@ -98,6 +99,7 @@ profile::buildmaster::cloud_agents:
           labels:
             - windock
           useAsMuchAsPosible: true
+          idleTerminationMinutes: 30 # Windows is billed per hour: let's wait half of this period since most of the builds are less than 30 min on Windows
         - description: "High memory ubuntu 20.04"
           maxInstances: 20
           instanceType: M54xlarge # 16 vCPUS / 64 Gb
@@ -109,6 +111,7 @@ profile::buildmaster::cloud_agents:
             - docker
             - linux
           useAsMuchAsPosible: false
+          idleTerminationMinutes: 5 # Quick deallocation as Linux is billed per minute
         - description: "ARM64 ubuntu 20.04"
           maxInstances: 2
           instanceType: A1Xlarge # 4 vCPUs / 8 Gb
@@ -118,6 +121,7 @@ profile::buildmaster::cloud_agents:
             - arm64docker
             - linux
           useAsMuchAsPosible: false
+          idleTerminationMinutes: 5 # Quick deallocation as Linux is billed per minute
   azure-vm-agents:
     azureCredentialsId: "azure-credentials"
     resource_group: eastus-cijenkinsio

--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -24,6 +24,46 @@ profile::buildmaster::groovy_d_pipeline_configuration: 'present'
 profile::buildmaster::groovy_d_set_up_git: 'present'
 profile::buildmaster::groovy_d_terraform_credentials: 'present'
 profile::buildmaster::memory_limit: '7g'
+profile::buildmaster::jcasc:
+  enabled: true
+  custom_configs:
+    - trusted.ci.jenkins.io/agents.yaml.erb
+  reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAlreoLMhSaHCcZZaL1r7BQgmqUVbqWs+e2kaj0cn+r8o4N/qKZGXkkYBN9xhK+b5MRe2cTlfQ9J3gFFLFa6i1n1GrM/WwNMUm/cVYA2eGFNcV3ruUfigyriIrIaQVm7KIQZqv+RIQoZHJ1cWy+CdKg2hXi4KUBSawl1V3VXjSD4ZJEWv96KSceJZRTzVjZW66iD8i8Uq50WvHhvivMfHkaghowz626w/ejz0AettIKCVL9/j0B1iVv+ghOyd4A5kyIYJKR0BwQLpfKFoXY/0uhB7toZWSe7TUS7hzTAfYNhyTbS0aaczsa7pshiFZzxHAdvMeU7om4N1Dj+5LDUgAsDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBByyf8QkfPXbWYxJbMykP8SgCAQ5ncRq7jZddH/cFcb+xHJzKluSoRQU3fnSKJ8fnbEQA==]
+profile::buildmaster::cloud_agents:
+  azure-vm-agents:
+    azureCredentialsId: "azure-sponsorship-credentials"
+    resource_group: jenkinsinfra-trustedvmagents
+    agent_definitions:
+      - name: "ubuntu-20"
+        description: "Ubuntu 20.04 LTS"
+        imageDefinition: jenkins-agent-ubuntu-20
+        os: "ubuntu"
+        storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXhMrX6DhUDJU5Ug4nLaRGGPWFHT2u9ZnxTQuXVQTBbR3Pb8pOYr/kWxQJmZTpVoqEnanVineZn1PFTxVVkjHUirX3kKgdwu3pZTrzaklBex1C1us64SmHErbHds0KeE/EX03k+Gti/V9W1z9jcTueHSld58olNCAb5oNbyo6noqLAZehoQLS39eRvsQDb4sYmVUv9X7daZ7Zu+kCYBtBZyfDNbRFMSOYcbj9WuygCwAijVGIC6q9hJWZYe/5DKAUZnynWDdPmtzDytrc3qKDaHSQ+5nQYORcO9vTuAevUoHis5elQ8dm6VWGiyvafx7xKzqbNghu9xGz/5IA/zzC9TBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBEbhkLOEK5AaKPTV2CVxhagCAx5gsM01ONtqyQ7FRhnqOtyISGBXJtdfdcJXbp2MSBtw==]
+        location: "East US"
+        instanceType: Standard_DS2_v2 # 2 vCPUS / 7 Gb
+        architecture: amd64
+        labels:
+          - java
+          - linux
+          - docker
+        idleTerminationMinutes: 10
+        maxInstances: 15
+        useAsMuchAsPosible: true
+        credentialsId: "azure-jenkins-user"
+      - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
+        description: "Windows 2019"
+        imageDefinition: jenkins-agent-windows-2019
+        os: "windows"
+        storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEACyYOJKI6ZUkaYxvjc2B28AgmrulBjPZu4/1CgWkG9UDeDL36IaKtwZpbrunMC1iomzchJeeamWP97FYXZEuL+UrjtksLyDWMwXRjH+reENg8zXkm0d3ixajOAxyWMp8oWBQXHbF6sabFthVFsyH/NHiJNK7SathpmEZb2CV4Wijh2OEqWD9siJiIuG6ltkOO3lof2v83QG7FdBiiUq19k3vZQ7DQa8ew8jqH0+/+nMoMnpSg93PY/CJ5ty5Wp1gKEl3fZoLWT9ajwsPSAdQz7aK74/eYkSfbFY8EYPxSteAsLZz/OUJjhKpQQH8OUiYj88caw6uw+hnCdUI7ii+goTBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBcFfMvnXKFZn9P6fwpv38CgCBZNquRP9m0BnCJIVRT+f8AvBve8ReanZIVHLCtKasF4w==]
+        location: "East US"
+        instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
+        architecture: amd64
+        labels:
+          - windock
+        idleTerminationMinutes: 60
+        maxInstances: 5
+        useAsMuchAsPosible: true
+        credentialsId: "azure-jenkins-user"
 # These are plugins we need only in our trusted-ci environment
 profile::buildmaster::plugins:
   - ansicolor
@@ -34,6 +74,7 @@ profile::buildmaster::plugins:
   - cloudbees-folder
   - credentials
   - credentials-binding
+  - configuration-as-code
   - docker-workflow
   - git-client
   - git
@@ -47,7 +88,8 @@ profile::buildmaster::plugins:
   - parallel-test-executor
   - pipeline-stage-view
   - pipeline-utility-steps
-  - ssh-agent
+  - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs
+  - ssh-slaves # SSH Build Agent to implement "outbound agents"
   - throttle-concurrents
   - timestamper
   - toolenv

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -308,6 +308,22 @@ profile::buildmaster::agent_images:
     jnlp-node: jenkinsciinfra/inbound-agent-node@sha256:ec1c70001433a61a660745e8d4deb4f9a94940f8c506a32c6044e710108fb905
     jnlp-alpine: jenkins/inbound-agent@sha256:687937233cb97da0dc4a8bca394173d2e31bcdb0e4cd7cca85af0a4c3c2b3021
     jnlp: jenkins/inbound-agent@sha256:2484ddb024d6c4c18641c7cd5bc69ac8eecbb06fbef73ee2969951436226e7f7
+profile::buildmaster::tools:
+  jdk8:
+    version: "8u302-b08"
+    sourceURL: https://github.com/adoptium/temurin8-binaries/releases/download
+  jdk11:
+    version: "11.0.12+7"
+    sourceURL: https://github.com/adoptium/temurin11-binaries/releases/download
+  jdk17:
+    version: "17+35"
+    sourceURL: https://github.com/adoptium/temurin17-binaries/releases/download
+  maven:
+    mvn:
+      version: "3.8.1"
+  groovy:
+    groovy: # Default version is named "groovy"
+      version: "2.4.7"
 ldap_url: 'ldap://localhost:389'
 ldap_dn: 'dc=example,dc=com'
 ldap_admin_dn: 'cn=admin,dc=example,dc=com'

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -14,7 +14,6 @@ profile::buildmaster::jcasc:
   enabled: true
   custom_configs:
     - azure.ci.jenkins.io/agents.yaml.erb
-    - azure.ci.jenkins.io/tools.yaml.erb
   reload_token: SuperSecretThatShouldBeEncryptedInProduction
 profile::buildmaster::cloud_agents:
   kubernetes:
@@ -157,20 +156,6 @@ profile::buildmaster::cloud_agents:
           memory: 3.5
           labels:
             - maven-11-window
-profile::buildmaster::tools:
-  jdk8:
-    version: "8u302-b08"
-    sourceURL: https://github.com/adoptium/temurin8-binaries/releases/download
-  jdk11:
-    version: "11.0.12+7"
-    sourceURL: https://github.com/adoptium/temurin11-binaries/releases/download
-  jdk17:
-    version: "17+35"
-    sourceURL: https://github.com/adoptium/temurin17-binaries/releases/download
-  maven:
-    version: "3.8.1"
-  groovy:
-    version: "2.4.7"
 profile::buildmaster::plugins:
   - ansicolor
   - azure-container-agents


### PR DESCRIPTION
This PR aims at managing some part of trusted.ci.jenkins.io with JCasc.

It introduces the following changes:
- [chore / code] factorization of the following CasC elements from ci.jenkins.io's definition to the common "buildmaster" Puppet profile:
  - tools
  - credentials for clouds and cloud agents
 -  [fix / code] ensure that the cloud agent VM's idle termination time is defined for both Azure VM and EC2, and used in CasC
 - [trusted.ci.jenkins.io]
   - Enabling JCasC, with management of Cloud agents , agents and Tools
   - The default Maven tool namled `mvn` bumped to 3.8.1



Applying this change should have the following change on the configuration of trusted.ci:

<details>
 <summary>Click to expand the diff</summary>

```diff
--- a/trusted-ci-2021-09-27-10h13.yaml
+++ b/jenkins.yaml
   clouds:
   - azureVM:
       azureCredentialsId: "azure-sponsorship-credentials"
-      cloudName: "Azure"
+      cloudName: "azure-ubuntu-20"
+      configurationStatus: "pass"
       deploymentTimeout: 1200
-      existingResourceGroupName: "jenkinsinfra-vmagents"
-      maxVirtualMachinesLimit: 20
-      newResourceGroupName: "jenkinsinfra-trustedvmagents"
-      resourceGroupReferenceType: "new"
+      existingResourceGroupName: "jenkinsinfra-trustedvmagents"
+      maxVirtualMachinesLimit: 15
       vmTemplates:
       - agentLaunchMethod: "SSH"
         agentWorkspace: "/home/jenkins"
-        builtInImage: "Ubuntu 16.04 LTS"
         credentialsId: "azure-jenkins-user"
         diskType: "managed"
         doNotUseMachineIfInitFails: true
         enableMSI: false
         enableUAMI: false
-        ephemeralOSDisk: false
-        executeInitScriptAsRoot: true
-        existingStorageAccountName: "jneiuungdkcjv2zd3luvyiaa"
+        ephemeralOSDisk: true
+        executeInitScriptAsRoot: false
+        existingStorageAccountName: "SuperSecret"
         imageReference:
           galleryImageDefinition: "jenkins-agent-ubuntu-20"
-          galleryImageVersion: "0.2.4"
+          galleryImageVersion: "0.5.0"
           galleryName: "prod_packer_images"
           galleryResourceGroup: "prod-packer-images"
-          gallerySubscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+          gallerySubscriptionId: "ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAluBQmOHo1MWoOCMVOCcgVUs9gOzFVEZMT7RA3V33KeolyRKh0lm5Ta5+C9aKJe9myuVGaDQsd99XsW40d7NdygJcnBxUV+VTnnLphjplPtCX5JIS4ww/S8JGOpOIE2zejy5bL2CpnZhgSFh+aD1FLD91ozNS5lgNOq9hNKqo+mSfUnX5wrUFvlCaadTWp3yxG7l7VluxP1Wh4BlsRmphmbUmmgFo56CjDUVz9dMwxT/p/uE1S/SPuEirJOAPtPCl7x2NQWg+Qlv5j1tC5ASgh9beD3SjUVPd6VYM+K+u07aw8jOj/meARXgghtUPgqHqWC44JGHPzWkZ4dQFhe6jyzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDc6VPQnQTEmwF9aAh/uK9IgDDXAM9S6QNxRH8cFSOAESeqOlLFBKVAlJc3Mnby3Pc/6H21BsehZbQLUd+1MfcoPI0=]"
         imageTopLevelType: "advanced"
-        initScript: |
-          # Allow user 'jenkins' to use Docker without sudo
-          usermod -aG docker jenkins
         installDocker: false
         installGit: false
         installMaven: false
         javaPath: "java"
-        labels: "linux java docker azure"
+        labels: "ubuntu amd64 azure vm java linux docker"
         location: "East US"
-        newStorageAccountName: "jneiuungdkcjv2zd3luvyiaa"
         noOfParallelJobs: 1
         osDiskSize: 0
         osType: "Linux"
@@ -226,70 +42,63 @@ jenkins:
           azureVMCloudRetentionStrategy:
             idleTerminationMinutes: 10
         shutdownOnIdle: false
-        storageAccountNameReferenceType: "new"
         storageAccountType: "Standard_LRS"
         templateDesc: "Dynamically provisioned Ubuntu 20.04 LTS machine"
         templateDisabled: false
-        templateName: "ubuntu-jenkinsinfra"
+        templateName: "ubuntu-20"
         usageMode: "Use this node as much as possible"
         usePrivateIP: false
         virtualMachineSize: "Standard_DS2_v2"
+  - azureVM:
+      azureCredentialsId: "azure-sponsorship-credentials"
+      cloudName: "azure-win-2019"
+      configurationStatus: "pass"
+      deploymentTimeout: 1200
+      existingResourceGroupName: "jenkinsinfra-trustedvmagents"
+      maxVirtualMachinesLimit: 5
+      vmTemplates:
       - agentLaunchMethod: "SSH"
         agentWorkspace: "C:\\Jenkins"
-        builtInImage: "Ubuntu 20.04 LTS"
         credentialsId: "azure-jenkins-user"
         diskType: "managed"
-        doNotUseMachineIfInitFails: false
+        doNotUseMachineIfInitFails: true
         enableMSI: false
         enableUAMI: false
-        ephemeralOSDisk: false
+        ephemeralOSDisk: true
         executeInitScriptAsRoot: false
-        existingStorageAccountName: "e7xc3bqr3vhcospecvm"
+        existingStorageAccountName: "SuperSecret"
         imageReference:
           galleryImageDefinition: "jenkins-agent-windows-2019"
-          galleryImageVersion: "0.2.4"
+          galleryImageVersion: "0.5.0"
           galleryName: "prod_packer_images"
           galleryResourceGroup: "prod-packer-images"
-          gallerySubscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+          gallerySubscriptionId: "ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAluBQmOHo1MWoOCMVOCcgVUs9gOzFVEZMT7RA3V33KeolyRKh0lm5Ta5+C9aKJe9myuVGaDQsd99XsW40d7NdygJcnBxUV+VTnnLphjplPtCX5JIS4ww/S8JGOpOIE2zejy5bL2CpnZhgSFh+aD1FLD91ozNS5lgNOq9hNKqo+mSfUnX5wrUFvlCaadTWp3yxG7l7VluxP1Wh4BlsRmphmbUmmgFo56CjDUVz9dMwxT/p/uE1S/SPuEirJOAPtPCl7x2NQWg+Qlv5j1tC5ASgh9beD3SjUVPd6VYM+K+u07aw8jOj/meARXgghtUPgqHqWC44JGHPzWkZ4dQFhe6jyzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDc6VPQnQTEmwF9aAh/uK9IgDDXAM9S6QNxRH8cFSOAESeqOlLFBKVAlJc3Mnby3Pc/6H21BsehZbQLUd+1MfcoPI0=]"
         imageTopLevelType: "advanced"
         installDocker: false
         installGit: false
         installMaven: false
         javaPath: "java"
-        labels: "windows amd64 windock azure"
+        labels: "windows amd64 azure vm windock"
         location: "East US"
-        maximumDeploymentSize: 10
-        newStorageAccountName: "jnxh0iohhn6h6n6qcpohizlq"
         noOfParallelJobs: 1
-        osDiskSize: 200
+        osDiskSize: 0
         osType: "Windows"
         preInstallSsh: false
         retentionStrategy:
           azureVMCloudRetentionStrategy:
             idleTerminationMinutes: 60
         shutdownOnIdle: false
-        storageAccountNameReferenceType: "new"
         storageAccountType: "Standard_LRS"
-        templateDesc: "Dynamically provisioned Windows 2019 Core image"
+        templateDesc: "Dynamically provisioned Windows 2019 machine"
         templateDisabled: false
-        templateName: "win2019-jenkinsinfra"
+        templateName: "win-2019"
         usageMode: "Use this node as much as possible"
         usePrivateIP: false
         virtualMachineSize: "Standard_DS4_v2"
   slaveAgentPort: 50000
 tool:
   git:
     installations:
@@ -562,15 +319,70 @@ tool:
       properties:
       - installSource:
           installers:
-          - jdkInstaller:
-              acceptLicense: true
-              id: "jdk-8u172-oth-JPR"
+          - zip:
+              label: "linux && amd64"
+              subdir: "jdk8u302-b08"
+              url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz"
+          - zip:
+              label: "windows"
+              subdir: "jdk8u302-b08"
+              url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u302b08.zip"
+          - zip:
+              label: "linux && arm64"
+              subdir: "jdk8u302-b08"
+              url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz"
+          - zip:
+              label: "ppc64le"
+              subdir: "jdk8u302-b08"
+              url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u302b08.tar.gz"
     - name: "jdk11"
       properties:
       - installSource:
           installers:
-          - adoptOpenJdkInstaller:
-              id: "jdk-11.0.9.1+1"
+          - zip:
+              label: "linux && amd64"
+              subdir: "jdk-11.0.12+7"
+              url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12+7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz"
+          - zip:
+              label: "windows"
+              subdir: "jdk-11.0.12+7"
+              url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12+7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.12_7.zip"
+          - zip:
+              label: "linux && arm64"
+              subdir: "jdk-11.0.12+7"
+              url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12+7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.12_7.tar.gz"
+          - zip:
+              label: "ppc64le"
+              subdir: "jdk-11.0.12+7"
+              url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12+7/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.12_7.tar.gz"
+          - zip:
+              label: "s390x"
+              subdir: "jdk-11.0.12+7"
+              url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12+7/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.12_7.tar.gz"
+    - name: "jdk17"
+      properties:
+      - installSource:
+          installers:
+          - zip:
+              label: "linux && amd64"
+              subdir: "jdk-17+35"
+              url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17+35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz"
+          - zip:
+              label: "windows"
+              subdir: "jdk-17+35"
+              url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17+35/OpenJDK17-jdk_x64_windows_hotspot_17_35.zip"
+          - zip:
+              label: "linux && arm64"
+              subdir: "jdk-17+35"
+              url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17+35/OpenJDK17-jdk_aarch64_linux_hotspot_17_35.tar.gz"
+          - zip:
+              label: "ppc64le"
+              subdir: "jdk-17+35"
+              url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17+35/OpenJDK17-jdk_ppc64le_linux_hotspot_17_35.tar.gz"
+          - zip:
+              label: "s390x"
+              subdir: "jdk-17+35"
+              url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17+35/OpenJDK17-jdk_s390x_linux_hotspot_17_35.tar.gz"
   maven:
     installations:
     - name: "mvn"
@@ -578,7 +390,7 @@ tool:
       - installSource:
           installers:
           - maven:
-              id: "3.6.3"
+              id: "3.8.1"
   mavenGlobalConfig:
     globalSettingsProvider: "standard"
     settingsProvider: "standard"
```
</details>