### PR TITLE
fix [buildmaster] update JDK tools

### DIFF
--- a/dist/profile/templates/buildmaster/casc/tools.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/tools.yaml.erb
@@ -15,6 +15,18 @@ tool:
     <%- end -%>
   jdk:
     installations:
+    - name: "jdk8-linux-static"
+      home: "/opt/jdk-8"
+    - name: "jdk8-windows-static"
+      home: "C:\\Tools\\jdk-8"
+    - name: "jdk11-linux-static"
+      home: "/opt/jdk-11"
+    - name: "jdk11-windows-static"
+      home: "C:\\Tools\\jdk-11"
+    - name: "jdk17-linux-static"
+      home: "/opt/jdk-17"
+    - name: "jdk17-windows-static"
+      home: "C:\\Tools\\jdk-17"
     - name: "jdk8"
       properties:
       - installSource:

--- a/dist/profile/templates/buildmaster/casc/tools.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/tools.yaml.erb
@@ -16,17 +16,73 @@ tool:
   jdk:
     installations:
     - name: "jdk8"
-      home: "/opt/jdk-8"
-    - name: "jdk8-windows"
-      home: "C:\\Tools\\jdk-8"
+      properties:
+      - installSource:
+          installers:
+          - zip:
+              label: "(linux && amd64) || updatecenter || census"
+              subdir: "jdk<%= @tools["jdk8"]["version"] %>"
+              url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_x64_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
+          - zip:
+              label: "windows"
+              subdir: "jdk<%= @tools["jdk8"]["version"] %>"
+              url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_x64_windows_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.zip"
+          - zip:
+              label: "linux && arm64"
+              subdir: "jdk<%= @tools["jdk8"]["version"] %>"
+              url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_aarch64_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
+          - zip:
+              label: "ppc64le"
+              subdir: "jdk<%= @tools["jdk8"]["version"] %>"
+              url: "<%= @tools["jdk8"]["sourceURL"] %>/jdk<%= @tools["jdk8"]["version"] %>/OpenJDK8U-jdk_ppc64le_linux_hotspot_<%= @tools["jdk8"]["version"].gsub('-', '') %>.tar.gz"
     - name: "jdk11"
-      home: "/opt/jdk-11"
-    - name: "jdk11-windows"
-      home: "C:\\Tools\\jdk-11"
+      properties:
+      - installSource:
+          installers:
+          - zip:
+              label: "linux && amd64"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
+              url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_x64_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "windows"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
+              url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_x64_windows_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.zip"
+          - zip:
+              label: "linux && arm64"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
+              url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_aarch64_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "ppc64le"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
+              url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_ppc64le_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "s390x"
+              subdir: "jdk-<%= @tools["jdk11"]["version"] %>"
+              url: "<%= @tools["jdk11"]["sourceURL"] %>/jdk-<%= @tools["jdk11"]["version"] %>/OpenJDK11U-jdk_s390x_linux_hotspot_<%= @tools["jdk11"]["version"].gsub('+', '_') %>.tar.gz"
     - name: "jdk17"
-      home: "/opt/jdk-17"
-    - name: "jdk17-windows"
-      home: "C:\\Tools\\jdk-17"
+      properties:
+      - installSource:
+          installers:
+          - zip:
+              label: "linux && amd64"
+              subdir: "jdk-<%= @tools["jdk17"]["version"] %>"
+              url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_x64_linux_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "windows"
+              subdir: "jdk-<%= @tools["jdk17"]["version"] %>"
+              url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_x64_windows_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.zip"
+          - zip:
+              label: "linux && arm64"
+              subdir: "jdk-<%= @tools["jdk17"]["version"] %>"
+              url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_aarch64_linux_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "ppc64le"
+              subdir: "jdk-<%= @tools["jdk17"]["version"] %>"
+              url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_ppc64le_linux_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.tar.gz"
+          - zip:
+              label: "s390x"
+              subdir: "jdk-<%= @tools["jdk17"]["version"] %>"
+              url: "<%= @tools["jdk17"]["sourceURL"] %>/jdk-<%= @tools["jdk17"]["version"] %>/OpenJDK17-jdk_s390x_linux_hotspot_<%= @tools["jdk17"]["version"].gsub('+', '_') %>.tar.gz"
   maven:
     installations:
     <%- @tools["maven"].each do |name, setup| -%>

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -309,6 +309,15 @@ profile::buildmaster::agent_images:
     jnlp-alpine: jenkins/inbound-agent@sha256:7d74cca45601fa726932227c97446c91ea280aa6f161c6254232e56b8c680328
     jnlp: jenkins/inbound-agent@sha256:b8753324d9874de95998fc66cad547d9d4420bc33fafc8fc99a21f267679bda4
 profile::buildmaster::default_tools:
+  jdk8:
+    version: "8u302-b08"
+    sourceURL: https://github.com/adoptium/temurin8-binaries/releases/download
+  jdk11:
+    version: "11.0.12+7"
+    sourceURL: https://github.com/adoptium/temurin11-binaries/releases/download
+  jdk17:
+    version: "17+35"
+    sourceURL: https://github.com/adoptium/temurin17-binaries/releases/download
   maven:
     mvn:
       version: "3.8.2"


### PR DESCRIPTION
This PR follows up the revert proposal of @MarkEWaite in #1919  (❤️ ) to fix the build issues on ci|trusted we had recently.

It introduces the following changes:

- Reverts #1916 , because it broke the usages in static agents + containers
- Add a set of new JDK tools named with the following pattern `jdk<MAJOR>-<OS>-static` to be used by the pipeline-library