### PR TITLE
fix: remove bandwidth module, as we're on a cloud with far lower bandwidth cost (Oracle)

### DIFF
--- a/dist/profile/templates/archives/vhost.conf
+++ b/dist/profile/templates/archives/vhost.conf
@@ -1,15 +1,1 @@
 CustomLog "|/usr/bin/rotatelogs /var/log/apache2/archives.jenkins-ci.org/access.log.%Y%m%d%H%M%S 604800" reverseproxy_combined
-
-
-# see http://bwmod.sourceforge.net/files/mod_bw-0.7.txt
-# allocate the combined total of N KB/sec bandwidth to this service,
-# all the concurrent users will share this bandwidth pool, so if 10 people download
-# at the same time, they get tenth the bandwidth each.
-#
-# 1000KB/sec constant transfer is equivalent of 2600GB/month transfer.
-# At $0.12/GB, that costs about $300/month
-
-BandwidthModule On
-ForceBandWidthModule On
-Bandwidth all 1024000
-MinBandwidth all 0


### PR DESCRIPTION
Ref: https://matrix.to/\#/!CuJBSpFAVIYrdHrjnY:libera.chat/\?via\=libera.chat\&via\=matrix.org\&via\=g4v.dev