### PR TITLE
chore: move globalLibraries configuration for the groovy init scripts to JCasC

### DIFF
--- a/dist/profile/files/buildmaster/pipeline-configuration.groovy
+++ b/dist/profile/files/buildmaster/pipeline-configuration.groovy
@@ -1,31 +1,6 @@
 #!/usr/bin/env groovy
 
-/* Configure the right defaults for our Jenkins instances and their Pipeline
- * configurations
- */
-
-import jenkins.model.*
-import jenkins.plugins.git.GitSCMSource
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
-import org.jenkinsci.plugins.workflow.libs.*
 import org.jenkinsci.plugins.pipeline.modeldefinition.config.GlobalConfig
-
-
-/* Add our global library properly */
-GitSCMSource source= new GitSCMSource('pipeline-library',
-                        'https://github.com/jenkins-infra/pipeline-library.git',
-                        null, null, null, false)
-
-LibraryConfiguration lib = new LibraryConfiguration('pipeline-library',
-                                            new SCMSourceRetriever(source))
-
-lib.implicit = true
-lib.defaultVersion = 'master'
-lib.includeInChangesets = false
-lib.cachingConfiguration = new LibraryCachingConfiguration(180, null)
-
-GlobalLibraries.get().libraries = [lib]
-
 
 /* Set the default Docker label for Declarative Pipeline to .. wait for it ..
  * docker

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -236,6 +236,7 @@ class profile::buildmaster(
     common_configs => [ # Configurations shared by all Jenkins controllers. There are hieradata attribute to really fill the configs (as an additional step for opt-in)
       'buildmaster/casc/clouds.yaml.erb',
       'buildmaster/casc/tools.yaml.erb',
+      'buildmaster/casc/global-libraries.yaml.erb',
     ],
     config_dir =>     'casc.d', # Relative to the jenkins_home
   }

--- a/dist/profile/templates/buildmaster/casc/global-libraries.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/global-libraries.yaml.erb
@@ -1,0 +1,19 @@
+unclassified:
+  globalLibraries:
+    libraries:
+      - defaultVersion: "master"
+        implicit: true
+        includeInChangesets: false
+        name: "pipeline-library"
+        retriever:
+          modernSCM:
+            scm:
+              git:
+                id: "pipeline-library"
+                remote: "https://github.com/jenkins-infra/pipeline-library.git"
+                traits:
+                - "gitBranchDiscovery"
+                - discoverOtherRefsTrait:
+                    ref: "pull/*"
+                - headWildcardFilter:
+                    includes: "*"


### PR DESCRIPTION
Followup of https://github.com/jenkins-infra/jenkins-infra/pull/2047 