### PR TITLE
hotfix(vpn) correct the hieradata key string for networks

### DIFF
--- a/hieradata/clients/vpn.jenkins.io.yaml
+++ b/hieradata/clients/vpn.jenkins.io.yaml
@@ -1,6 +1,6 @@
 ---
-networks:
-  eth0: 
+profile::openvpn::networks:
+  eth0:
     route-metric: 100
     macaddress: 00:0d:3a:0e:4b:1c
   eth1:

--- a/hieradata/vagrant/clients/openvpn.yaml
+++ b/hieradata/vagrant/clients/openvpn.yaml
@@ -1,6 +1,6 @@
 ---
-networks:
-  eth0: 
+profile::openvpn::networks:
+  eth0:
     route-metric: 100
     macaddress: 00:0d:3a:0e:4b:1c
   eth1:


### PR DESCRIPTION
Follow up #1992 where we the hieradata key was not following convention, hence it was ignored by the template engine.