### PR TITLE
chore(buildmaster) fix unit tests (bad casc file name)

### DIFF
--- a/spec/classes/profile/buildmaster_spec.rb
+++ b/spec/classes/profile/buildmaster_spec.rb
@@ -51,7 +51,7 @@ describe 'profile::buildmaster' do
 
     context 'JCasC' do
       it { is_expected.to contain_file('/var/lib/jenkins/casc.d').with('ensure' => 'directory')}
-      it { is_expected.to contain_file('/var/lib/jenkins/casc.d/agents.yaml')}
+      it { is_expected.to contain_file('/var/lib/jenkins/casc.d/clouds.yaml')}
       it { should contain_exec('install-plugin-configuration-as-code') }
       it { should contain_exec('perform-jcasc-reload') }
       it { should contain_exec('safe-restart-jenkins') }


### PR DESCRIPTION
This PR fixes the CI failures by correcting the faulty puppet unit test.

Error was introduced in https://github.com/jenkins-infra/jenkins-infra/pull/2077 (sorry, I wasn't careful when adding my commits to Stephane's PR).

As per https://github.com/jenkins-infra/jenkins-infra/blob/production/spec/fixtures/hiera.yaml, the fixtures used in the spec tests are the vagrant ones. Since #2077 changed some of this parameters (to allow testing in Vagrant), it had an impact on the unit test behavior, hence the fix here.