### PR TITLE
fix [ci.jenkins.io] ensure that the azure VM template for windows 2019 can be provisionned

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -19,7 +19,7 @@ jenkins:
         doNotUseMachineIfInitFails: true
         enableMSI: false
         enableUAMI: false
-        ephemeralOSDisk: true
+        ephemeralOSDisk: <%= agent["useEphemeralOSDisk"].nil? ? true : agent["useEphemeralOSDisk"] %>
         existingStorageAccountName: "<%= agent["storageAccount"] %>"
         storageAccountNameReferenceType: "existing"
         storageAccountType: "Standard_LRS"

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -174,6 +174,7 @@ profile::buildmaster::cloud_agents:
         maxInstances: 10
         useAsMuchAsPosible: true
         credentialsId: "jenkinsvmagents-userpass"
+        useEphemeralOSDisk: false
   azure-container-agents:
     aci-windows:
       credentialsId: "azure-credentials"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -138,6 +138,7 @@ profile::buildmaster::cloud_agents:
         idleTerminationMinutes: 30
         maxInstances: 10
         useAsMuchAsPosible: true
+        useEphemeralOSDisk: false
   azure-container-agents:
     aci-windows:
       credentialsId: "azure-credentials"


### PR DESCRIPTION
[New PR message]
This PR disable the ephemeral disk for the Azure VM template for win-2019 on ci.jenkins.io, until the packer image is shrunk below 100 Gb.


[Original PR message]
* With the current setup on ci.jenkins.io (`Standard_DS4_v3`), deployment fails with this error:

```text
OS disk of Ephemeral VM with size greater than 100 GB is not allowed for VM size Standard_D4s_v3 when the DiffDiskPlacement is CacheDisk.
```

Because the VM image (`0.5.0`) is defining a size of 130 Gb for the system disk (https://github.com/jenkins-infra/packer-images/blob/0.5.0/jenkins-agent.pkr.hcl#L244), which is more than the 100 Gb specified for this instance size as per https://docs.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series.

* If forcing disk size less than 100 Gb, then the error changes to the following:

```text
The specified disk size 90 GB is smaller than the size of the corresponding disk in the VM image: 130 GB. This is not allowed. Please choose equal or greater size or do not specify an explicit size.
```

* So this Pull Request switches the size instance to DS8_v3 (200 Gb of caching instead of 100 Gb of cache) to fix the allocation issue for now

