### PR TITLE
feat(trusted.ci.jenkins.io) use the same Docker CE version as the rest of machines

### DIFF
--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -6,7 +6,6 @@ accounts:
         key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC3oj0NN9UL1dIfBP44JDsOj/bGX/DG/GIv82imhgWbCQvsKcPczb32+W+zVo+OF3mADX4EoBG681GGopjYCKLreo8D3nFSP/+kdAt0lEqbufzoLvSyyxa0RUHDwzVQIiMiNlzDiWqLRkF2TdeFDl5u+bbdPTYCGil5/qZ3Ro8sG9ayWXMxh+f+s0MAU9qFIwau838RF2R9OCMjmPodW/zf+Mcq+SqrbZyYfYha5jOWxoN8IdrGuAOQeYks7mrXC6qq5N9ojUtMKONvayFwNOsuC0U8PYUtukkHVnm2IK9KM1A38HDlV9eTF8ac7yCUHLlttmoIBdLUuLJAw72BQkK/
     groups:
       - sudo
-docker::version: '5:20.10.7~3-0~ubuntu-bionic'
 docker::log_opt::max-size: '100m'
 docker::log_opt::max-file: 2
 profile::buildmaster::ci_fqdn: 'trusted.ci.jenkins.io'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -362,6 +362,7 @@ usage_ssh_pubkey: 'AAAAB3NzaC1yc2EAAAADAQABAAACAQD66Xfd/5HgBkc6lGGqCrhJ/LBIWOTQ5
 usage_ssh_privkey: 'usage_ssh_privkey'
 osuosl_mirroring_privkey: ''
 archives_mirroring_privkey: ''
+## Full version of the Ubuntu package used for Docker CE as per apt-cache output
 docker::version: '5:20.10.10~3-0~ubuntu-bionic'
 # profile::pluginsite::image_tag is deprecated as pluginsite is now deployed on kubernetes
 # you should instead update profile::kubernetes::resources:pluginsite::image_tag

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -215,7 +215,6 @@ profile::kubernetes::resources::chatbot_jenkinsadmin::jira_password: 'jiratoken'
 profile::kubernetes::resources::chatbot_jenkinsadmin::nick_password: 'ircpassword'
 profile::jira::database_url: mysql://jira:raji@db/jiradb
 
-docker::version: '5:20.10.7~3-0~ubuntu-bionic'
 docker::log_opt::max-size: '100m'
 docker::log_opt::max-file: 2
 

--- a/updatecli/weekly.d/docker-ce.yaml
+++ b/updatecli/weekly.d/docker-ce.yaml
@@ -1,11 +1,17 @@
 ---
 title: Bump docker-ce version
 sources:
-  default:
+  lastDockerCePackageVersion:
     name: Get latest docker-ce version
     kind: shell
     spec:
       command: bash ./updatecli/scripts/docker-ce-updates.sh
+conditions:
+  checkIfHieradataHasDockerVersionKey:
+    kind: file
+    spec:
+      file: hieradata/common.yaml
+      matchPattern: 'docker::version:.*'
 targets:
   default:
     name: Update docker-ce version in common.yaml


### PR DESCRIPTION
Since #1958 , the version of Docker CE is fixed and managed with updatecli.

It means that we do not need to fix Docker CE package version on specific machines: we can share the version from `hieradata/common.yaml`.


Please note that this PR also adds a sanity check in the updatecli manfiest for the docker CE version to ensure we catch the failure if the hierata content is changed.