### PR TITLE
fix: add 'docker-windows' label to hieradata templates (INFRA-3099)

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -134,6 +134,7 @@ profile::buildmaster::cloud_agents:
           architecture: "amd64"
           labels:
             - windock
+            - docker-windows
           useAsMuchAsPosible: true
           idleTerminationMinutes: 30 # Windows is billed per hour: let's wait half of this period since most of the builds are less than 30 min on Windows
         - description: "High memory ubuntu 20.04"
@@ -216,6 +217,7 @@ profile::buildmaster::cloud_agents:
         architecture: amd64
         labels:
           - windock
+          - docker-windows
         idleTerminationMinutes: 30
         maxInstances: 20
         useAsMuchAsPosible: true

--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -61,6 +61,7 @@ profile::buildmaster::cloud_agents:
         architecture: amd64
         labels:
           - windock
+          - docker-windows
         idleTerminationMinutes: 60
         maxInstances: 5
         useAsMuchAsPosible: true

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -75,6 +75,7 @@ profile::buildmaster::cloud_agents:
           architecture: "amd64"
           labels:
             - windock
+            - docker-windows
           useAsMuchAsPosible: true
         - description: "High memory ubuntu 20.04"
           maxInstances: 20
@@ -148,6 +149,7 @@ profile::buildmaster::cloud_agents:
         architecture: amd64
         labels:
           - windock
+          - docker-windows
         idleTerminationMinutes: 30
         maxInstances: 10
         useAsMuchAsPosible: true


### PR DESCRIPTION
Add a new 'docker-windows' label, which will replace the 'windock' one. (To be coherent with the 'docker-highmem' label)
See https://issues.jenkins.io/browse/INFRA-3099?focusedCommentId=414936