### PR TITLE
chore [updatecli] enable autoupdate of the updatecli-action with updatecli

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -24,7 +24,7 @@ jobs:
           aws-region: us-east-2
       - name: Diff
         continue-on-error: true
-        uses: updatecli/updatecli-action@v1
+        uses: updatecli/updatecli-action@v1.12.0
         with:
           command: diff
           flags: "--config ./updatecli/weekly.d --values ./updatecli/values.github-action.yaml"
@@ -32,7 +32,7 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Apply
         if: github.ref == 'refs/heads/production'
-        uses: updatecli/updatecli-action@v1
+        uses: updatecli/updatecli-action@v1.12.0
         with:
           command: apply
           flags: "--config ./updatecli/weekly.d --values ./updatecli/values.github-action.yaml"

--- a/updatecli/weekly.d/updatecli-action.yaml
+++ b/updatecli/weekly.d/updatecli-action.yaml
@@ -1,0 +1,46 @@
+---
+title: Bump updatecli-action version
+sources:
+  default:
+    name: Get latest updatecli-action version
+    kind: githubRelease
+    spec:
+      owner: updatecli
+      repository: updatecli-action
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+targets:
+  gh-workflow-step-diff:
+    name: "Update the version of the updatecli-action in the GitHub workflow file for step 'diff'"
+    transformers:
+      - addPrefix: "updatecli/updatecli-action@"
+    kind: yaml
+    spec:
+      file: .github/workflows/updatecli.yaml
+      key: "jobs.updatecli.steps[2].uses"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  gh-workflow-step-apply:
+    name: "Update the version of the updatecli-action in the GitHub workflow file for step 'apply'"
+    transformers:
+      - addPrefix: "updatecli/updatecli-action@"
+    kind: yaml
+    spec:
+      file: .github/workflows/updatecli.yaml
+      key: "jobs.updatecli.steps[3].uses"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"


### PR DESCRIPTION
Not really sure why the notation `@v1` for the updatecli-action does not resolve to the latest 1.x version (1.12.0 for instance).
But using the `@v1` makes the latest changes unavailable (such as having `curl` installed...).

This PR fixes the version of the updatecli-action to the latest known as for today, with the expected behavior, and adds an updatecli manifest that auto-update the updatecli-action when a new version is released.