### PR TITLE
feat(trusted.ci) add jdk11 related labels for VM agents

### DIFF
--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -46,6 +46,8 @@ profile::buildmaster::cloud_agents:
           - java
           - linux
           - docker
+          - maven-11
+          - jdk11
         idleTerminationMinutes: 5
         maxInstances: 7 # Quota of 56 vCPUs
         useAsMuchAsPosible: true


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2732

This PR adds the labels `maven-11` and `jdk11` to trusted.ci.jenkins.io to make it closer to ci.jenkins.io's agent features.

Ping @MarkEWaite @daniel-beck @wfollonier @lemeurherve @timja for information.

Rationale is:
- trusted.ci.jenkins.io is the "CD" while ci.jenkins.io is the "CI": they should provide the same build environment
- Both instances uses the same VM templates (on both Azure and AWS) and are updated at the same time thanks to the puppet code => JDK and Maven version (for instance) are always the same
- VM agents on both instances have the 3 JDK: 8, 11 and 17. 11 is the default. Which means that it is safe to add these 2 labels since JDK11 is default.