### PR TITLE
fix(datadog) Use new APT key (changed May 2022)

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -70,7 +70,7 @@ mod 'saz/ssh', '5.0.0'
 mod 'puppetlabs-sshkeys_core', '1.0.2'
 
 mod 'puppetlabs/lvm', '0.3.2'
-mod 'datadog/datadog_agent', '3.8.0'
+mod 'datadog/datadog_agent', '3.16.0'
 
 # Used for grabbing certificates for jenkins.io
 mod 'puppet-letsencrypt', '6.0.0'


### PR DESCRIPTION
The GPG key used to sign datadog packages was rotated the 2nd of May 2022.

Ref. https://docs.datadoghq.com/agent/guide/linux-agent-2022-key-rotation/?tab=debianubuntu
