### PR TITLE
feat [ci.jenkins.io] increase VM agents limit for hacktoberfest

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -117,7 +117,7 @@ profile::buildmaster::cloud_agents:
       sshKeysCredentialsId: "ec2-agent-ssh-2021-06"
       agent_definitions:
         - description: "Ubuntu 20.04 LTS"
-          maxInstances: 5
+          maxInstances: 20
           instanceType: T3Xlarge # 8 vCPUs / 16 Gb
           os: "ubuntu"
           architecture: "amd64"
@@ -137,7 +137,7 @@ profile::buildmaster::cloud_agents:
           useAsMuchAsPosible: true
           idleTerminationMinutes: 30 # Windows is billed per hour: let's wait half of this period since most of the builds are less than 30 min on Windows
         - description: "High memory ubuntu 20.04"
-          maxInstances: 20
+          maxInstances: 50
           instanceType: M54xlarge # 16 vCPUS / 64 Gb
           os: "ubuntu"
           architecture: "amd64"
@@ -149,7 +149,7 @@ profile::buildmaster::cloud_agents:
           useAsMuchAsPosible: false
           idleTerminationMinutes: 5 # Quick deallocation as Linux is billed per minute
         - description: "ARM64 ubuntu 20.04"
-          maxInstances: 2
+          maxInstances: 5
           instanceType: A1Xlarge # 4 vCPUs / 8 Gb
           os: "ubuntu"
           architecture: "arm64"
@@ -193,7 +193,7 @@ profile::buildmaster::cloud_agents:
           - highram
           - docker
         idleTerminationMinutes: 5
-        maxInstances: 10
+        maxInstances: 20
         useAsMuchAsPosible: false
         credentialsId: "jenkinsvmagents-userpass"
       - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
@@ -207,7 +207,7 @@ profile::buildmaster::cloud_agents:
         labels:
           - windock
         idleTerminationMinutes: 30
-        maxInstances: 10
+        maxInstances: 20
         useAsMuchAsPosible: true
         credentialsId: "jenkinsvmagents-userpass"
         useEphemeralOSDisk: false


### PR DESCRIPTION
Ref. https://groups.google.com/g/jenkinsci-dev/c/7jitt4zBZvo

Some limitations though:

- Azure VMs are currently limited to 50 Public IPs (we can change this but it's not an easy change)
- Cost on AWS EC2 hare already high with the highmem