### PR TITLE
Print flags specified on command line or set by ergonomics

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -160,6 +160,9 @@ jenkins:
         - containers:
           - alwaysPullImage: false
             image: "<%= @agent_images["container_images"][agent["name"]] %>"
+            env:
+            - name: "JENKINS_JAVA_OPTS"
+              value: "-XX:+PrintCommandLineFlags"
             livenessProbe:
               failureThreshold: 0
               initialDelaySeconds: 0


### PR DESCRIPTION
My goal is to get a complete understanding of the minimum and maximum heap sizes for all JVMs that are launched in our test containers for core, BOM, and plugin CI builds. This will allow me to accurately measure our consumption of memory and compare that to the available memory in those containers. Right now, I have an observability gap because I do not know how much heap is being used by the inbound agent JVM. We do not specify an explicit flag, so this must be determined by Java ergonomics, and I have no visibility into what Java ergonomics is choosing. This PR seeks to close that visibility gap.

See [this file](https://github.com/jenkinsci/docker-inbound-agent/blob/63c0008358e77507f367a9ec45dce9ed6d246e21/jenkins-agent) for how this information is used. I am assuming this information will show up in the agent logs when the agent is launched. I don't have access to that on ci.jenkins.io, but I assume I can ask someone to read it to me once this is deployed.

I am also working in parallel to print the same observability information for the main Maven JVM and agent JVMs launched by tests. Unfortunately I have not been able to find a way to make Surefire log the same information, but at least in core builds we use Surefire with an explicit heap size.

Once I have the data for all JVMs, I will assess the consumption of our builds and whether it is appropriate for the size of the containers we have. I suspect that we are close to the limit, which is one of my theories for why we are seeing lots of instability in core builds. But to confirm or deny this theory I need the data.