### PR TITLE
Fix for ci.jenkins.io agents (more kubernetes agents, fix maven-11-windows)

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -53,7 +53,6 @@ profile::buildmaster::cloud_agents:
           cpus: 4
           memory: 8
         - name: jnlp-maven-11
-          image: jenkinsciinfra/inbound-agent-maven@sha256:0ddce98de47930b7505418421b89cbbfa5378d1c8f9c01bee416ff8ffe1d0775
           labels:
             - maven-11
             - jdk11

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -192,7 +192,7 @@ profile::buildmaster::cloud_agents:
           cpus: 4
           memory: 8
           labels:
-            - maven-11-window
+            - maven-11-windows
 # These are plugins we need in our ci environment
 profile::buildmaster::plugins:
   - ansicolor

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -37,12 +37,12 @@ profile::buildmaster::cloud_agents:
   kubernetes:
     cik8s:
       credentialsId: "cik8s-kubeconfig"
-      max_capacity: 100 # Max 50 workers (8 CPU / 32 G) with 2 pods (4 CPU / 8G) each
+      max_capacity: 150 # Max 50 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each
       url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAF1QzoLi/6iki6G5iXpZPTQfRhQMUg/+gnz/0mBSPjyKmN2FJO4Q0AvEB64cR0geLnNdQB4Nylkm5Yxyy633TG6iRFokFiBf2L/jx1hCFXWESpRZv3Jcqm4Lb4LlhNdmV3w5pQcBdEFeqvqUM8MB+25eVMnapR2Cj9B5ozJuMmAarp17hKOZmzDXvS/eX09ybvQt5WZckMbHch1iUBtCqWy8Ze0LEN2LuyEtR3kyRBbSGknUzS763AsVTw5sZ32MdYkGVHuEZTZ+GIW9WQWj7xhCeGfoVMGvhC+v24s+KycoDXRVkjNRkECc0QY7Brp8XjqxgYeJtlRzfJn1wVbtD5TB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBC4DXAv9aHddQFOkb7bSms0gFAEf+Cgob9UbWdKJmgrSdyol3A/+NwNpUJI0OaZAWllKc0NBqPeQE6qor407wYQobMPpbeebr/scI+NkU5wInwuWDlqlra1XrRdYJ+6b2/83g==]
       agent_definitions:
         - name: jnlp-ruby
-          cpus: 4
-          memory: 8
+          cpus: 2
+          memory: 4
           labels:
             - ruby
         - name: jnlp-maven-8
@@ -59,8 +59,8 @@ profile::buildmaster::cloud_agents:
           cpus: 4
           memory: 8
         - name: jnlp-node
-          cpus: 4
-          memory: 8
+          cpus: 2
+          memory: 4
           labels:
             - node
         - name: jnlp-alpine

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -156,7 +156,7 @@ profile::buildmaster::cloud_agents:
           cpus: 4
           memory: 8
           labels:
-            - maven-11-window
+            - maven-11-windows
 profile::buildmaster::plugins:
   - ansicolor
   - azure-container-agents

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -31,7 +31,6 @@ profile::buildmaster::cloud_agents:
           cpus: 4
           memory: 8
         - name: jnlp-maven-11
-          image: jenkinsciinfra/inbound-agent-maven@sha256:0ddce98de47930b7505418421b89cbbfa5378d1c8f9c01bee416ff8ffe1d0775
           labels:
             - maven-11
             - jdk11


### PR DESCRIPTION
This PR introduces the following changes:

- Fix the maven-11 windows ACI agent not allocated on ci.jenkins.io (typo: missing `s`)
- Adjust the Kubernetes agent size and capping on ci.jenkins.io to handle increased load after
  - Follows up https://github.com/jenkins-infra/aws/pull/31
  - New container cap is 150 (3 maven-jdk pods per worker max)
  - Please note that the non maven-jdk pods have a smaller size to "fill" the gap. As there is no container cap per template, this is only to avoid triggerring too much workers, but does not change anything when the 150 pods limit is reached
- cleanup chore: removing unused hieradata keys (container images definitions have moved to `hieradata/common.yaml`)