### PR TITLE
fix: keep only 'high*' labels on large marchines so they won't be used for anything else (INFRA-3099)

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -145,8 +145,6 @@ profile::buildmaster::cloud_agents:
           labels:
             - highmem
             - highram
-            - docker
-            - linux
             - docker-highmem
           useAsMuchAsPosible: false
           idleTerminationMinutes: 5 # Quick deallocation as Linux is billed per minute
@@ -193,11 +191,8 @@ profile::buildmaster::cloud_agents:
         instanceType: Standard_D16s_v3 # 16 vCPUS / 64 Gb
         architecture: amd64
         labels:
-          - linux
-          - java
           - highmem
           - highram
-          - docker
           - docker-highmem
         idleTerminationMinutes: 5
         maxInstances: 20

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -85,8 +85,6 @@ profile::buildmaster::cloud_agents:
           labels:
             - highmem
             - highram
-            - docker
-            - linux
             - docker-highmem
           useAsMuchAsPosible: false
         - description: "ARM64 ubuntu 20.04"
@@ -129,11 +127,8 @@ profile::buildmaster::cloud_agents:
         instanceType: Standard_D16s_v3 # 16 vCPUS / 64 Gb
         architecture: amd64
         labels:
-          - linux
-          - java
           - highmem
           - highram
-          - docker
           - docker-highmem
         idleTerminationMinutes: 5
         maxInstances: 10


### PR DESCRIPTION
Following [these PRs](https://github.com/jenkins-infra/jenkins-infra/pull/1934), 2 issues has been created and must be resolved before merging this PR:
- https://github.com/jenkinsci/jms-messaging-plugin/issues/226
- https://issues.jenkins.io/browse/JENKINS-66924 (kerberos-oss-plugin)

See https://issues.jenkins.io/browse/INFRA-3099?focusedCommentId=414936