### PR TITLE
fix: replace deprecated git:// protocol by https://

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,21 +2,21 @@
 fixtures:
   repositories:
     yamlfile:
-      repo: 'git://github.com/reidmv/puppet-module-yamlfile.git'
+      repo: 'https://github.com/reidmv/puppet-module-yamlfile.git'
     filemapper:
-      repo: 'git://github.com/adrienthebo/puppet-filemapper.git'
+      repo: 'https://github.com/adrienthebo/puppet-filemapper.git'
       ref: '1.1.2'
     account:
-      repo: 'git://github.com/jenkins-infra/puppet-account.git'
+      repo: 'https://github.com/jenkins-infra/puppet-account.git'
       ref: '1deebe9'
     sudo:
-      repo: 'git://github.com/saz/puppet-sudo.git'
+      repo: 'https://github.com/saz/puppet-sudo.git'
       ref: 'v3.0.6'
     irc:
-      repo: 'git://github.com/jenkins-infra/puppet-irc.git'
+      repo: 'https://github.com/jenkins-infra/puppet-irc.git'
       ref: '4e5e437'
     apachelogcompressor:
-      repo: 'git://github.com/jenkins-infra/puppet-apachelogcompressor.git'
+      repo: 'https://github.com/jenkins-infra/puppet-apachelogcompressor.git'
 
   forge_modules:
     stdlib:

--- a/Puppetfile
+++ b/Puppetfile
@@ -36,13 +36,13 @@ mod 'puppet/epel', '3.0.1'
 
 # Dependencies for the Puppet IRC report processor, using our forked version
 # which updates on any changed status
-mod 'irc', :git => 'git://github.com/jenkins-infra/puppet-irc.git',
+mod 'irc', :git => 'https://github.com/jenkins-infra/puppet-irc.git',
            :ref => '4e5e437'
 
 # Needed for managing our accounts in hiera, this fork contains the pull
 # request which adds support for multiple SSH keys:
 # <https://github.com/torrancew/puppet-account/pull/18>
-mod 'account', :git => 'git://github.com/jenkins-infra/puppet-account.git',
+mod 'account', :git => 'https://github.com/jenkins-infra/puppet-account.git',
                :ref => '1deebe9'
 
 mod 'jenkins_keys',
@@ -53,7 +53,7 @@ mod 'jenkins_keys',
 mod "puppetlabs/apache", '3.5.0'
 # Used internally to gzip compress rotated logs
 mod 'apachelogcompressor',
-        :git => 'git://github.com/jenkins-infra/puppet-apachelogcompressor.git',
+        :git => 'https://github.com/jenkins-infra/puppet-apachelogcompressor.git',
         :ref => '0113d7b'
 
 mod "puppetlabs/concat", '5.2.0'


### PR DESCRIPTION
As per https://github.blog/2021-09-01-improving-git-protocol-security-github/, the `git://` (unencrypted) protocol had been phased out by GitHub.

This PR fixes the CI by switching protocol to `https://` for the public repositories used in the Puppet dependency chain.