### PR TITLE
feat(ci.jenkins.io) tune disk and behavior of Azure VM Agents

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -37,13 +37,14 @@ jenkins:
         labels: "<%= agent["os"] %> <%= agent["architecture"] %> azure vm <%= agent["labels"].join(' ') %>"
         location: "<%= agent["location"] %>"
         noOfParallelJobs: 1
-        osDiskSize: 0
+        osDiskSize: <%= agent["osDiskSize"] ? agent["osDiskSize"] : 0 %>
         osType: "<%= agent["os"] == "windows" ? 'Windows' : 'Linux' %>"
         preInstallSsh: false
         retentionStrategy:
           azureVMCloudRetentionStrategy:
             idleTerminationMinutes: "<%= agent["idleTerminationMinutes"] %>"
         shutdownOnIdle: false
+        spotInstance: <%= agent["spotInstance"] || agent["spot"] ? true : false %>
         templateDesc: "Dynamically provisioned <%= agent["description"] %> machine"
         templateDisabled: false
         templateName: "<%= agent["name"] %>"

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -173,7 +173,7 @@ profile::buildmaster::cloud_agents:
           - java
           - linux
           - docker
-        idleTerminationMinutes: 5
+        idleTerminationMinutes: 1
         maxInstances: 10
         useAsMuchAsPosible: true
         credentialsId: "jenkinsvmagents-userpass"
@@ -181,6 +181,8 @@ profile::buildmaster::cloud_agents:
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
         subnetName: "ci.j-agents-vm"
+        osDiskSize: 90
+        spot: true
       - name: "ubuntu-20-highmem"
         description: "Ubuntu 20.04 LTS Highmem"
         imageDefinition: jenkins-agent-ubuntu-20
@@ -193,7 +195,7 @@ profile::buildmaster::cloud_agents:
           - highmem
           - highram
           - docker-highmem
-        idleTerminationMinutes: 5
+        idleTerminationMinutes: 1
         maxInstances: 20
         useAsMuchAsPosible: false
         usePrivateIP: true
@@ -201,6 +203,8 @@ profile::buildmaster::cloud_agents:
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
         subnetName: "ci.j-agents-vm"
+        osDiskSize: 90
+        spot: true
       - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
         description: "Windows 2019"
         imageDefinition: jenkins-agent-windows-2019
@@ -220,6 +224,8 @@ profile::buildmaster::cloud_agents:
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
         subnetName: "ci.j-agents-vm"
+        osDiskSize: 90
+        spot: true
   azure-container-agents:
     aci-windows:
       credentialsId: "azure-credentials"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -117,6 +117,8 @@ profile::buildmaster::cloud_agents:
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
         subnetName: "ci.j-agents-vm"
+        osDiskSize: 90
+        spot: true
       - name: "ubuntu-20-highmem"
         description: "Ubuntu 20.04 LTS Highmem"
         imageDefinition: jenkins-agent-ubuntu-20
@@ -133,6 +135,7 @@ profile::buildmaster::cloud_agents:
         maxInstances: 10
         useAsMuchAsPosible: false
         usePrivateIP: false
+        osDiskSize: 90
       - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
         description: "Windows 2019"
         imageDefinition: jenkins-agent-windows-2019
@@ -147,6 +150,7 @@ profile::buildmaster::cloud_agents:
         maxInstances: 10
         useAsMuchAsPosible: true
         useEphemeralOSDisk: false
+        osDiskSize: 90
   azure-container-agents:
     aci-windows:
       credentialsId: "azure-credentials"


### PR DESCRIPTION
- disk to 90 Gb to avoid breaking jenkins.io website builder indirectly
- enable spot instances (to cost less)
- Ensure that Linux Azure VMs are recycled as soon as possible