### PR TITLE
Use JDK 17.0.2, not JDK 17.0

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -255,7 +255,7 @@ profile::buildmaster::default_tools:
     version: "11.0.14+9"
     sourceURL: https://github.com/adoptium/temurin11-binaries/releases/download
   jdk17:
-    version: "17+35"
+    version: "17.0.2+8"
     sourceURL: https://github.com/adoptium/temurin17-binaries/releases/download
   maven:
     mvn:

--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -13,17 +13,17 @@ function get_jdk_download_url() {
   jdk_version="${1}"
   platform="${2}"
   case "${jdk_version}" in
-    8u*)
+    8*)
       ## JDK8 does not have the carret ('-') in their archive names
       echo "https://github.com/adoptium/temurin8-binaries/releases/download/jdk${jdk_version}/OpenJDK8U-jdk_${platform}_hotspot_${jdk_version//-}";
       return 0;;
-    11.*)
+    11*)
       ## JDK11 URLs have an underscore ('_') instead of a plus ('+') in their archive names
       echo "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${jdk_version}/OpenJDK11U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
-    17+*)
+    17*)
       ## JDK17 URLs have an underscore ('_') instead of a plus ('+') in their archive names
-      echo "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${jdk_version}/OpenJDK17-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      echo "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${jdk_version}/OpenJDK17U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
     *)
       echo "ERROR: unsupported JDK version (${jdk_version}).";
@@ -37,7 +37,7 @@ case "${1}" in
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "ppc64le_linux");;
   11.*)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "ppc64le_linux" "s390x_linux");;
-  17+*)
+  17.*+*)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "ppc64le_linux" "s390x_linux");;
   *)
     echo "ERROR: unsupported JDK version (${1}).";

--- a/updatecli/weekly.d/buildmaster-tools-jdk17.yaml
+++ b/updatecli/weekly.d/buildmaster-tools-jdk17.yaml
@@ -23,8 +23,8 @@ sources:
       username: "{{ .github.username }}"
       versionFilter:
         kind: regex
-        # jdk-17+35(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17%2B35) is OK
-        pattern: "^jdk-17\\+(\\d*)$"
+        # jdk-17.0.2+8(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.2%2B8) is OK
+        pattern: "^jdk-17.(\\d*).(\\d*).(\\d*)+(\\d*)$"
     transformers:
       - trimPrefix: "jdk-"
 


### PR DESCRIPTION
## Use JDK 17.0.2 rather than JDK 17.0

Extend updatecli for JDK 17 to match JDK 11

Makes progress on jenkins-infra/helpdesk#2758
