### PR TITLE
chore(docker) bump puppet module for docker + track its version with updatecli

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -28,7 +28,7 @@ mod 'reidmv/yamlfile'
 # Needed by `yamlfile`
 mod 'adrien/filemapper'
 
-mod 'puppetlabs-docker', '4.0.1'
+mod 'puppetlabs-docker', '4.4.0'
 
 # Deps for docker
 mod 'puppetlabs/apt', '8.0.2'

--- a/updatecli/weekly.d/puppet-modules/docker.yaml
+++ b/updatecli/weekly.d/puppet-modules/docker.yaml
@@ -1,0 +1,57 @@
+---
+title: Bump the Docker Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppetlabe/docker module version
+    spec:
+      owner: puppetlabs
+      repository: puppetlabs-docker
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppetlabs-docker-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest docker module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppetlabs-docker'(.*)
+      replacepattern: >
+        mod 'puppetlabs-docker', '{{ source "latestVersion" }}'
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - puppetfile
+    spec:
+      labels:
+        - puppet-module
+        - dependencies


### PR DESCRIPTION
Risk is low for this one: even with 1 year of discrepancy, the changelog is quite small: https://forge.puppet.com/modules/puppetlabs/docker/4.4.0/changelog.

