### PR TITLE
fix: add 'docker-highmen' label to hieradata templates (INFRA-3099)

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -146,6 +146,7 @@ profile::buildmaster::cloud_agents:
             - highram
             - docker
             - linux
+            - docker-highmem
           useAsMuchAsPosible: false
           idleTerminationMinutes: 5 # Quick deallocation as Linux is billed per minute
         - description: "ARM64 ubuntu 20.04"
@@ -196,6 +197,7 @@ profile::buildmaster::cloud_agents:
           - highmem
           - highram
           - docker
+          - docker-highmem
         idleTerminationMinutes: 5
         maxInstances: 20
         useAsMuchAsPosible: false

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -86,6 +86,7 @@ profile::buildmaster::cloud_agents:
             - highram
             - docker
             - linux
+            - docker-highmem
           useAsMuchAsPosible: false
         - description: "ARM64 ubuntu 20.04"
           maxInstances: 2
@@ -132,6 +133,7 @@ profile::buildmaster::cloud_agents:
           - highmem
           - highram
           - docker
+          - docker-highmem
         idleTerminationMinutes: 5
         maxInstances: 10
         useAsMuchAsPosible: false


### PR DESCRIPTION
First step of https://issues.jenkins.io/browse/INFRA-3099