### PR TITLE
chore: switch vagrant to Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ catalog on a VM.
 ##### Pre-requisites for Vagrant
 
 * Install [Vagrant](https://www.vagrantup.com)
-* Install Vagrant plugins: `vagrant plugin install vagrant-serverspec`
+<!-- * Install Vagrant plugins: `vagrant plugin install vagrant-serverspec` -->
 * Run the `./vagrant-bootstrap` script locally to make sure your local
   environment is prepared for Vagranting
 
 To launch a test instance, `vagrant up ROLE` where `ROLE` is [one of the defined roles](dist/role/manifests).
 You can rerun puppet and execute tests with `vagrant provision ROLE` repeatedly while the VM is up and running.
-To just rerun serverspect without puppet, `vagrant provision --provision-with serverspec ROLE`.
-When it's all done, deprovision the instance via `vagrant destroy ROLE`.
+<!-- To just rerun serverspect without puppet, `vagrant provision --provision-with serverspec ROLE`.
+When it's all done, deprovision the instance via `vagrant destroy ROLE`. -->
 
 ### Updating dependencies
 

--- a/README.md
+++ b/README.md
@@ -50,26 +50,49 @@ The amount of testing that can be done locally is as follows:
   the rspec-puppet over and over, use `rake spec_standalone` to avoid
   re-initializing the Puppet module fixtures every time.
 
+### Pre-requisites for local development
+
+* Ruby 2.6.x is required.
+  * Please note that Ruby 2.7.x and 3.x have never been tested.
+* Bundler 1.17.x is required with the command line `bundle` installed and present in your `PATH`.
+  * Please note that Bundler 2.x had never been tested
+* A bash-compliant shell is required.
+  * `sh` has never been tested, neither Windows Cygwin Shell (but WSL is ok).
+
+You can **always** check the Docker image that ci.jenkins.io uses to run the test harness for this project at <https://github.com/jenkins-infra/docker-inbound-agents/blob/main/ruby/Dockerfile> (Jenkins agent labelled with `ruby`).
+
 ### Vagrant-based testing
 
-#### Running server spec tests
+#### Running Acceptance Tests
 
-We're using [serverspec](http://serverspec.org) for on-machine acceptance
-testing. Combined with Vagrant, this allows us to create an acceptance test
-[per-role](dist/role/manifests) which provisions and tests an entire Puppet
-catalog on a VM.
+TL;DR: As for today, there are no automated acceptance tests. Contributions are welcome.
+
+A long time ago, this repository used [serverspec](http://serverspec.org) for on-machine acceptance testing.
+Combined with Vagrant, it allowed to execute acceptance tests [per-role](dist/role/manifests).
+
+But this serverspec with Vagrant uses deprecated (and not maintained anymore) components.
+
+Proposal for the future:
+
+* Switch to [Goss](https://github.com/aelsabbahy/goss) as it can also be used for [Docker with the `dgoss` wrapper](https://github.com/aelsabbahy/goss/tree/master/extras/dgoss) and provides automatic adding tests
+* ServerSpec V2 executed through `vagrant ssh` (but requires updating ruby dependencies + find a way to run serverspec within the VM instead of outside)
 
 ##### Pre-requisites for Vagrant
 
-* Install [Vagrant](https://www.vagrantup.com)
-<!-- * Install Vagrant plugins: `vagrant plugin install vagrant-serverspec` -->
-* Run the `./vagrant-bootstrap` script locally to make sure your local
-  environment is prepared for Vagranting
+* Make sure that you have set up all the [Pre-requisites for local development](#pre-requisites-for-local-development) above
+* Install [Vagrant](https://www.vagrantup.com) version 2.x.
+* Install [Docker](https://www.docker.com/)
+  * Docker Desktop is recommended but any other Docker Engine installation should work.
+  * Only Linux containers are supported, with Cgroups v2. (CGroups v1 *might* work).
+  * The command line `docker` must be present in your `PATH`.
+  * You must be able to share a local directory and to use the flag `--privileged`.
+* Run the `./vagrant-bootstrap` script locally to make sure your local environment is prepared.
+  * Should use `bundle` to install ruby gem dependencies
+  * It also pre-builds the Docker image(s) required?
 
 To launch a test instance, `vagrant up ROLE` where `ROLE` is [one of the defined roles](dist/role/manifests).
 You can rerun puppet and execute tests with `vagrant provision ROLE` repeatedly while the VM is up and running.
-<!-- To just rerun serverspect without puppet, `vagrant provision --provision-with serverspec ROLE`.
-When it's all done, deprovision the instance via `vagrant destroy ROLE`. -->
+When it's all done, remove the instance the instance via `vagrant destroy ROLE`.
 
 ### Updating dependencies
 
@@ -80,8 +103,7 @@ reflect changes by running `bundle exec rake resolve`.
 
 ## Branching model
 
-The default branch of this repository is `staging` which is where pull requests
-should be applied to by default.
+The default branch of this repository is `production` which is where pull requests should be applied to by default.
 
 ```text
 
@@ -89,23 +111,12 @@ should be applied to by default.
 | pull-request-1 |
 +-----------x----+
              \
-              \ (review and merge, runs acceptance tests)
-staging        \
+              \ (review and merge, runs tests)
+production     \
 |---------------o--x--x--x---------------->
-                          \
-                           \ (manual merge, auto-deploys to prod hosts)
-production                  \
-|----------------------------o------------->
 ```
 
-The branching model is a little different than what you might be familiar with.
-We merge pull requests into a special branch called `staging` where we can run
-Puppet acceptance tests from. Once somebody has code reviewed a pull request it
-can be merged into `staging`.
-
-When a infra project team member is happy with the code in `staging` they can
-create a merge from `staging` to `production`. Once something has been merged
-to production, it will be automatically deployed to production hosts.
+When a infra project team member is happy with the code in your pull request, they can merge it to production, which will be automatically deployed to production hosts.
 
 ## Installing agents
 

--- a/dist/profile/manifests/apt.pp
+++ b/dist/profile/manifests/apt.pp
@@ -3,8 +3,8 @@
 # i.e. that it's updated daily
 class profile::apt {
   class { 'apt':
-  update => {
-    frequency => 'daily',
-  },
-}
+    update => {
+      frequency => 'daily',
+    },
+  }
 }

--- a/dist/profile/manifests/base.pp
+++ b/dist/profile/manifests/base.pp
@@ -1,7 +1,6 @@
 #
 # Basic profile included in each node
 class profile::base {
-
   include profile::accounts
   include profile::compliance
 
@@ -15,7 +14,10 @@ class profile::base {
     include profile::puppetagent
     include profile::rngd
 
-    include ssh::server
+    # Applying the production SSH would break the Vagrant SSH system
+    if $::vagrant != '1' {
+      include ssh::server
+    }
     include ssh::client
   }
 

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -1,7 +1,12 @@
 #
 # Profile for managing basics of docker installation/configuration
 class profile::docker {
-  class { '::docker':
+  class { 'docker':
+  }
+
+  if ($facts['os']['architecture'] == 'aarch64') {
+    # 'https://github.com/puppetlabs/puppetlabs-docker/issues/494 (even with APT module at 8.4.1)
+    Apt::Source <| architecture == 'aarch64' |> { architecture => 'arm64' }
   }
 
   include datadog_agent::integrations::docker_daemon
@@ -10,8 +15,8 @@ class profile::docker {
   user { $datadog_agent::params::dd_user:
     ensure  => present,
     groups  => ['docker'],
-    require => Class['::docker'],
-    before  => Class['datadog_agent::integrations::docker_daemon']
+    require => Class['docker'],
+    before  => Class['datadog_agent::integrations::docker_daemon'],
   }
 
   firewall { '010 allow inter-docker traffic':

--- a/updatecli/weekly.d/puppet-modules/docker.yaml
+++ b/updatecli/weekly.d/puppet-modules/docker.yaml
@@ -40,9 +40,9 @@ targets:
     spec:
       file: Puppetfile
       matchpattern: >
-        mod 'puppetlabs-docker'(.*)
+        mod 'puppetlabs/docker'(.*)
       replacepattern: >
-        mod 'puppetlabs-docker', '{{ source "latestVersion" }}'
+        mod 'puppetlabs/docker', '{{ source "latestVersion" }}'
     scmid: default
 
 pullrequests:

--- a/vagrant-bootstrap
+++ b/vagrant-bootstrap
@@ -5,3 +5,5 @@ echo "> Installing gems.."
 bundle install --path vendor/bundle
 echo "> Installing Puppet modules into modules/"
 bundle exec r10k puppetfile install
+echo "> Prebuilding the Docker image to ensure it is kept in cache (by giving a name)"
+docker build -t jenkins-infra-ubuntu:18.04 ./vagrant-docker

--- a/vagrant-bootstrap
+++ b/vagrant-bootstrap
@@ -4,4 +4,4 @@
 echo "> Installing gems.."
 bundle install --path vendor/bundle
 echo "> Installing Puppet modules into modules/"
-r10k puppetfile install
+bundle exec r10k puppetfile install

--- a/vagrant-docker/Dockerfile
+++ b/vagrant-docker/Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG="en_US.UTF-8"
+ENV LC_ALL="en_US.UTF-8"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# hadolint ignore=DL3008,SC2016
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  apt-utils \
+  build-essential \
+  curl \
+  iproute2 \
+  locales \
+  openssh-server \
+  passwd \
+  rsyslog \
+  software-properties-common \
+  sudo \
+  systemd \
+  systemd-cron \
+  wget \
+  && apt-get clean \
+  && rm -Rf /var/lib/apt/lists/* /usr/share/doc && rm -Rf /usr/share/man \
+  && sed -i 's/^\($ModLoad imklog\)/#\1/' /etc/rsyslog.conf \
+  && locale-gen en_US.UTF-8 \
+  ## Tuning to allow systemd to work in the container by removing unwanted links and files from the systemd startup hierarchy
+  && for file in /lib/systemd/system/sysinit.target.wants/*; do test "$file" == "systemd-tmpfiles-setup.service" || rm -f "$file"; done \
+  && rm -f /lib/systemd/system/multi-user.target.wants/* \
+  /etc/systemd/system/*.wants/* \
+  /lib/systemd/system/local-fs.target.wants/* \
+  /lib/systemd/system/sockets.target.wants/*udev* \
+  /lib/systemd/system/sockets.target.wants/*initctl* \
+  /lib/systemd/system/basic.target.wants/* \
+  /lib/systemd/system/anaconda.target.wants/* \
+  /run/nologin \
+  && systemctl enable ssh.service
+
+## Create the default vagrant user with the default vagrant ssh key - https://www.vagrantup.com/docs/boxes/base#defaultusersettings
+RUN useradd --create-home -s /bin/bash vagrant \
+  && echo -e "vagrant\nvagrant" | passwd vagrant \
+  && echo 'vagrant ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/vagrant \
+  && chmod 440 /etc/sudoers.d/vagrant \
+  && mkdir -p /home/vagrant/.ssh \
+  && chmod 700 /home/vagrant/.ssh \
+  # Avoids SSH errors with vagrant: disable requiretty, PAM and DNS
+  && sed -i -e 's/Defaults.*requiretty/#&/' /etc/sudoers \
+  && sed -i -e 's/\(UsePAM \)yes/\1 no/' /etc/ssh/sshd_config \
+  && sed -i -e 's/\(UseDNS \)yes/\1 no/' /etc/ssh/sshd_config
+
+# Define the vagrant insecure key as default for vagrant user
+ADD https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub /home/vagrant/.ssh/authorized_keys
+RUN chmod 600 /home/vagrant/.ssh/authorized_keys \
+  && chown -R vagrant:vagrant /home/vagrant/.ssh
+
+# /sys/fs/cgroup must be a volume to ensure cgroup hierarchy is not on the overlayfs (and should be mounted by user from the host cgroup)
+# /tmp and /run are temp. filesystem so at least a data volume outside the container
+# /var/lib/docker must be outside the overlay root filesystem
+VOLUME ["/sys/fs/cgroup", "/tmp", "/run", "/var/lib/docker"]
+
+# PID 1 must be systemd to ensure we can enable and start services, without dbus error.
+# Require privileged mode!
+CMD ["/lib/systemd/systemd"]


### PR DESCRIPTION
This PR is an attempt at moving away from virtualbox to docker as a provider to ensure an easier acceptance testing of the puppet provisioning.

The main target are macOS ARM CPUs for the first iteration, to allow team members with such a setup to be able to test their system.


Ping @smerle33 @timja if you are able to test this on your M1 machines:

```shell
# Checkout this PR locally
gh pr checkout 2235

# Bootstrap dependencies (requires `bundle` command installed and in your PATH)
./vagrant-bootstrap

# Install vagrant - https://www.vagrantup.com/downloads or "bundle install vagrant" if no option

# Try to start the pkg VM
vagrant up pkg
```