### PR TITLE
fix [updatecli] ensure that no PR is opened for unreleased maven or n…

### DIFF
--- a/updatecli/scripts/check-maven.sh
+++ b/updatecli/scripts/check-maven.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eux
+
+MAVEN_VERSION="${1}"
+
+command -v curl >/dev/null 2>&1 || { echo "ERROR: curl command not found. Exiting."; exit 1; }
+
+curl --connect-timeout 5 --location --head --fail --silent --show-error \
+  "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"

--- a/updatecli/scripts/get-ami.sh
+++ b/updatecli/scripts/get-ami.sh
@@ -8,6 +8,7 @@ image_version="${3}"
 
 ## As GitHub Actions forbids credentials from forks, we have this special hack to print a dummy string but not failing updatecli diff
 # to ensure other configurations are fine.
+export DRY_RUN
 if ! aws configure list >/dev/null 2>&1 && DRY_RUN="true"
 then
   echo "dummy-value-no-aws-credential-and-dryrun-enabled"
@@ -17,11 +18,19 @@ fi
 ##
 # - https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-filter.html is a great help to understand filtering, sorting and querying with jmespath and aws CLI
 # - Do NOT use multiple times the flag "--filters" (only the last one is used which can leads to unwanted results such as ignoring the other filters)
-aws ec2 describe-images \
+RESULTING_AMI="$(aws ec2 describe-images \
   --owners 200564066411 `# Owner ID for AWS account cloudbees-jenkins` \
   --region=us-east-2 `#AWS region where ci.jenkins.io runs its EC2 agents` \
   --filters "Name=name,Values=jenkins-agent-${operating_system}-${cpu_architecture}-*" `# Search by name, with a pattern for the end (timestamps)` \
     "Name=tag:build_type,Values=prod" `# Only retrieve production ready AMIs` \
     "Name=tag:version,Values=${image_version}" `# image version is a semantic version v2 string` \
   --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' `# Get the most recent one by sorting by creation date and get the latest and extract its AMI ID` \
-  --output text `# We don't want JSON`
+  --output text `# We don't want JSON`)"
+
+if [[ "${RESULTING_AMI}" != "ami-"* ]]
+then
+  >&2 echo "ERROR: the string returned by the AWS command line does not look like an AMI ID: ${RESULTING_AMI}."
+  exit 1
+fi
+
+echo "${RESULTING_AMI}"

--- a/updatecli/weekly.d/buildmaster-tools.yaml
+++ b/updatecli/weekly.d/buildmaster-tools.yaml
@@ -60,6 +60,13 @@ sources:
     transformers:
       - trimPrefix: "jdk-"
 
+conditions:
+  checkIfMavenReleaseIsAvailable:
+    kind: shell
+    sourceID: mavenVersion
+    spec:
+      command: bash ./updatecli/scripts/check-maven.sh
+
 targets:
   setMavenVersion:
     sourceID: mavenVersion


### PR DESCRIPTION
The 2 following PRs were opened "too early" (e.g. updatecli detected a source but the associated asset was not available yet):

- https://github.com/jenkins-infra/jenkins-infra/pull/1895 => the maven tag is published but not the binaries (same as https://github.com/jenkins-infra/packer-images/pull/100)
- https://github.com/jenkins-infra/jenkins-infra/pull/1882#pullrequestreview-764014925 => the tag on jenkins-infra/packer-images was published, but not the images yet, resulting on no AMI id returned by the script.

This PR adds a verification to avoid this PR to be opened too early in the future.

Closes #1895