### PR TITLE
Fixup "feat(pkg): redirect pkg.jenkins-ci.org to pkg.jenkins.io"

### DIFF
--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -4,6 +4,7 @@ class profile::pkgrepo (
   $docroot      = '/var/www/pkg.jenkins.io',
   $release_root = '/srv/releases/jenkins',
   $repo_fqdn    = 'pkg.origin.jenkins.io',
+  $repo_legacy_fqdn    = 'pkg.jenkins-ci.org',
   $mirror_fqdn  = 'mirrors.jenkins.io',
 ) {
   include stdlib
@@ -22,10 +23,14 @@ class profile::pkgrepo (
     ensure => present,
   }
 
-  $apache_log_dir = "/var/log/apache2/${repo_fqdn}"
+  $apache_log_dir_fqdn = "/var/log/apache2/${repo_fqdn}"
+  $apache_log_dir_legacy_fqdn = "/var/log/apache2/${repo_legacy_fqdn}"
 
-  file { $apache_log_dir:
-    ensure => directory,
+  # Create apache dirs
+  [$apache_log_dir_fqdn,$apache_log_dir_legacy_fqdn].each |String $dir| {
+    file { $dir:
+      ensure => directory,
+    }
   }
 
   file { $docroot:
@@ -33,7 +38,7 @@ class profile::pkgrepo (
     owner   => 'www-data',
     # We need group writes on this directory for pushing a release
     mode    => '0775',
-    require => File[$apache_log_dir],
+    require => [File[$apache_log_dir_fqdn], File[$apache_log_dir_legacy_fqdn]],
   }
 
   $repos = [
@@ -99,8 +104,8 @@ class profile::pkgrepo (
     ssl             => true,
     docroot         => $docroot,
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 604800",
+    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/access.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/error.log.%Y%m%d%H%M%S 604800",
     require         => File[$docroot],
   }
 
@@ -110,8 +115,8 @@ class profile::pkgrepo (
     override        => ['All'],
     docroot         => $docroot,
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_nonssl.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_nonssl.log.%Y%m%d%H%M%S 604800",
+    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/access_nonssl.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/error_nonssl.log.%Y%m%d%H%M%S 604800",
     require         => File[$docroot],
   }
 
@@ -120,8 +125,8 @@ class profile::pkgrepo (
     port            => 80,
     docroot         => $docroot,
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_legacy_nonssl.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_legacy_nonssl.log.%Y%m%d%H%M%S 604800",
+    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/access_nonssl.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/error_nonssl.log.%Y%m%d%H%M%S 604800",
     redirect_status => 'permanent',
     redirect_dest   => ['https://pkg.jenkins.io/'],
     # Due to fastly caching on the target domain, it is required to force re-establishing TLS connection to new domain (HTTP/2 tries to reuse connection thinking it is the same server)
@@ -135,8 +140,8 @@ class profile::pkgrepo (
     docroot         => $docroot,
     ssl             => true,
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_legacy.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_legacy.log.%Y%m%d%H%M%S 604800",
+    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/access.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/error.log.%Y%m%d%H%M%S 604800",
     redirect_status => 'permanent',
     redirect_dest   => ['https://pkg.jenkins.io/'],
     # Due to fastly caching on the target domain, it is required to force re-establishing TLS connection to new domain (HTTP/2 tries to reuse connection thinking it is the same server)

--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -122,7 +122,10 @@ class profile::pkgrepo (
 
     access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_legacy_nonssl.log.%Y%m%d%H%M%S 604800",
     error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_legacy_nonssl.log.%Y%m%d%H%M%S 604800",
+    redirect_status => 'permanent',
     redirect_dest   => ['https://pkg.jenkins.io/'],
+    # Due to fastly caching on the target domain, it is required to force re-establishing TLS connection to new domain (HTTP/2 tries to reuse connection thinking it is the same server)
+    custom_fragment => 'Protocols http/1.1',
     require         => File[$docroot],
   }
 
@@ -134,7 +137,10 @@ class profile::pkgrepo (
 
     access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_legacy.log.%Y%m%d%H%M%S 604800",
     error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_legacy.log.%Y%m%d%H%M%S 604800",
+    redirect_status => 'permanent',
     redirect_dest   => ['https://pkg.jenkins.io/'],
+    # Due to fastly caching on the target domain, it is required to force re-establishing TLS connection to new domain (HTTP/2 tries to reuse connection thinking it is the same server)
+    custom_fragment => 'Protocols http/1.1',
     require         => File[$docroot],
   }
 

--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -91,9 +91,6 @@ class profile::pkgrepo (
   }
 
   apache::vhost { $repo_fqdn:
-    serveraliases   => [
-      'pkg.jenkins-ci.org',
-    ],
     port            => 443,
     # We need FollowSymLinks to ensure our fallback for old APT clients works
     # properly, see debian's htaccess file for more
@@ -115,24 +112,43 @@ class profile::pkgrepo (
 
     access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_nonssl.log.%Y%m%d%H%M%S 604800",
     error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_nonssl.log.%Y%m%d%H%M%S 604800",
+    require         => File[$docroot],
   }
 
-  apache::vhost { 'pkg.jenkins-ci.org':
+  apache::vhost { 'pkg.jenkins-ci.org unsecured':
+    servername      => 'pkg.jenkins-ci.org',
     port            => 80,
     docroot         => $docroot,
-    override        => ['All'],
-    options         => 'Indexes FollowSymLinks MultiViews',
 
     access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_legacy_nonssl.log.%Y%m%d%H%M%S 604800",
     error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_legacy_nonssl.log.%Y%m%d%H%M%S 604800",
-    require         => Apache::Vhost[$repo_fqdn],
+    redirect_dest   => ['https://pkg.jenkins.io'],
+    require         => File[$docroot],
+  }
+
+  apache::vhost { 'pkg.jenkins-ci.org':
+    servername      => 'pkg.jenkins-ci.org',
+    port            => 443,
+    docroot         => $docroot,
+    ssl             => true,
+
+    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_legacy.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_legacy.log.%Y%m%d%H%M%S 604800",
+    redirect_dest   => ['https://pkg.jenkins.io'],
+    require         => File[$docroot],
   }
 
   # We can only acquire certs in production due to the way the letsencrypt
   # challenge process works
   if (($::environment == 'production') and ($::vagrant != '1')) {
     letsencrypt::certonly { $repo_fqdn:
-      domains     => [$repo_fqdn],
+      domains     => [$repo_fqdn, 'pkg.jenkins-ci.org'],
+      plugin      => 'apache',
+      manage_cron => true,
+    }
+
+    letsencrypt::certonly { 'pkg.jenkins-ci.org':
+      domains     => ['pkg.jenkins-ci.org'],
       plugin      => 'apache',
       manage_cron => true,
     }
@@ -141,6 +157,12 @@ class profile::pkgrepo (
       ssl_key         => '/etc/letsencrypt/live/pkg.origin.jenkins.io/privkey.pem',
       ssl_cert        => '/etc/letsencrypt/live/pkg.origin.jenkins.io/cert.pem',
       ssl_chain       => '/etc/letsencrypt/live/pkg.origin.jenkins.io/chain.pem',
+    }
+
+    Apache::Vhost <| title == 'pkg.jenkins-ci.org' |> {
+      ssl_key         => '/etc/letsencrypt/live/pkg.jenkins-ci.org/privkey.pem',
+      ssl_cert        => '/etc/letsencrypt/live/pkg.jenkins-ci.org/cert.pem',
+      ssl_chain       => '/etc/letsencrypt/live/pkg.jenkins-ci.org/chain.pem',
     }
   }
 }

--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -122,7 +122,7 @@ class profile::pkgrepo (
 
     access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_legacy_nonssl.log.%Y%m%d%H%M%S 604800",
     error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_legacy_nonssl.log.%Y%m%d%H%M%S 604800",
-    redirect_dest   => ['https://pkg.jenkins.io'],
+    redirect_dest   => ['https://pkg.jenkins.io/'],
     require         => File[$docroot],
   }
 
@@ -134,7 +134,7 @@ class profile::pkgrepo (
 
     access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_legacy.log.%Y%m%d%H%M%S 604800",
     error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_legacy.log.%Y%m%d%H%M%S 604800",
-    redirect_dest   => ['https://pkg.jenkins.io'],
+    redirect_dest   => ['https://pkg.jenkins.io/'],
     require         => File[$docroot],
   }
 

--- a/spec/classes/profile/pkgrepo_spec.rb
+++ b/spec/classes/profile/pkgrepo_spec.rb
@@ -139,7 +139,7 @@ describe 'profile::pkgrepo' do
         :port => 443,
         :ssl => true,
         :docroot => params[:docroot],
-        :redirect_dest => ['https://pkg.jenkins.io'],
+        :redirect_dest => ['https://pkg.jenkins.io/'],
       })
     end
 
@@ -156,7 +156,7 @@ describe 'profile::pkgrepo' do
         :servername => 'pkg.jenkins-ci.org',
         :port => 80,
         :docroot => params[:docroot],
-        :redirect_dest => ['https://pkg.jenkins.io'],
+        :redirect_dest => ['https://pkg.jenkins.io/'],
       })
     end
   end

--- a/spec/classes/profile/pkgrepo_spec.rb
+++ b/spec/classes/profile/pkgrepo_spec.rb
@@ -124,14 +124,22 @@ describe 'profile::pkgrepo' do
   context 'apache setup' do
     it { should contain_class 'apache::mod::rewrite' }
 
-    it 'should contain an SSL vhost' do
+    it 'should contain an SSL vhost for pkg.origin.jenkins.io' do
       expect(subject).to contain_apache__vhost('pkg.origin.jenkins.io').with({
-        :serveraliases => ['pkg.jenkins-ci.org'],
         :port => 443,
         :ssl => true,
         :docroot => params[:docroot],
         :options => 'Indexes FollowSymLinks MultiViews',
         :override => ['All'],
+      })
+    end
+
+    it 'should contain an SSL vhost for pkg.jenkins-ci.org with redirection' do
+      expect(subject).to contain_apache__vhost('pkg.jenkins-ci.org').with({
+        :port => 443,
+        :ssl => true,
+        :docroot => params[:docroot],
+        :redirect_dest => ['https://pkg.jenkins.io'],
       })
     end
 
@@ -144,11 +152,11 @@ describe 'profile::pkgrepo' do
     end
 
     it "should contain a non-ssl pkg.jenkins-ci.org vhost which doesn't upgrade" do
-      expect(subject).to contain_apache__vhost('pkg.jenkins-ci.org').with({
+      expect(subject).to contain_apache__vhost('pkg.jenkins-ci.org unsecured').with({
+        :servername => 'pkg.jenkins-ci.org',
         :port => 80,
-        :options => 'Indexes FollowSymLinks MultiViews',
-        :override => ['All'],
         :docroot => params[:docroot],
+        :redirect_dest => ['https://pkg.jenkins.io'],
       })
     end
   end
@@ -157,5 +165,6 @@ describe 'profile::pkgrepo' do
     let(:environment) { 'production' }
 
     it { should contain_letsencrypt__certonly('pkg.origin.jenkins.io') }
+    it { should contain_letsencrypt__certonly('pkg.jenkins-ci.org') }
   end
 end

--- a/spec/classes/profile/pkgrepo_spec.rb
+++ b/spec/classes/profile/pkgrepo_spec.rb
@@ -139,7 +139,9 @@ describe 'profile::pkgrepo' do
         :port => 443,
         :ssl => true,
         :docroot => params[:docroot],
+        :redirect_status => 'permanent',
         :redirect_dest => ['https://pkg.jenkins.io/'],
+        :custom_fragment => 'Protocols http/1.1',
       })
     end
 
@@ -156,7 +158,9 @@ describe 'profile::pkgrepo' do
         :servername => 'pkg.jenkins-ci.org',
         :port => 80,
         :docroot => params[:docroot],
+        :redirect_status => 'permanent',
         :redirect_dest => ['https://pkg.jenkins.io/'],
+        :custom_fragment => 'Protocols http/1.1',
       })
     end
   end

--- a/spec/classes/profile/updatesite_spec.rb
+++ b/spec/classes/profile/updatesite_spec.rb
@@ -57,7 +57,6 @@ describe 'profile::updatesite' do
         })
       end
 
-
       it { should contain_file('/var/log/apache2/updates.jenkins-ci.org').with_ensure(:directory) }
 
       it 'should contain a vhost on port 80/HTTP for updates.jenkins-ci.org' do
@@ -71,13 +70,10 @@ describe 'profile::updatesite' do
         })
       end
 
-      it 'should contain a vhost on port 443/HTTPs for updates.jenkins-ci.org' do
+      it 'should contain a vhost with ssl on port 443/HTTPs for updates.jenkins-ci.org' do
         expect(subject).to contain_apache__vhost('updates.jenkins-ci.org').with({
           :servername => 'updates.jenkins-ci.org',
           :port => 443,
-          :ssl_key => '/etc/letsencrypt/live/updates.jenkins-ci.org/privkey.pem',
-          :ssl_chain => '/etc/letsencrypt/live/updates.jenkins-ci.org/chain.pem',
-          :ssl_cert => '/etc/letsencrypt/live/updates.jenkins-ci.org/cert.pem',
           :ssl => true,
           :docroot => "/var/www/#{fqdn}",
           :override  => ['All'],
@@ -90,13 +86,23 @@ describe 'profile::updatesite' do
     let(:environment) { 'production' }
     it { should contain_letsencrypt__certonly(fqdn) }
 
-    it 'should configure the letsencrypt ssl keys on the vhost' do
+    it 'should configure the letsencrypt ssl keys on the main vhost' do
       expect(subject).to contain_apache__vhost(fqdn).with({
         :servername => fqdn,
         :port => 443,
         :ssl_key => "/etc/letsencrypt/live/#{fqdn}/privkey.pem",
         :ssl_cert => "/etc/letsencrypt/live/#{fqdn}/cert.pem",
         :ssl_chain => "/etc/letsencrypt/live/#{fqdn}/chain.pem",
+      })
+    end
+
+    it 'should configure the letsencrypt ssl keys on the updates.jenkins-ci.org vhost' do
+      expect(subject).to contain_apache__vhost('updates.jenkins-ci.org').with({
+        :servername => 'updates.jenkins-ci.org',
+        :port => 443,
+        :ssl_key => '/etc/letsencrypt/live/updates.jenkins-ci.org/privkey.pem',
+        :ssl_chain => '/etc/letsencrypt/live/updates.jenkins-ci.org/chain.pem',
+        :ssl_cert => '/etc/letsencrypt/live/updates.jenkins-ci.org/cert.pem',
       })
     end
   end


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3020

Follows up #2231 (which was reverted by #2236).

This PR is a fixup of #2231 which was causing HTTP 421 errors with fastly, with the following additional changes:

- [Mandatory improvement] Redirections from pkg.jenkins-ci.org to pkg.jenkins.io are now marked as "permanent"
- [Mandatory fix] HTTP 1.1 protocol is forced for the redirection (then it's up to the pkg.jenkins.io service to upgrade to HTTP/2 or not). It avoids the HTTP clients trying to reuse the same connection and forces a new TLS handshake instead (ref. https://httpd.apache.org/docs/2.4/mod/mod_http2.html#misdirected). Forcing to HTTP 1.1 avoids this issue.
- [Nice to have improvement] @smerle33 and I caught, while diagnosing, that the apache2 log directory was not split per vhosts. It's fixed.


Please note that:

- Unit tests are updated trying to cover all the changes
- Tested on a local vagrant VM, in pair
- Tested "manually" in production to validate that HTTP/421 errors does not appear anymore