### PR TITLE
Extend tool installer for updatecenter agent

### DIFF
--- a/dist/profile/templates/buildmaster/casc/tools.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/tools.yaml.erb
@@ -20,7 +20,7 @@ tool:
       - installSource:
           installers:
           - zip:
-              label: "linux && amd64"
+              label: "(linux && amd64) || updatecenter || census"
               subdir: "jdk<%= @tools["jdk8"]["version"] %>"
               url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_x64_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
           - zip:


### PR DESCRIPTION
## Extend tool installer for updatecenter and census agents

The update center job on trusted.ci.jenkins.io was failing because it could not install JDK 8.  Allow installation of JDK 8 on that agent.
