### PR TITLE
Fix(buildmasters) set windows vm agents disk size to 128Gb + track the value

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -37,8 +37,8 @@ jenkins:
         labels: "<%= agent["os"] %> <%= agent["architecture"] %> azure vm <%= agent["labels"].join(' ') %>"
         location: "<%= agent["location"] %>"
         noOfParallelJobs: 1
-        osDiskSize: <%= agent["osDiskSize"] ? agent["osDiskSize"] : 0 %>
-        osType: "<%= agent["os"] == "windows" ? 'Windows' : 'Linux' %>"
+        osDiskSize: <%= agent["osDiskSize"] ? agent["osDiskSize"] : @agents_setup[agent["os"].to_s]["osDiskSize"] %>
+        osType: "<%= agent["os"].to_s == "windows" ? 'Windows' : 'Linux' %>"
         preInstallSsh: false
         retentionStrategy:
           azureVMCloudRetentionStrategy:

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -199,7 +199,6 @@ profile::buildmaster::cloud_agents:
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
         subnetName: "ci.j-agents-vm"
-        osDiskSize: 90
         spot: true
       - name: "ubuntu-20-highmem"
         description: "Ubuntu 20.04 LTS Highmem"
@@ -221,7 +220,6 @@ profile::buildmaster::cloud_agents:
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
         subnetName: "ci.j-agents-vm"
-        osDiskSize: 90
         spot: true
       - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
         description: "Windows 2019"
@@ -242,7 +240,6 @@ profile::buildmaster::cloud_agents:
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
         subnetName: "ci.j-agents-vm"
-        osDiskSize: 90
         spot: true
   azure-container-agents:
     aci-windows:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -213,7 +213,7 @@ profile::buildmaster::agents_setup:
     agentDir: 'C:\\Jenkins'
     tempDir: 'C:\\\\temp'
     remoteAdmin: Administrator
-    osDiskSize: 90
+    osDiskSize: "128"
   ubuntu:
     agentDir: "/home/jenkins"
     remoteAdmin: jenkins

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -213,10 +213,12 @@ profile::buildmaster::agents_setup:
     agentDir: 'C:\\Jenkins'
     tempDir: 'C:\\\\temp'
     remoteAdmin: Administrator
+    osDiskSize: 90
   ubuntu:
     agentDir: "/home/jenkins"
     remoteAdmin: jenkins
     tempDir: "/tmp"
+    osDiskSize: 90
 profile::buildmaster::agent_images:
   ec2_amis:
     ubuntu-amd64: "ami-0b613ed394048f189"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -140,7 +140,6 @@ profile::buildmaster::cloud_agents:
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
         subnetName: "ci.j-agents-vm"
-        osDiskSize: 90
         spot: true
       - name: "ubuntu-20-highmem"
         description: "Ubuntu 20.04 LTS Highmem"
@@ -158,7 +157,6 @@ profile::buildmaster::cloud_agents:
         maxInstances: 10
         useAsMuchAsPosible: false
         usePrivateIP: false
-        osDiskSize: 90
       - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
         description: "Windows 2019"
         imageDefinition: jenkins-agent-windows-2019
@@ -173,7 +171,7 @@ profile::buildmaster::cloud_agents:
         maxInstances: 10
         useAsMuchAsPosible: true
         useEphemeralOSDisk: false
-        osDiskSize: 90
+        osDiskSize: 130 # For testing overriding at instance level in the template engine
   azure-container-agents:
     aci-windows:
       credentialsId: "azure-credentials"

--- a/updatecli/weekly.d/buildmaster-agents.yaml
+++ b/updatecli/weekly.d/buildmaster-agents.yaml
@@ -104,8 +104,27 @@ sources:
           values: "prod"
         - name: "tag:version"
           values: '{{ source "packerImageVersion" }}'
-
+  getWindowsVMAgentsDiskSize:
+    kind: file
+    depends_on:
+      - packerImageVersion
+    spec:
+      file: 'https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source `packerImageVersion` }}/locals.pkr.hcl'
+      # matchpattern can only retrieve the full line. A transformer is required after to strip the unused content
+      matchpattern: 'windows_disk_size_gb = (.*)'
+    transformers:
+      ## Retrieve only the integer (ignore whitespaces, comments, etc.)
+      - findsubmatch:
+          pattern: 'windows_disk_size_gb = (\d*)'
+          captureindex: 1
 targets:
+  setWindowsVMAgentDiskSize:
+    sourceid: getWindowsVMAgentsDiskSize
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::buildmaster::agents_setup.windows.osDiskSize"
+    scmid: default
   setAzureGalleryImageVersion:
     sourceid: packerImageVersion
     name: "Bump Azure Gallery Image Version"


### PR DESCRIPTION
This PR fixes https://github.com/jenkins-infra/helpdesk/issues/2949.

It introduces the following changes:

- feat(buildmaster) define Jenkins VM agent disk size globally (e.g. in `hieradata/common.yaml`) but keep the per-template override (to opt-out from global value is required in edge cases
- fix(buildmaster) set disk size to 128Gb globally for Windows VM agents
- [chore(updatecli) track windows VM agent disk size for buildmasters, so future changes in packer will be easier to update, or at least detect (because updatecli process will fail)

Please note tha the updatecli diff will fail on this PR because https://github.com/jenkins-infra/jenkins-infra/commit/d389b7388ff666065f7ec898668bb82665af6ce4 is not applied to the PR target branch yet.