### PR TITLE
feat(ci.jenkins.io,trusted.ci.jenkins.io) ensure that pipeline shared library are not cached when on a Pull Request branch

### DIFF
--- a/dist/profile/templates/buildmaster/casc/global-libraries.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/global-libraries.yaml.erb
@@ -6,6 +6,9 @@ unclassified:
         includeInChangesets: false
         name: "pipeline-library"
         cachingConfiguration:
+          ## Exclude pull request git reference to allow end to end testing when using annotation
+          # such as '@Library('pipeline-library@pull/333/head') _'
+          excludedVersionsStr: "pull/"
           refreshTimeMinutes: 180
         retriever:
           modernSCM:


### PR DESCRIPTION
While testing https://github.com/jenkins-infra/pipeline-library/pull/333, we wasted some time before realizing that pipeline-library are cached on ci.jenkins.io.

This change ensures that the cache is ignored for the git references which name follows the pattern `pull/*` too allow using annotations such `@Library('pipeline-library@pull/333/head') _` to end-to-end test  pull requests.