### PR TITLE
feat [ci.jenkins.io, trusted.ci.jenkins.io] allow Azure VM Agent to use private IPs

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -48,8 +48,15 @@ jenkins:
         templateDisabled: false
         templateName: "<%= agent["name"] %>"
         usageMode: "<%= agent["useAsMuchAsPosible"] == true ? 'Use this node as much as possible' : 'Only build jobs with label expressions matching this node' %>"
-        usePrivateIP: false
         virtualMachineSize: "<%= agent["instanceType"] %>"
+        <%- if agent["usePrivateIP"] -%>
+        usePrivateIP: true
+        virtualNetworkName: "<%= agent["virtualNetworkName"] %>"
+        virtualNetworkResourceGroupName: "<%= agent["virtualNetworkResourceGroupName"] %>"
+        subnetName: "<%= agent["subnetName"] %>"
+        <%- else -%>
+        usePrivateIP: false
+        <%- end -%>
     <%- end -%>
 <%- end -%>
 <%- if @cloud_agents["azure-container-agents"] && !@cloud_agents["azure-container-agents"].empty? -%>

--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -138,10 +138,12 @@ jenkins:
       directConnection: true
       namespace: "jenkins-agents"
       serverUrl: "<%= k8s_setup["url"] %>"
+      <%- if k8s_setup["serverCertificate"] -%>
       serverCertificate: |
         <%- k8s_setup["serverCertificate"].split("\n").each do |line| -%>
           <%= line %>
         <%- end -%>
+      <%- end -%>
       templates:
       <%- k8s_setup["agent_definitions"].each do |agent| -%>
         - containers:

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -178,6 +178,10 @@ profile::buildmaster::cloud_agents:
         maxInstances: 10
         useAsMuchAsPosible: true
         credentialsId: "jenkinsvmagents-userpass"
+        privateIP: true
+        virtualNetworkName: "prod-jenkins-public-prod"
+        virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+        subnetName: "ci.j-agents-vm"
       - name: "ubuntu-20-highmem"
         description: "Ubuntu 20.04 LTS Highmem"
         imageDefinition: jenkins-agent-ubuntu-20
@@ -195,7 +199,11 @@ profile::buildmaster::cloud_agents:
         idleTerminationMinutes: 5
         maxInstances: 20
         useAsMuchAsPosible: false
+        privateIP: true
         credentialsId: "jenkinsvmagents-userpass"
+        virtualNetworkName: "prod-jenkins-public-prod"
+        virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+        subnetName: "ci.j-agents-vm"
       - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
         description: "Windows 2019"
         imageDefinition: jenkins-agent-windows-2019
@@ -211,6 +219,10 @@ profile::buildmaster::cloud_agents:
         useAsMuchAsPosible: true
         credentialsId: "jenkinsvmagents-userpass"
         useEphemeralOSDisk: false
+        privateIP: true
+        virtualNetworkName: "prod-jenkins-public-prod"
+        virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+        subnetName: "ci.j-agents-vm"
   azure-container-agents:
     aci-windows:
       credentialsId: "azure-credentials"

--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -50,6 +50,7 @@ profile::buildmaster::cloud_agents:
         maxInstances: 15
         useAsMuchAsPosible: true
         credentialsId: "azure-jenkins-user"
+        privateIP: false
       - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
         description: "Windows 2019"
         imageDefinition: jenkins-agent-windows-2019
@@ -64,6 +65,7 @@ profile::buildmaster::cloud_agents:
         maxInstances: 5
         useAsMuchAsPosible: true
         credentialsId: "azure-jenkins-user"
+        privateIP: false
 # These are plugins we need only in our trusted-ci environment
 profile::buildmaster::plugins:
   - ansicolor

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -114,6 +114,10 @@ profile::buildmaster::cloud_agents:
         idleTerminationMinutes: 5
         maxInstances: 10
         useAsMuchAsPosible: true
+        usePrivateIP: true
+        virtualNetworkName: "prod-jenkins-public-prod"
+        virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+        subnetName: "ci.j-agents-vm"
       - name: "ubuntu-20-highmem"
         description: "Ubuntu 20.04 LTS Highmem"
         imageDefinition: jenkins-agent-ubuntu-20
@@ -131,6 +135,7 @@ profile::buildmaster::cloud_agents:
         idleTerminationMinutes: 5
         maxInstances: 10
         useAsMuchAsPosible: false
+        usePrivateIP: false
       - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
         description: "Windows 2019"
         imageDefinition: jenkins-agent-windows-2019


### PR DESCRIPTION
This PR introduces the ability to use private IPs for Azure Agent.

It also fixes the actual errors on the test harness and vagrant VM (that was also breaking the CI builds) by fixing a nil pointer in the template for Casc clouds.