### PR TITLE
fix: remove census role from trusted-agent

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -149,7 +149,7 @@ node 'cert-ci' {
 node /^trusted-agent-\d+$/ {
   notice('This agent is trusted!')
   $hiera_role = 'trustedagent'
-  include role::census::agent
+  # include role::census::agent
   include role::updatecenter
 
 }


### PR DESCRIPTION
Puppet run on trusted-agent-1 are failing with an error related to missing census configuration.

This PR removes the census role on this agent to fix this error.