### PR TITLE
Fix incorrect import

### DIFF
--- a/dist/profile/files/buildmaster/pipeline-configuration.groovy
+++ b/dist/profile/files/buildmaster/pipeline-configuration.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-import org.jenkinsci.plugins.pipeline.modeldefinition.config.GlobalConfig
+import org.jenkinsci.plugins.docker.workflow.declarative.GlobalConfig
 
 /* Set the default Docker label for Declarative Pipeline to .. wait for it ..
  * docker


### PR DESCRIPTION
### Problem

Observed during the most recent restart of `ci.jenkins.io`:

```
2022-05-02 21:32:44.363+0000 [id=42]    WARNING j.util.groovy.GroovyHookScript#execute: Failed to run script file:/var/jenkins_home/init.groovy.d/pipeline-configuration.groovy
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
/var/jenkins_home/init.groovy.d/pipeline-configuration.groovy: 3: unable to resolve class org.jenkinsci.plugins.pipeline.modeldefinition.config.GlobalConfig
 @ line 3, column 1.
   import org.jenkinsci.plugins.pipeline.modeldefinition.config.GlobalConfig
   ^

1 error

        at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:309)
        at org.codehaus.groovy.control.CompilationUnit.applyToSourceUnits(CompilationUnit.java:981)
        at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:626)
        at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:575)
        at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:323)
        at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:293)
        at groovy.lang.GroovyShell.parseClass(GroovyShell.java:677)
        at groovy.lang.GroovyShell.parse(GroovyShell.java:689)
        at groovy.lang.GroovyShell.evaluate(GroovyShell.java:573)
        at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:136)
        at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:126)
        at jenkins.util.groovy.GroovyHookScript.run(GroovyHookScript.java:109)
        at hudson.init.impl.GroovyInitScript.init(GroovyInitScript.java:42)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:109)
        at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:185)
        at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
        at jenkins.model.Jenkins$5.runTask(Jenkins.java:1156)
        at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:222)
        at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:121)
        at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

### Evaluation

This class was renamed when this code was moved to the `docker-workflow` plugin, but we continue referring to the original name.

### Solution

Use the correct name.

### Testing done

I ran the old script in the Script Console on my local Jenkins system and reproduced the failure. With the changes from this PR, the same failure cannot be reproduced any longer.