### PR TITLE
fix [buildmasters]: ensure no new storage account created with azure VMs

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -7,9 +7,9 @@ jenkins:
   - azureVM:
       azureCredentialsId: "<%= @cloud_agents["azure-vm-agents"]["azureCredentialsId"] %>"
       cloudName: "azure-<%= agent["name"] %>"
-      configurationStatus: "pass"
       deploymentTimeout: 1200
       maxVirtualMachinesLimit: <%= agent["maxInstances"] %>
+      resourceGroupReferenceType: "existing"
       existingResourceGroupName: "<%= @cloud_agents["azure-vm-agents"]["resource_group"] %>"
       vmTemplates:
       - agentLaunchMethod: "SSH"
@@ -21,6 +21,7 @@ jenkins:
         enableUAMI: false
         ephemeralOSDisk: true
         existingStorageAccountName: "<%= agent["storageAccount"] %>"
+        storageAccountNameReferenceType: "existing"
         storageAccountType: "Standard_LRS"
         imageReference:
           galleryImageDefinition: "<%= agent["imageDefinition"] %>"


### PR DESCRIPTION
The initial Casc setup for Azure VM on both ci.jenkins.io and trusted.ci.jenkins.io is missing some attributes to be sure that there is no new storage account created.

This PR ensures that it is fixed.