### PR TITLE
We don't use Declarative on cert.ci

### DIFF
--- a/hieradata/clients/cert-ci.yaml
+++ b/hieradata/clients/cert-ci.yaml
@@ -59,15 +59,18 @@ profile::buildmaster::plugins:
 
   # Basic Pipeline configuration
   - basic-branch-build-strategies
-  - pipeline-model-definition # TODO check how much is needed
-  - inline-pipeline # https://cert.ci.jenkins.io/job/jenkins-merge-data/
+  - github-branch-source
+  - inline-pipeline
+  - pipeline-groovy-lib
 
   # Pipeline steps
   - build-timeout
   - config-file-provider
   - groovy # Provides groovy tool in some pipelines
   - junit-realtime-test-reporter
+  - pipeline-stage-step # Used in mavenBuild
   - timestamper
+  - workflow-basic-steps
 
   # Utility
   - compact-columns


### PR DESCRIPTION
This will allow uninstalling `pipeline-model-extensions`, `pipeline-input-step`, `pipeline-model-definition`, `pipeline-model-api`, `pipeline-stage-tags-metadata`.