### PR TITLE
Revert "feat(ci.jenkins.io default url): switch from blueocean to default url"

### DIFF
--- a/dist/profile/manifests/buildmaster.pp
+++ b/dist/profile/manifests/buildmaster.pp
@@ -47,7 +47,6 @@ class profile::buildmaster(
 -Duser.home=${container_jenkins_home} \
 -Djenkins.install.runSetupWizard=false \
 -Djenkins.model.Jenkins.slaveAgentPort=50000 \
--Djenkins.displayurl.provider=org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider \
 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2", # Must be Java 11 compliant!
 ) {
   include ::stdlib


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2143.

As per the comment in https://github.com/jenkins-infra/helpdesk/issues/2833#issuecomment-1120933932, it seems that there is a problem with the display-api: the links generated on GitHub checks by ci.jenkins.io does not uses the `/redirects` endpoint.

There are multiple source of failure in this stack (bug in display url, misconfiguration of GitHub on the jobs, etc.) so as suggested by @KalleOlaviNiemitalo and @timja , we are reverting the previous behavior to ensure that GitHub links are kep with the `/redirect` (to be considered as always valid, and to allow chanign per user preference).