### PR TITLE
chore(updatecli) allow updatecli to update its GitHub Workflow file

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -13,13 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Configure AWS Credentials
-        if: github.ref == 'refs/heads/production'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-2
       - name: Install updatecli CLI
         env:
           UPDATECLI_VERSION: "0.13.1"
@@ -34,9 +27,24 @@ jobs:
           updatecli diff --config ./updatecli/weekly.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure AWS Credentials
+        if: github.ref == 'refs/heads/production'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      ## This step allows to generate a short-lived token which is allowed to modify GitHub Workflow files (that the default GITHUB_TOKEN cannot)
+      ## Please make sure that the 2 secrets are defined (usually at organization level, with a per-repository access)
+      - uses: tibdex/github-app-token@v1.5
+        id: generate_token
+        if: github.ref == 'refs/heads/production'
+        with:
+          app_id: ${{ secrets.JENKINS_ADMIN_APP_ID }}
+          private_key: ${{ secrets.JENKINS_ADMIN_APP_PRIVKEY }}
       - name: Apply
         if: github.ref == 'refs/heads/production'
         run: |
           updatecli apply --config ./updatecli/weekly.d --values ./updatecli/values.github-action.yaml
         env:
-          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
This PR ensures that the GitHub workflow for updatecli is allowed  to edit itself: it allows the updatecli version to be bumped to recent version.

It's done by using a GitHub Action that generates a short lived token from a GitHub App (which is restricted per repositories), from organization-scoped secrets.