### PR TITLE
chore(updatecli weekly): revert order for sorting AWS/AMI by most recent first

### DIFF
--- a/updatecli/weekly.d/buildmaster-agents.yaml
+++ b/updatecli/weekly.d/buildmaster-agents.yaml
@@ -68,7 +68,7 @@ sources:
       - packerImageVersion
     spec:
       region: us-east-2
-      sortBy: creationDateAsc
+      sortBy: creationDateDesc
       filters:
         - name: "name"
           values: "jenkins-agent-ubuntu-20-amd64-*"
@@ -82,7 +82,7 @@ sources:
       - packerImageVersion
     spec:
       region: us-east-2
-      sortBy: creationDateAsc
+      sortBy: creationDateDesc
       filters:
         - name: "name"
           values: "jenkins-agent-windows-2019-amd64-*"
@@ -96,7 +96,7 @@ sources:
       - packerImageVersion
     spec:
       region: us-east-2
-      sortBy: creationDateAsc
+      sortBy: creationDateDesc
       filters:
         - name: "name"
           values: "jenkins-agent-ubuntu-20-arm64-*"


### PR DESCRIPTION
This PR closes #2098 and revert the sorting order for the AWS AMI used as source within updatecli.
 