### PR TITLE
Add SSH public key to the `azure.ci.jenkins.io` machine

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -1,4 +1,10 @@
 accounts:
+  basil:
+    ssh_keys:
+      basil:
+        key: AAAAB3NzaC1yc2EAAAADAQABAAACAQCkR0yiRuFiY82o1IUyglIFAGLlkqXfuIv/zGU8x/BWvjHBUetM4LLdVTT21lagee85wSKEPEhwBHd0NpSKZQj/iXlhHt5IQQAt0ZKuJYNHtbIUXPEue4bpHssn58tNsbtIvgEKoLkbqkjRbSTceT9yB8FLS9fYleFtwxera/1S7L8U0if9idfCibJhmxI91K+lKT+PMvQ3SS/9KGlOae0t9UfN+TT2YKLWa74Pi4QYrATDny3F8+ad4xeW6Tzour9yVWEXbXab1u7yXZcBwpQpCPMc9xSuP8/gomRum5Cw2M1dKSGi7UX7K03hWPr7F68zIQ8CkD/NZyJDj9R4QxTEDRINYpAznig8GRklbECvBLE5nenQ7hT6vTv7cWf0JBotrpoGOJHcK2vcEjDPu9nhtsB+sZp/BvTiFLvZSmNDgkrNOHRZaI5dbREkgBJrYYsFnfJNf7/+6BrbKpBa4rRHl7OfYnlLrcw7xWR8XZeKA8y80521oPpm7XMDij/yNbAqxWpxJfukbHIM7ouUo2mV+FsuSpkDh8w9ab5F4HkJs3jlMRtrYy0IV0HKPFZ57ILGUpHTdod1rwvUnF7/MeX3I2lqS56YbzCYpnhBsJ41Hai07V7GVa7cFaRUNWgHRtu2GN/rg7RaFFdCBRSxY6B2qyyJEWt7mNj5mXSm37JO8Q
+    groups:
+      - sudo
   wfollonier:
     ssh_keys:
       wfollonier:


### PR DESCRIPTION
I would like SSH access to `ci.jenkins.io` to help in diagnosing issues causing outages or performance problems.