### PR TITLE
Certificate renewal

### DIFF
--- a/dist/profile/files/bind/jenkins-ci.org.zone
+++ b/dist/profile/files/bind/jenkins-ci.org.zone
@@ -110,7 +110,7 @@ lists      3600    IN    MX    0    smtp4.osuosl.org.
 ; Certificates DNS Verification, it can be removed when validated
 @          3600  IN  TXT   "nuorpib8b66b00omtejqkj76v4"   ; For certificate:  jenkins-ci.org
 @          3600  IN  TXT   "a7p88u6si2hmbsdfsdtgbs04dt"   ; For certificate:  wiki.jenkins-ci.org
-@          3600  IN  TXT   "rffukoeejek9rl4d1b1o2bvk0q"   ; For certificate:  repo.jenkins-ci.org
+@          3600  IN  TXT   "d9g3op5gq2093d1q9kqc4mteqr"   ; For certificate:  repo.jenkins-ci.org
 
 ; DKIM
 cucumber._domainkey     1W IN TXT ("v=DKIM1;p="


### PR DESCRIPTION
GoDaddy needs the domain ownership validation before we can issue a new certificate https://www.godaddy.com/help/verify-domain-ownership-html-or-dns-for-my-ssl-certificate-7452?locale=en