### PR TITLE
chore(updatecli) fix manifests warnings and errors for updatecli 0.25.0

### DIFF
--- a/updatecli/weekly.d/buildmaster-agents.yaml
+++ b/updatecli/weekly.d/buildmaster-agents.yaml
@@ -14,50 +14,50 @@ scms:
 
 sources:
   packerImageVersion:
-    kind: githubRelease
+    kind: githubrelease
     spec:
       owner: "jenkins-infra"
       repository: "packer-images"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
   getLatestInboundRubyContainerImage:
-    kind: dockerDigest
+    kind: dockerdigest
     spec:
       image: "jenkinsciinfra/inbound-agent-ruby"
       tag: "latest"
       architecture: amd64
   getLatestInboundMaven8ContainerImage:
-    kind: dockerDigest
+    kind: dockerdigest
     spec:
       image: "jenkinsciinfra/inbound-agent-maven"
       tag: "jdk8"
       architecture: amd64
   getLatestInboundMaven11ContainerImage:
-    kind: dockerDigest
+    kind: dockerdigest
     spec:
       image: "jenkinsciinfra/inbound-agent-maven"
       tag: "jdk11"
       architecture: amd64
   getLatestInboundMaven17ContainerImage:
-    kind: dockerDigest
+    kind: dockerdigest
     spec:
       image: "jenkinsciinfra/inbound-agent-maven"
       tag: "jdk17"
       architecture: amd64
   getLatestInboundNodeContainerImage:
-    kind: dockerDigest
+    kind: dockerdigest
     spec:
       image: "jenkinsciinfra/inbound-agent-node"
       tag: "latest"
       architecture: amd64
   getLatestInboundAlpineContainerImage:
-    kind: dockerDigest
+    kind: dockerdigest
     spec:
       image: "jenkins/inbound-agent"
       tag: "alpine"
       architecture: amd64
   getLatestInboundJDK11ContainerImage:
-    kind: dockerDigest
+    kind: dockerdigest
     spec:
       image: "jenkins/inbound-agent"
       tag: "latest-jdk11"
@@ -122,7 +122,7 @@ targets:
       file: hieradata/common.yaml
       key: "profile::buildmaster::agent_images.container_images.jnlp-ruby"
     transformers:
-      - addPrefix: "jenkinsciinfra/inbound-agent-ruby@sha256:"
+      - addprefix: "jenkinsciinfra/inbound-agent-ruby@sha256:"
     scmid: default
   setInboundMaven8ContainerImage:
     sourceid: getLatestInboundMaven8ContainerImage
@@ -132,7 +132,7 @@ targets:
       file: hieradata/common.yaml
       key: "profile::buildmaster::agent_images.container_images.jnlp-maven-8"
     transformers:
-      - addPrefix: "jenkinsciinfra/inbound-agent-maven@sha256:"
+      - addprefix: "jenkinsciinfra/inbound-agent-maven@sha256:"
     scmid: default
   setInboundMaven11ContainerImage:
     sourceid: getLatestInboundMaven11ContainerImage
@@ -142,7 +142,7 @@ targets:
       file: hieradata/common.yaml
       key: "profile::buildmaster::agent_images.container_images.jnlp-maven-11"
     transformers:
-      - addPrefix: "jenkinsciinfra/inbound-agent-maven@sha256:"
+      - addprefix: "jenkinsciinfra/inbound-agent-maven@sha256:"
     scmid: default
   setInboundMaven17ContainerImage:
     sourceid: getLatestInboundMaven17ContainerImage
@@ -152,7 +152,7 @@ targets:
       file: hieradata/common.yaml
       key: "profile::buildmaster::agent_images.container_images.jnlp-maven-17"
     transformers:
-      - addPrefix: "jenkinsciinfra/inbound-agent-maven@sha256:"
+      - addprefix: "jenkinsciinfra/inbound-agent-maven@sha256:"
     scmid: default
   setInboundNodeContainerImage:
     sourceid: getLatestInboundNodeContainerImage
@@ -162,7 +162,7 @@ targets:
       file: hieradata/common.yaml
       key: "profile::buildmaster::agent_images.container_images.jnlp-node"
     transformers:
-      - addPrefix: "jenkinsciinfra/inbound-agent-node@sha256:"
+      - addprefix: "jenkinsciinfra/inbound-agent-node@sha256:"
     scmid: default
   setInboundAlpineContainerImage:
     sourceid: getLatestInboundAlpineContainerImage
@@ -172,7 +172,7 @@ targets:
       file: hieradata/common.yaml
       key: "profile::buildmaster::agent_images.container_images.jnlp-alpine"
     transformers:
-      - addPrefix: "jenkins/inbound-agent@sha256:"
+      - addprefix: "jenkins/inbound-agent@sha256:"
     scmid: default
   setInboundJDK11ContainerImage:
     sourceid: getLatestInboundJDK11ContainerImage
@@ -182,7 +182,7 @@ targets:
       file: hieradata/common.yaml
       key: "profile::buildmaster::agent_images.container_images.jnlp"
     transformers:
-      - addPrefix: "jenkins/inbound-agent@sha256:"
+      - addprefix: "jenkins/inbound-agent@sha256:"
     scmid: default
   setUbuntuAgentAMIAmd64:
     name: "Bump AMI ID for Ubuntu AMD64 agents"

--- a/updatecli/weekly.d/buildmaster-tools-jdk11.yaml
+++ b/updatecli/weekly.d/buildmaster-tools-jdk11.yaml
@@ -14,7 +14,7 @@ scms:
 
 sources:
   default:
-    kind: githubRelease
+    kind: githubrelease
     name: Get the latest Adoptium JDK11 version
     spec:
       owner: "adoptium"
@@ -26,7 +26,7 @@ sources:
         # jdk-11.0.12+7(https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.12%2B7) is OK
         pattern: "^jdk-11.(\\d*).(\\d*).(\\d*)+(\\d*)$"
     transformers:
-      - trimPrefix: "jdk-"
+      - trimprefix: "jdk-"
 
 conditions:
   checkIfReleaseIsAvailable:

--- a/updatecli/weekly.d/buildmaster-tools-jdk17.yaml
+++ b/updatecli/weekly.d/buildmaster-tools-jdk17.yaml
@@ -14,7 +14,7 @@ scms:
 
 sources:
   default:
-    kind: githubRelease
+    kind: githubrelease
     name: Get the latest Adoptium JDK17 version
     spec:
       owner: "adoptium"
@@ -26,7 +26,7 @@ sources:
         # jdk-17.0.2+8(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.2%2B8) is OK
         pattern: "^jdk-17.(\\d*).(\\d*).(\\d*)+(\\d*)$"
     transformers:
-      - trimPrefix: "jdk-"
+      - trimprefix: "jdk-"
 
 conditions:
   checkIfReleaseIsAvailable:

--- a/updatecli/weekly.d/buildmaster-tools-jdk8.yaml
+++ b/updatecli/weekly.d/buildmaster-tools-jdk8.yaml
@@ -14,7 +14,7 @@ scms:
 
 sources:
   getLatestJDK8Version:
-    kind: githubRelease
+    kind: githubrelease
     name: Get the latest Adoptium JDK8 version
     spec:
       owner: "adoptium"
@@ -26,7 +26,7 @@ sources:
         # jdk8u302-b08 is OK, but jdk8u302-b08.1 is not
         pattern: "^jdk8u(\\d*)-b(\\d*)$"
     transformers:
-      - trimPrefix: "jdk"
+      - trimprefix: "jdk"
 
 conditions:
   checkIfReleaseIsAvailable:

--- a/updatecli/weekly.d/buildmaster-tools-maven.yaml
+++ b/updatecli/weekly.d/buildmaster-tools-maven.yaml
@@ -14,7 +14,7 @@ scms:
 
 sources:
   getLatestMavenVersion:
-    kind: githubRelease
+    kind: githubrelease
     name: Get the latest Maven version
     spec:
       owner: "apache"
@@ -24,7 +24,7 @@ sources:
       versionfilter:
         kind: latest
     transformers:
-      - trimPrefix: "maven-"
+      - trimprefix: "maven-"
 
 conditions:
   checkIfReleaseIsAvailable:

--- a/updatecli/weekly.d/docker-ce.yaml
+++ b/updatecli/weekly.d/docker-ce.yaml
@@ -19,12 +19,15 @@ sources:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/docker-ce-updates.sh
+
 conditions:
   checkIfHieradataHasDockerVersionKey:
     kind: file
+    disablesourceinput: true
     spec:
       file: hieradata/common.yaml
       matchpattern: "docker::version:.*"
+
 targets:
   default:
     name: Update docker-ce version in common.yaml

--- a/updatecli/weekly.d/jenkins-lts.yaml
+++ b/updatecli/weekly.d/jenkins-lts.yaml
@@ -23,10 +23,10 @@ sources:
         username: "{{ .github.username }}"
         token: "{{ requiredEnv .github.token }}"
     transformers:
-      - addSuffix: "-jdk11"
+      - addsuffix: "-jdk11"
 
 conditions:
-  defaultCiDockerImage:
+  defaultCidockerimage:
     name: "Ensure default jenkins docker image name set to jenkins/jenkins"
     kind: yaml
     disablesourceinput: true
@@ -34,8 +34,8 @@ conditions:
       file: hieradata/common.yaml
       key: "profile::buildmaster::docker_image"
       value: "jenkins/jenkins"
-  testDockerImageExist:
-    kind: dockerImage
+  testdockerimageExist:
+    kind: dockerimage
     sourceid: jenkinsLatestLTS
     spec:
       image: "jenkins/jenkins"

--- a/updatecli/weekly.d/openvpn.yaml
+++ b/updatecli/weekly.d/openvpn.yaml
@@ -15,7 +15,7 @@ scms:
 
 sources:
   latestVersion:
-    kind: githubRelease
+    kind: githubrelease
     name: Get the latest stable docker-openvpn version
     spec:
       owner: "jenkins-infra"
@@ -26,8 +26,8 @@ sources:
         kind: semver
 
 conditions:
-  testDockerImageExist:
-    kind: dockerImage
+  testdockerimageExist:
+    kind: dockerimage
     spec:
       image: "jenkinsciinfra/openvpn"
       architecture: amd64

--- a/updatecli/weekly.d/updatecli.yaml
+++ b/updatecli/weekly.d/updatecli.yaml
@@ -15,7 +15,7 @@ scms:
 
 sources:
   latestUpdatecliVersion:
-    kind: githubRelease
+    kind: githubrelease
     name: Get the latest stable updatecli version
     spec:
       owner: "updatecli"


### PR DESCRIPTION
- Updatecli now provides a JSON schema automatically enabled on VSCode. With the recent 0.24.x and 0.25.x versions, the schema raises warnings that are fixed in this PR
- Our VMs reports that a new Docker package is available (`5:20.10.15~3-0~ubuntu-bionic`), but the updatecli job in this repository is failing to open a PR: there was an error on the manifest, caught thanks to the JSON schema. Fixed on this PR.