### PR TITLE
feat(ci.jenkins.io) enable spot instances for EC2 VM agents (INFRA-3101)

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -120,6 +120,9 @@ jenkins:
         remoteAdmin: "<%= @agents_setup[agent["os"].to_s]["remoteAdmin"] %>"
         remoteFS: "<%= @agents_setup[agent["os"].to_s]["agentDir"] %>"
         securityGroups: "ci-agents"
+        spotConfig:
+          fallbackToOndemand: true
+          useBidPrice: false
         stopOnTerminate: false
         t2Unlimited: false
         tags:


### PR DESCRIPTION
This PR enables EC2 spot reservation for all the EC2 VM agents (only ci.jenkins.io as for today).

No bidding price is applied: the current market price will be used as in the end, the reservation and lifecycle does not change based on the price.

Please note that the fallback to on demand instance is enabled: if no spot reservation is possible, it would allow to still provide a working solution.