### PR TITLE
Disambiguate permission assignment for matrix-auth 3.0+

### DIFF
--- a/dist/profile/templates/buildmaster/lockbox.groovy.erb
+++ b/dist/profile/templates/buildmaster/lockbox.groovy.erb
@@ -4,6 +4,7 @@ import jenkins.model.*
 import hudson.security.*
 import hudson.security.csrf.*
 import hudson.model.Item
+import org.jenkinsci.plugins.matrixauth.PermissionEntry
 
 def instance = Jenkins.instance
 
@@ -55,12 +56,12 @@ AuthorizationStrategy strategy = new GlobalMatrixAuthorizationStrategy()
     Jenkins.READ,
     Item.READ,
 ].each { permission ->
-    strategy.add(permission, 'anonymous')
+    strategy.add(permission, PermissionEntry.user('anonymous'))
 }
 <%end%>
 
 <% @admin_ldap_groups.each do |group|%>
-strategy.add(Jenkins.ADMINISTER, '<%= group %>')
+strategy.add(Jenkins.ADMINISTER, PermissionEntry.group('<%= group %>'))
 <%end%>
 
 instance.authorizationStrategy = strategy


### PR DESCRIPTION
Semi-tested locally: I took parts of the script and ran them in a script console, then manually copied them back.