### PR TITLE
chore(updatecli) fix maven manifest to use git tags (instead of gh releases)

### DIFF
--- a/updatecli/weekly.d/buildmaster-tools-maven.yaml
+++ b/updatecli/weekly.d/buildmaster-tools-maven.yaml
@@ -11,16 +11,18 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       branch: "{{ .github.branch }}"
+  mavenGitHubMirror:
+    kind: git
+    spec:
+      url: "https://github.com/apache/maven.git"
+      branch: master
 
 sources:
   getLatestMavenVersion:
-    kind: githubrelease
+    kind: gittag
     name: Get the latest Maven version
+    scmid: mavenGitHubMirror
     spec:
-      owner: "apache"
-      repository: "maven"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
       versionfilter:
         kind: latest
     transformers:


### PR DESCRIPTION
Closes #2214 .

This PR changes the updatecli manifest for Maven.

We used an updatecli source of kind githubrelease, which behaves by checking releases, and if none is found then it falls back to git tags.

When we created the Maven manifest, the repository https://github.com/apache/maven.git (which is a mirror of the original git repo of maven) used to only have tags.

Sounds like that since Maven 3.8.4, there hapen to have GitHub release... sometimes: https://github.com/apache/maven/releases.

So the change here is to switch to the git tags: 3.8.6 is now used as expected.


Need to be translated to the repositories jenkins-infra/packer-images and jenkins-infra/docker-inbound-agents