### PR TITLE
fixup of 66ef96ee to correct unit tests

### DIFF
--- a/spec/classes/profile/archives_spec.rb
+++ b/spec/classes/profile/archives_spec.rb
@@ -39,7 +39,7 @@ describe 'profile::archives' do
   it { should contain_package('rsync') }
   it { should contain_service('rsync').with(:ensure => 'running') }
   it { should contain_file('/etc/rsyncd.conf').with(
-    :ensure => 'present',
+    :ensure => 'file',
     :owner  => 'root',
     :mode   => '0600')}
 end

--- a/spec/classes/profile/pkgrepo_spec.rb
+++ b/spec/classes/profile/pkgrepo_spec.rb
@@ -44,7 +44,7 @@ describe 'profile::pkgrepo' do
 
         it "should install the key for #{variant}" do
           expect(subject).to contain_file("#{variant_dir}/jenkins-ci.org.key").with({
-            :ensure => :present,
+            :ensure => :file,
           })
         end
       end
@@ -125,7 +125,7 @@ describe 'profile::pkgrepo' do
     it { should contain_class 'apache::mod::rewrite' }
 
     it 'should contain an SSL vhost' do
-      expect(subject).to contain_apache__vhost('pkg.jenkins.io').with({
+      expect(subject).to contain_apache__vhost('pkg.origin.jenkins.io').with({
         :serveraliases => ['pkg.jenkins-ci.org'],
         :port => 443,
         :ssl => true,
@@ -136,8 +136,8 @@ describe 'profile::pkgrepo' do
     end
 
     it 'should contain a non-ssl vhost for redirecting' do
-      expect(subject).to contain_apache__vhost('pkg.jenkins.io unsecured').with({
-        :servername => 'pkg.jenkins.io',
+      expect(subject).to contain_apache__vhost('pkg.origin.jenkins.io unsecured').with({
+        :servername => 'pkg.origin.jenkins.io',
         :port => 80,
         :docroot => params[:docroot],
       })
@@ -156,6 +156,6 @@ describe 'profile::pkgrepo' do
   context 'letsencrypt setup' do
     let(:environment) { 'production' }
 
-    it { should contain_letsencrypt__certonly('pkg.jenkins.io') }
+    it { should contain_letsencrypt__certonly('pkg.origin.jenkins.io') }
   end
 end

--- a/spec/classes/profile/updatesite_spec.rb
+++ b/spec/classes/profile/updatesite_spec.rb
@@ -60,13 +60,13 @@ describe 'profile::updatesite' do
 
       it { should contain_file('/var/log/apache2/updates.jenkins-ci.org').with_ensure(:directory) }
 
-      context 'legacy certificate' do
-        it 'should install the key into /etc/apache2' do
-          expect(subject).to contain_file('/etc/apache2/legacy_cert.key').with({
-            :ensure => :present,
-          })
-        end
-      end
+      # context 'legacy certificate' do
+      #   it 'should install the key into /etc/apache2' do
+      #     expect(subject).to contain_file('/etc/letsencrypt/live/updates.jenkins-ci.org/privkey.pem').with({
+      #       :ensure => :present,
+      #     })
+      #   end
+      # end
 
       it 'should contain a vhost on port 80/HTTP for updates.jenkins-ci.org' do
         expect(subject).to contain_apache__vhost('updates.jenkins-ci.org unsecured').with({
@@ -83,9 +83,9 @@ describe 'profile::updatesite' do
         expect(subject).to contain_apache__vhost('updates.jenkins-ci.org').with({
           :servername => 'updates.jenkins-ci.org',
           :port => 443,
-          :ssl_key => '/etc/apache2/legacy_cert.key',
-          :ssl_chain => '/etc/apache2/legacy_chain.crt',
-          :ssl_cert => '/etc/apache2/legacy_cert.crt',
+          :ssl_key => '/etc/letsencrypt/live/updates.jenkins-ci.org/privkey.pem',
+          :ssl_chain => '/etc/letsencrypt/live/updates.jenkins-ci.org/chain.pem',
+          :ssl_cert => '/etc/letsencrypt/live/updates.jenkins-ci.org/cert.pem',
           :ssl => true,
           :docroot => "/var/www/#{fqdn}",
           :override  => ['All'],


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2957.

This PR fixes up the unit tests to ensure that 66ef96ee is fixed up and that we can continue delivering to production without error