### PR TITLE
fix [buildmaster] stop reusing EC2 agents after a build

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -111,7 +111,7 @@ jenkins:
         instanceCapStr: "<%= agent["maxInstances"] %>"
         labelString: "<%= agent["os"] %> <%= agent["architecture"] %> aws ec2 vm <%= agent["labels"].join(' ') %>"
         launchTimeoutStr: "1000"
-        maxTotalUses: 30
+        maxTotalUses: 1 # Throw away the VMs after a build
         minimumNumberOfInstances: 0
         minimumNumberOfSpareInstances: 0
         mode: <%= agent["useAsMuchAsPosible"] == true ? 'NORMAL' : 'EXCLUSIVE' %>


### PR DESCRIPTION
Reported in the IRC #jenkins-infra:

> jenkinsci/docker builds all fail because of dockerhub rate limiting
> e.g https://github.com/jenkinsci/docker/pull/1219/checks?check_run_id=3878727770

Since the failing build mentioned here was using EC2 VM agents on ci.jenkins.io, this PR treat the EC2 agents as ephemeral (e.g. 1 build and then throw away) to avoid rate limiting