### PR TITLE
Revert "feat [buildmaster] define static paths for jdk tools"

### DIFF
--- a/dist/profile/templates/buildmaster/casc/tools.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/tools.yaml.erb
@@ -16,17 +16,73 @@ tool:
   jdk:
     installations:
     - name: "jdk8"
-      home: "/opt/jdk-8"
-    - name: "jdk8-windows"
-      home: "C:\\Tools\\jdk-8"
+      properties:
+      - installSource:
+          installers:
+          - zip:
+              label: "(linux && amd64) || updatecenter || census"
+              subdir: "jdk<%= @tools["jdk8"]["version"] %>"
+              url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_x64_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
+          - zip:
+              label: "windows"
+              subdir: "jdk<%= @tools["jdk8"]["version"] %>"
+              url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_x64_windows_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.zip"
+          - zip:
+              label: "linux && arm64"
+              subdir: "jdk<%= @tools["jdk8"]["version"] %>"
+              url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_aarch64_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
+          - zip:
+              label: "ppc64le"
+              subdir: "jdk<%= @tools["jdk8"]["version"] %>"
+              url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_ppc64le_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
     - name: "jdk11"
-      home: "/opt/jdk-11"
-    - name: "jdk11-windows"
-      home: "C:\\Tools\\jdk-11"
+      properties:
+      - installSource:
+          installers:
+          - zip:
+              label: "linux && amd64"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
+              url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_x64_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "windows"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
+              url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_x64_windows_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.zip"
+          - zip:
+              label: "linux && arm64"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
+              url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_aarch64_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "ppc64le"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
+              url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_ppc64le_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "s390x"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
+              url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_s390x_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
     - name: "jdk17"
-      home: "/opt/jdk-17"
-    - name: "jdk17-windows"
-      home: "C:\\Tools\\jdk-17"
+      properties:
+      - installSource:
+          installers:
+          - zip:
+              label: "linux && amd64"
+              subdir: "jdk-<%= @tools["jdk17"]["version"] %>"
+              url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_x64_linux_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "windows"
+              subdir: "jdk-<%= @tools["jdk17"]["version"] %>"
+              url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_x64_windows_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.zip"
+          - zip:
+              label: "linux && arm64"
+              subdir: "jdk-<%= @tools["jdk17"]["version"] %>"
+              url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_aarch64_linux_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "ppc64le"
+              subdir: "jdk-<%= @tools["jdk17"]["version"] %>"
+              url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_ppc64le_linux_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "s390x"
+              subdir: "jdk-<%= @tools["jdk17"]["version"] %>"
+              url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_s390x_linux_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.tar.gz"
   maven:
     installations:
     <%- @tools["maven"].each do |name, setup| -%>

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -309,6 +309,15 @@ profile::buildmaster::agent_images:
     jnlp-alpine: jenkins/inbound-agent@sha256:7d74cca45601fa726932227c97446c91ea280aa6f161c6254232e56b8c680328
     jnlp: jenkins/inbound-agent@sha256:b8753324d9874de95998fc66cad547d9d4420bc33fafc8fc99a21f267679bda4
 profile::buildmaster::default_tools:
+  jdk8:
+    version: "8u302-b08"
+    sourceURL: https://github.com/adoptium/temurin8-binaries/releases/download
+  jdk11:
+    version: "11.0.12+7"
+    sourceURL: https://github.com/adoptium/temurin11-binaries/releases/download
+  jdk17:
+    version: "17+35"
+    sourceURL: https://github.com/adoptium/temurin17-binaries/releases/download
   maven:
     mvn:
       version: "3.8.2"


### PR DESCRIPTION
## Restore JDK tool installer temporarily

Static JDK tool location is not available on every agent type.  We need the tool installer to be available until the static JDK tool location is available on all agent types.

See

* https://ci.jenkins.io/job/Plugins/job/elastic-axis-plugin/job/PR-46/3/console

This reverts commit f841cdfda5982354c233c5a4a475f1b797965847.
