### PR TITLE
cleanup(ci.jenkins.io,trusted.ci.jenkins.io) remove declarative pipeline docker configuration groovy

### DIFF
--- a/dist/profile/files/buildmaster/pipeline-configuration.groovy
+++ b/dist/profile/files/buildmaster/pipeline-configuration.groovy
@@ -1,9 +1,0 @@
-#!/usr/bin/env groovy
-
-import org.jenkinsci.plugins.docker.workflow.declarative.GlobalConfig
-
-/* Set the default Docker label for Declarative Pipeline to .. wait for it ..
- * docker
- */
-GlobalConfig c = GlobalConfiguration.all().find { it instanceof GlobalConfig }
-c?.dockerLabel = 'docker'

--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -29,7 +29,6 @@ class profile::buildmaster(
   $groovy_init_enabled             = false,
   $groovy_d_enable_ssh_port        = 'absent',
   $groovy_d_set_up_git             = 'absent',
-  $groovy_d_pipeline_configuration = 'absent',
   $groovy_d_lock_down_jenkins      = 'absent',
   $jcasc                           = {},
   $cloud_agents                    = {},
@@ -163,19 +162,6 @@ class profile::buildmaster(
       owner   => 'jenkins',
       group   => 'jenkins',
       source  => "puppet:///modules/${module_name}/buildmaster/set-up-git.groovy",
-      require => [
-          User['jenkins'],
-          File[$groovy_d],
-      ],
-      before  => Docker::Run[$docker_container_name],
-      notify  => Service['docker-jenkins'],
-    }
-
-    file { "${groovy_d}/pipeline-configuration.groovy":
-      ensure  => $groovy_d_pipeline_configuration,
-      owner   => 'jenkins',
-      group   => 'jenkins',
-      source  => "puppet:///modules/${module_name}/buildmaster/pipeline-configuration.groovy",
       require => [
           User['jenkins'],
           File[$groovy_d],

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -29,7 +29,6 @@ profile::buildmaster::docker_tag: 'lts-jdk11'
 profile::buildmaster::groovy_init_enabled: true
 profile::buildmaster::groovy_d_enable_ssh_port: 'present'
 profile::buildmaster::groovy_d_lock_down_jenkins: 'present'
-profile::buildmaster::groovy_d_pipeline_configuration: 'present'
 profile::buildmaster::groovy_d_set_up_git: 'present'
 profile::buildmaster::memory_limit: '30g'
 profile::buildmaster::jcasc:

--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -18,7 +18,6 @@ profile::buildmaster::letsencrypt: false
 profile::buildmaster::groovy_init_enabled: true
 profile::buildmaster::groovy_d_enable_ssh_port: "present"
 profile::buildmaster::groovy_d_lock_down_jenkins: "present"
-profile::buildmaster::groovy_d_pipeline_configuration: "present"
 profile::buildmaster::groovy_d_set_up_git: "present"
 profile::buildmaster::memory_limit: "7g"
 profile::buildmaster::jcasc:

--- a/spec/classes/profile/buildmaster_spec.rb
+++ b/spec/classes/profile/buildmaster_spec.rb
@@ -43,7 +43,6 @@ describe 'profile::buildmaster' do
       context "By default: Init Groovy directory" do
         it { is_expected.not_to contain_file('/var/lib/jenkins/init.groovy.d/enable-ssh-port.groovy')}
         it { is_expected.not_to contain_file('/var/lib/jenkins/init.groovy.d/set-up-git.groovy')}
-        it { is_expected.not_to contain_file('/var/lib/jenkins/init.groovy.d/pipeline-configuration.groovy')}
       end
     end
 


### PR DESCRIPTION
Follow up of #2148, #2149 and #2151, to help on diagnosins ci.jenkins.io (https://github.com/jenkins-infra/helpdesk/issues/2908).

This PR fixes the error message (in controller logs) below:

```
2022-05-04 10:32:47.657+0000 [id=29]	WARNING	j.util.groovy.GroovyHookScript#execute: Failed to run script file:/var/jenkins_home/init.groovy.d/pipeline-configuration.groovy
groovy.lang.MissingPropertyException: No such property: GlobalConfiguration for class: pipeline-configuration
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:66)
	at org.codehaus.groovy.runtime.callsite.PogoGetPropertySite.getProperty(PogoGetPropertySite.java:51)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGroovyObjectGetProperty(AbstractCallSite.java:310)
	at pipeline-configuration.run(pipeline-configuration.groovy:8)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:574)
	at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:136)
	at jenkins.util.groovy.GroovyHookScript.execute(GroovyHookScript.java:126)
	at jenkins.util.groovy.GroovyHookScript.run(GroovyHookScript.java:109)
	at hudson.init.impl.GroovyInitScript.init(GroovyInitScript.java:42)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:109)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:185)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1156)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:222)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:121)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

- This setting is currently set to its default since.... at least 18 months 

<img width="1393" alt="Capture d’écran 2022-05-04 à 15 39 25" src="https://user-images.githubusercontent.com/1522731/166694002-1e6cf4f6-dd0b-4f5e-bbbf-ee17f395d3a2.png">

- Using the label `docker` alone is confusing for the agent sleection, since we have Linux ARM64 and Windows AMD64 machines, along  with Linux AM64

- Such setting, if required, should be defined by JCasc.

Please note that the file terraform-credentials.groovy must be manually deleted on the VMs once the change is applied.