### PR TITLE
Revert "feat(ci.jenkins.io,trusted.ci.jenkins.io) ensure that pipeline shared library are not cached when on a Pull Request branch"

### DIFF
--- a/dist/profile/templates/buildmaster/casc/global-libraries.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/global-libraries.yaml.erb
@@ -6,9 +6,6 @@ unclassified:
         includeInChangesets: false
         name: "pipeline-library"
         cachingConfiguration:
-          ## Exclude pull request git reference to allow end to end testing when using annotation
-          # such as '@Library('pipeline-library@pull/333/head') _'
-          excludedVersionsStr: "pull/"
           refreshTimeMinutes: 180
         retriever:
           modernSCM:


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2142 since https://github.com/jenkins-infra/pipeline-library/pull/333 is finished, and to check if not the/a cause of https://github.com/jenkins-infra/helpdesk/issues/2908

