### PR TITLE
hotfix(updatecenter) remove deprecated directive on concat::fragment

### DIFF
--- a/dist/profile/manifests/updatecenter.pp
+++ b/dist/profile/manifests/updatecenter.pp
@@ -44,7 +44,6 @@ class profile::updatecenter(
   )
 
   concat::fragment { 'updates-rsync-key concat':
-    ensure  => present,
     target  => "${home_dir}/.ssh/config",
     order   => '99',
     content => "


### PR DESCRIPTION
Signed-off-by: Damien Duportal <damien.duportal@gmail.com>