### PR TITLE
fix(ci.jenkins.io) switch EC2 account to the new terraform-managed jenkins-ci account

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -113,7 +113,7 @@ profile::buildmaster::cloud_agents:
   ec2:
     aws-us-east-2:
       region: us-east-2
-      credentialsId: "aws-credentials"
+      credentialsId: "aws-credentials-jenkins-ci"
       sshKeysCredentialsId: "ec2-agent-ssh-2021-06"
       agent_definitions:
         - description: "Ubuntu 20.04 LTS"


### PR DESCRIPTION
With https://github.com/jenkins-infra/aws/pull/36, a new AWS account was created with a new API credential set.

This account is managed by Terraform AND has the correct IAM authorization to support EC2 agents cases including spot (INFRA-3101).