### PR TITLE
fix(buildmasters) ensure that JDK11 is used to start agent process for Azure VM agents

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -40,6 +40,7 @@ class profile::buildmaster(
   $agent_images                    = {},
   $additional_tools                = {},
   $default_tools                   = {},
+  $agent_cli_tools                 = {},
   $memory_limit                    = '1g',
   $java_opts = "-server \
 -Xlog:gc*=info,ref*=debug,ergo*=trace,age*=trace:file=${container_jenkins_home}/gc/gc.log::filecount=5,filesize=40M \

--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -33,7 +33,7 @@ jenkins:
         installDocker: false
         installGit: false
         installMaven: false
-        javaPath: "java"
+        javaPath: "<%= agent["os"] == "windows" ? @agent_cli_tools['jdk']['jdk11']['windows'] : @agent_cli_tools['jdk']['jdk11']['linux'] %>/bin/java"
         labels: "<%= agent["os"] %> <%= agent["architecture"] %> azure vm <%= agent["labels"].join(' ') %>"
         location: "<%= agent["location"] %>"
         noOfParallelJobs: 1

--- a/dist/profile/templates/buildmaster/casc/tools.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/tools.yaml.erb
@@ -16,17 +16,17 @@ tool:
   jdk:
     installations:
     - name: "jdk8-linux-static"
-      home: "/opt/jdk-8"
+      home: "<%= @agent_cli_tools['jdk']['jdk8']['linux'] %>"
     - name: "jdk8-windows-static"
-      home: "C:\\Tools\\jdk-8"
+      home: "<%= @agent_cli_tools['jdk']['jdk8']['windows'] %>"
     - name: "jdk11-linux-static"
-      home: "/opt/jdk-11"
+      home: "<%= @agent_cli_tools['jdk']['jdk11']['linux'] %>"
     - name: "jdk11-windows-static"
-      home: "C:\\Tools\\jdk-11"
+      home: "<%= @agent_cli_tools['jdk']['jdk11']['windows'] %>"
     - name: "jdk17-linux-static"
-      home: "/opt/jdk-17"
+      home: "<%= @agent_cli_tools['jdk']['jdk17']['linux'] %>"
     - name: "jdk17-windows-static"
-      home: "C:\\Tools\\jdk-17"
+      home: "<%= @agent_cli_tools['jdk']['jdk17']['windows'] %>"
     - name: "jdk8"
       properties:
       - installSource:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -331,6 +331,17 @@ profile::buildmaster::default_tools:
   groovy:
     groovy: # Default version is named "groovy"
       version: "2.4.7"
+profile::buildmaster::agent_cli_tools:
+  jdk:
+    jdk8:
+      linux: /opt/jdk-8
+      windows: C:/Tools/jdk-8
+    jdk11:
+      linux: /opt/jdk-11
+      windows: C:/Tools/jdk-11
+    jdk17:
+      linux: /opt/jdk-17
+      windows: C:/Tools/jdk-17
 ldap_url: 'ldap://localhost:389'
 ldap_dn: 'dc=example,dc=com'
 ldap_admin_dn: 'cn=admin,dc=example,dc=com'


### PR DESCRIPTION
This PR introduces the following changes for all buildmasters managed with JCasc (ci.jenkins and trusted.ci):

- Specifies the java binary used on Azure VMs to force the embeded JDK11 instead of the default java found in path (INFRA-3126)
  - It is still possible to overrides the java binary on a specific templates through node's hieradata
  - It supports both Windows and Linux
-  Factorize in hieradata/common.yaml the default JDK installation paths to ease updates if the upstream jenkins-infra/packer-images changes the path.
    - It supports both Windows and Linux
