### PR TITLE
[ci.jenkins.io, trusted.ci.jenkins.io,cert-ci.jenkins.io] EOL `agent-security.groovy`

### DIFF
--- a/dist/profile/files/buildmaster/agent-security.groovy
+++ b/dist/profile/files/buildmaster/agent-security.groovy
@@ -1,8 +1,0 @@
-#!/usr/bin/env groovy
-import jenkins.model.*
-import org.kohsuke.stapler.StaplerProxy
-import jenkins.security.s2m.AdminWhitelistRule
-
-/* INFRA-659: enforce  Agent -> Master Access control */
-// TODO Remove once we're on 2.326+
-Jenkins.instance.getExtensionList(StaplerProxy).get(AdminWhitelistRule).masterKillSwitch = false

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -29,7 +29,6 @@ class profile::buildmaster(
   $groovy_init_enabled             = false,
   $groovy_d_enable_ssh_port        = 'absent',
   $groovy_d_set_up_git             = 'absent',
-  $groovy_d_agent_security         = 'absent',
   $groovy_d_pipeline_configuration = 'absent',
   $groovy_d_lock_down_jenkins      = 'absent',
   $groovy_d_terraform_credentials  = 'absent',
@@ -165,19 +164,6 @@ class profile::buildmaster(
       owner   => 'jenkins',
       group   => 'jenkins',
       source  => "puppet:///modules/${module_name}/buildmaster/set-up-git.groovy",
-      require => [
-          User['jenkins'],
-          File[$groovy_d],
-      ],
-      before  => Docker::Run[$docker_container_name],
-      notify  => Service['docker-jenkins'],
-    }
-
-    file { "${groovy_d}/agent-security.groovy":
-      ensure  => $groovy_d_agent_security,
-      owner   => 'jenkins',
-      group   => 'jenkins',
-      source  => "puppet:///modules/${module_name}/buildmaster/agent-security.groovy",
       require => [
           User['jenkins'],
           File[$groovy_d],

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -27,7 +27,6 @@ profile::buildmaster::letsencrypt: true
 profile::buildmaster::docker_image: 'jenkins/jenkins'
 profile::buildmaster::docker_tag: 'lts-jdk11'
 profile::buildmaster::groovy_init_enabled: true
-profile::buildmaster::groovy_d_agent_security: 'present'
 profile::buildmaster::groovy_d_enable_ssh_port: 'present'
 profile::buildmaster::groovy_d_lock_down_jenkins: 'present'
 profile::buildmaster::groovy_d_pipeline_configuration: 'present'

--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -16,7 +16,6 @@ profile::buildmaster::admin_ldap_groups:
   - trusted-admins
 profile::buildmaster::letsencrypt: false
 profile::buildmaster::groovy_init_enabled: true
-profile::buildmaster::groovy_d_agent_security: 'present'
 profile::buildmaster::groovy_d_enable_ssh_port: 'present'
 profile::buildmaster::groovy_d_lock_down_jenkins: 'present'
 profile::buildmaster::groovy_d_pipeline_configuration: 'present'

--- a/spec/classes/profile/buildmaster_spec.rb
+++ b/spec/classes/profile/buildmaster_spec.rb
@@ -43,7 +43,6 @@ describe 'profile::buildmaster' do
       context "By default: Init Groovy directory" do
         it { is_expected.not_to contain_file('/var/lib/jenkins/init.groovy.d/enable-ssh-port.groovy')}
         it { is_expected.not_to contain_file('/var/lib/jenkins/init.groovy.d/set-up-git.groovy')}
-        it { is_expected.not_to contain_file('/var/lib/jenkins/init.groovy.d/agent-security.groovy')}
         it { is_expected.not_to contain_file('/var/lib/jenkins/init.groovy.d/terraform-credentials.groovy')}
         it { is_expected.not_to contain_file('/var/lib/jenkins/init.groovy.d/pipeline-configuration.groovy')}
       end


### PR DESCRIPTION
### Problem

Observed during the last restart of `ci.jenkins.io`:

```
2022-05-02 21:32:23.266+0000 [id=42]    WARNING j.util.groovy.GroovyHookScript#execute: Failed to run script file:/var/jenkins_home/init.groovy.d/agent-security.groovy
java.lang.NullPointerException: Cannot set property 'masterKillSwitch' on null object
        at org.codehaus.groovy.runtime.NullObject.setProperty(NullObject.java:80)
        at org.codehaus.groovy.runtime.InvokerHelper.setProperty(InvokerHelper.java:213)
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.setProperty(ScriptBytecodeAdapter.java:497)
        at agent-security.run(agent-security.groovy:8)
        at groovy.lang.GroovyShell.evaluate(GroovyShell.java:574)
        at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:136)
        at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:126)
        at jenkins.util.groovy.GroovyHookScript.run(GroovyHookScript.java:109)
        at hudson.init.impl.GroovyInitScript.init(GroovyInitScript.java:42)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:109)
        at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:185)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
        at jenkins.model.Jenkins$5.runTask(Jenkins.java:1156)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:222)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:121)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

### Evaluation

This was necessary prior to jenkinsci/jenkins#5885, but as the comments state, this is no longer necessary:

```
// TODO Remove once we're on 2.326+
```

### Solution

Remove the unneeded code.

### Testing done

Failed to find any references to this code:

```
$ git ls-files | grep -i agent.security                          
$ git grep -i agent.security
$
```