### PR TITLE
Use /opt/jdk-11 to run ppc64le Java agent

### DIFF
--- a/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
@@ -12,6 +12,7 @@ jenkins:
         ssh:
           credentialsId: "ppc64le-ed25519-2021-12-03"
           host: "158.175.161.173"
+          javaPath: "/opt/jdk-11/bin/java"
           launchTimeoutSeconds: 713
           port: 22
           retryWaitTime: 175


### PR DESCRIPTION
## Use /opt/jdk-11 to run ppc64le Java agent

The Ubuntu Java 11.0.11 at /usr/bin/java does not complete the connection, while the Eclipse Adoptium Java 11.0.13 that is installed at /opt/jdk-11 completes the connection.

No idea why, but that's what I observe when comparing the working connection from my test environment to the ci.jenkins.io agent that is unable to complete the connection of the agent.
