### PR TITLE
fix: remove 'windock' label, replaced by 'docker-windows' (INFRA-3099)

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -133,7 +133,6 @@ profile::buildmaster::cloud_agents:
           os: "windows"
           architecture: "amd64"
           labels:
-            - windock
             - docker-windows
           useAsMuchAsPosible: true
           idleTerminationMinutes: 30 # Windows is billed per hour: let's wait half of this period since most of the builds are less than 30 min on Windows
@@ -216,7 +215,6 @@ profile::buildmaster::cloud_agents:
         instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
         architecture: amd64
         labels:
-          - windock
           - docker-windows
         idleTerminationMinutes: 30
         maxInstances: 20

--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -60,7 +60,6 @@ profile::buildmaster::cloud_agents:
         instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
         architecture: amd64
         labels:
-          - windock
           - docker-windows
         idleTerminationMinutes: 60
         maxInstances: 5

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -60,7 +60,7 @@ profile::buildmaster::cloud_agents:
       agent_definitions:
         - description: "Ubuntu 20.04 LTS"
           maxInstances: 5
-          instanceType: T3Xlarge # 8 vCPUs / 16 Gb
+          instanceType: T3Xlarge # 4 vCPUs / 16 Gb
           os: "ubuntu"
           architecture: "amd64"
           labels:
@@ -70,7 +70,7 @@ profile::buildmaster::cloud_agents:
           useAsMuchAsPosible: true
         - description: "Windows 2019"
           maxInstances: 10
-          instanceType: T3Xlarge # 8 vCPUs / 16 Gb
+          instanceType: T3Xlarge # 4 vCPUs / 16 Gb
           os: "windows"
           architecture: "amd64"
           labels:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -74,7 +74,6 @@ profile::buildmaster::cloud_agents:
           os: "windows"
           architecture: "amd64"
           labels:
-            - windock
             - docker-windows
           useAsMuchAsPosible: true
         - description: "High memory ubuntu 20.04"
@@ -148,7 +147,6 @@ profile::buildmaster::cloud_agents:
         instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
         architecture: amd64
         labels:
-          - windock
           - docker-windows
         idleTerminationMinutes: 30
         maxInstances: 10


### PR DESCRIPTION
As [all PRs](https://github.com/jenkins-infra/jenkins-infra/pull/1936) introducing the new 'docker-windows' label have been merged, we can now remove the replaced 'windock' label