### PR TITLE
Fix(ci.jenkins.io, trusted.ci.jenkins.io) revert Maven to 3.8.4

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -223,11 +223,11 @@ profile::buildmaster::agents_setup:
     tempDir: '/tmp'
 profile::buildmaster::agent_images:
   ec2_amis:
-    ubuntu-amd64: "ami-0a34eb36a82073cfa"
-    windows-amd64: "ami-0ee9ee571c6c7f090"
-    ubuntu-arm64: "ami-0b59d2201f429d9eb"
+    ubuntu-amd64: "ami-0a11509f4a702d787"
+    windows-amd64: "ami-0f2792367a1687a81"
+    ubuntu-arm64: "ami-05e14994806ee6819"
   azure_vms_gallery_image:
-    version: 0.16.0
+    version: 0.15.1
     subscription_id: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAluBQmOHo1MWoOCMVOCcgVUs9gOzFVEZMT7RA3V33KeolyRKh0lm5Ta5+C9aKJe9myuVGaDQsd99XsW40d7NdygJcnBxUV+VTnnLphjplPtCX5JIS4ww/S8JGOpOIE2zejy5bL2CpnZhgSFh+aD1FLD91ozNS5lgNOq9hNKqo+mSfUnX5wrUFvlCaadTWp3yxG7l7VluxP1Wh4BlsRmphmbUmmgFo56CjDUVz9dMwxT/p/uE1S/SPuEirJOAPtPCl7x2NQWg+Qlv5j1tC5ASgh9beD3SjUVPd6VYM+K+u07aw8jOj/meARXgghtUPgqHqWC44JGHPzWkZ4dQFhe6jyzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDc6VPQnQTEmwF9aAh/uK9IgDDXAM9S6QNxRH8cFSOAESeqOlLFBKVAlJc3Mnby3Pc/6H21BsehZbQLUd+1MfcoPI0=]
   container_images:
     jnlp-maven-8-windows: jenkins/jnlp-agent-maven:windows-nanoserver

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -251,7 +251,7 @@ profile::buildmaster::default_tools:
     sourceURL: https://github.com/adoptium/temurin17-binaries/releases/download
   maven:
     mvn:
-      version: "3.8.5"
+      version: "3.8.4"
   groovy:
     groovy: # Default version is named "groovy"
       version: "2.4.7"


### PR DESCRIPTION
This PR works closes https://github.com/jenkins-infra/helpdesk/issues/2835

- Reverts jenkins-infra/jenkins-infra#2101
- Reverts jenkins-infra/jenkins-infra#2096