### PR TITLE
chore(updatecli) allow docker-ce to be bumped through a PR

### DIFF
--- a/updatecli/weekly.d/docker-ce.yaml
+++ b/updatecli/weekly.d/docker-ce.yaml
@@ -13,3 +13,12 @@ targets:
     spec:
       file: hieradata/common.yaml
       key: "docker::version"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"


### PR DESCRIPTION
This PR is a follow up of #1958 that adds the `scm` section to allow updatecli to open PRs for bumping the Docker version.

The reason for not blocking #1958 was to avoid updatecli failing because of the `scm` (ref. https://github.com/updatecli/updatecli/issues/262).

Since https://github.com/jenkins-infra/jenkins-infra/runs/4118822831?check_suite_focus=true#step:6:311 clearly demonstrate that it works as expected, we can safely go ahead \o/

```
✔ Key 'docker::version', from file 'hieradata/common.yaml', was updated from '5:20.10.7~3-0~ubuntu-bionic' to ''5:20.10.10~3-0~ubuntu-bionic''
```

