### PR TITLE
chore: bump puppet module for apache to 7.0.0 + track its version with updatecli

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -34,7 +34,7 @@ mod 'puppetlabs/docker', '4.4.0'
 mod 'puppetlabs/apt', '8.4.1'
 
 # Apache and its dependencies
-mod "puppetlabs/apache", '3.5.0'
+mod "puppetlabs/apache", '7.0.0'
 
 mod "puppetlabs/concat", '5.2.0'
 

--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -108,55 +108,65 @@ class profile::archives (
     require => Package['libapache2-mod-bw'],
   }
 
-  apache::vhost { 'archives.jenkins-ci.org non-ssl':
-    servername      => 'archives.jenkins-ci.org',
-    vhost_name      => '*',
-    port            => '80',
-    docroot         => $archives_dir,
-    access_log      => false,
-    error_log_file  => 'archives.jenkins-ci.org/error.log',
-    log_level       => 'warn',
-    custom_fragment => template("${module_name}/archives/vhost.conf"),
-    options         => ['FollowSymLinks', 'MultiViews', 'Indexes'],
-    notify          => Service['apache2'],
-    require         => [File['/var/log/apache2/archives.jenkins-ci.org'],
+  apache::vhost { 'archives.jenkins-ci.org unsecure':
+    servername                   => 'archives.jenkins-ci.org',
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    vhost_name                   => '*',
+    port                         => '80',
+    docroot                      => $archives_dir,
+    access_log                   => false,
+    error_log_file               => 'archives.jenkins-ci.org/error.log',
+    log_level                    => 'warn',
+    custom_fragment              => template("${module_name}/archives/vhost.conf"),
+    options                      => ['FollowSymLinks', 'MultiViews', 'Indexes'],
+    notify                       => Service['apache2'],
+    require                      => [File['/var/log/apache2/archives.jenkins-ci.org'],
       File[$archives_dir],
     Apache::Mod['bw']],
   }
 
   apache::vhost { 'archives.jenkins-ci.org':
-    port            => '443',
-    ssl             => true,
-    docroot         => $archives_dir,
-    access_log      => false,
-    error_log_file  => 'archives.jenkins-ci.org/error.log',
-    log_level       => 'warn',
-    custom_fragment => template("${module_name}/archives/vhost.conf"),
+    servername                   => 'archives.jenkins-ci.org',
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    port                         => '443',
+    ssl                          => true,
+    docroot                      => $archives_dir,
+    access_log                   => false,
+    error_log_file               => 'archives.jenkins-ci.org/error.log',
+    log_level                    => 'warn',
+    custom_fragment              => template("${module_name}/archives/vhost.conf"),
 
-    notify          => Service['apache2'],
-    require         => File['/var/log/apache2/archives.jenkins-ci.org'],
+    notify                       => Service['apache2'],
+    require                      => File['/var/log/apache2/archives.jenkins-ci.org'],
   }
 
-  apache::vhost { 'archives.jenkins.io non-ssl':
+  apache::vhost { 'archives.jenkins.io unsecured':
     # redirect non-SSL to SSL
-    servername      => 'archives.jenkins.io',
-    port            => '80',
-    docroot         => $archives_dir,
-    redirect_status => 'temp',
-    redirect_dest   => 'https://archives.jenkins.io/',
+    servername                   => 'archives.jenkins.io',
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    port                         => '80',
+    docroot                      => $archives_dir,
+    redirect_status              => 'temp',
+    redirect_dest                => 'https://archives.jenkins.io/',
   }
 
   apache::vhost { 'archives.jenkins.io':
-    port            => '443',
-    ssl             => true,
-    docroot         => $archives_dir,
-    access_log      => false,
-    error_log_file  => 'archives.jenkins.io/error.log',
-    log_level       => 'warn',
-    custom_fragment => template("${module_name}/archives/vhost.conf"),
+    servername                   => 'archives.jenkins.io',
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    port                         => '443',
+    ssl                          => true,
+    docroot                      => $archives_dir,
+    access_log                   => false,
+    error_log_file               => 'archives.jenkins.io/error.log',
+    log_level                    => 'warn',
+    custom_fragment              => template("${module_name}/archives/vhost.conf"),
 
-    notify          => Service['apache2'],
-    require         => File['/var/log/apache2/archives.jenkins-ci.org'],
+    notify                       => Service['apache2'],
+    require                      => File['/var/log/apache2/archives.jenkins-ci.org'],
   }
 
   # We can only acquire certs in production due to the way the letsencrypt

--- a/dist/profile/manifests/census.pp
+++ b/dist/profile/manifests/census.pp
@@ -1,14 +1,14 @@
 #
 # Defines an census server for serving census datasets
 #
-class profile::census(
+class profile::census (
   $home_dir = '/srv/census',
   $user     = 'census',
   $group    = 'census',
 ) {
-  include ::stdlib
+  include stdlib
   # volume configuration is in hiera
-  include ::lvm
+  include lvm
   include profile::apachemisc
 
   $docroot = "${home_dir}/census"
@@ -59,16 +59,19 @@ class profile::census(
   }
 
   apache::vhost { 'census.jenkins.io':
-    vhost_name      => '*',
-    port            => '80',
-    docroot         => $docroot,
-    access_log_pipe => '|/usr/bin/rotatelogs /var/log/apache2/census.jenkins.io/access.log.%Y%m%d%H%M%S 604800',
-    error_log_pipe  => '|/usr/bin/rotatelogs /var/log/apache2/census.jenkins.io/error.log.%Y%m%d%H%M%S 604800',
-    options         => ['FollowSymLinks', 'MultiViews', 'Indexes'],
-    override        => ['All'],
-    notify          => Service['apache2'],
-    require         => [File['/var/log/apache2/census.jenkins.io'],
-                        File[$docroot],
-                        Mount[$home_dir]],
+    servername                   => 'census.jenkins.io',
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    vhost_name                   => '*',
+    port                         => '80',
+    docroot                      => $docroot,
+    access_log_pipe              => '|/usr/bin/rotatelogs /var/log/apache2/census.jenkins.io/access.log.%Y%m%d%H%M%S 604800',
+    error_log_pipe               => '|/usr/bin/rotatelogs /var/log/apache2/census.jenkins.io/error.log.%Y%m%d%H%M%S 604800',
+    options                      => ['FollowSymLinks', 'MultiViews', 'Indexes'],
+    override                     => ['All'],
+    notify                       => Service['apache2'],
+    require                      => [File['/var/log/apache2/census.jenkins.io'],
+      File[$docroot],
+    Mount[$home_dir]],
   }
 }

--- a/dist/profile/manifests/demo.pp
+++ b/dist/profile/manifests/demo.pp
@@ -1,7 +1,7 @@
 #
 # Run a demo instance of Jenkins in a Docker container
-class profile::demo(
-$image_tag = '2.23'
+class profile::demo (
+  $image_tag = '2.23'
 ) {
   include profile::docker
   include profile::apachemisc
@@ -22,7 +22,7 @@ $image_tag = '2.23'
     ports           => ['8080:8080'],
     restart_service => true,
     require         => [
-      Class['::docker'],
+      Class['docker'],
       Docker::Image[$image],
       File['/srv/demo/passwd'],
       User[$user],
@@ -40,7 +40,7 @@ $image_tag = '2.23'
   }
 
   file { '/srv/demo/passwd':
-    ensure  => present,
+    ensure  => file,
     content => template("${module_name}/demo/passwd.erb"),
   }
 
@@ -55,7 +55,7 @@ $image_tag = '2.23'
 
     notify          => Service['apache2'],
     require         => [File["/var/log/apache2/${site}.jenkins-ci.org"],
-                        Docker::Run[$site]
+      Docker::Run[$site]
     ],
   }
 

--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -409,7 +409,7 @@ RewriteRule (.*)/api/xml(/|$)(.*) /empty.xml
     error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 86400",
     proxy_preserve_host          => true,
     allow_encoded_slashes        => 'on',
-    custom_fragment       => "${ci_fqdn_x_forwarded_host}
+    custom_fragment              => "${ci_fqdn_x_forwarded_host}
 ${base_custom_fragment}
 ${custom_fragment_api_paths}
 ",

--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -386,79 +386,155 @@ RewriteRule (.*)/api/xml(/|$)(.*) /empty.xml
   }
 
   apache::vhost { $ci_fqdn:
-    serveraliases         => [
+    servername                   => $ci_fqdn,
+    serveraliases                => [
       # Give all our jenkinscontroller profiles this server alias; it's easier than
       # parameterizing it for compatibility's sake
       'ci.jenkins-ci.org', $ci_resource_domain,
     ],
-    require               => [
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    require                      => [
       Docker::Run[$docker_container_name],
       File[$docroot],
       # We need our installation to be secure before we allow access
       File[$groovy_d],
     ],
-    port                  => 443,
-    override              => 'All',
-    ssl                   => true,
-    docroot               => $docroot,
+    port                         => 443,
+    override                     => 'All',
+    ssl                          => true,
+    docroot                      => $docroot,
 
-    access_log_pipe       => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access.log.%Y%m%d%H%M%S 86400",
-    error_log_pipe        => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 86400",
-    proxy_preserve_host   => true,
-    allow_encoded_slashes => 'on',
-    custom_fragment       => "${ci_fqdn_x_forwarded_host}
-${base_custom_fragment}
-${custom_fragment_api_paths}
+    access_log_pipe              => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access.log.%Y%m%d%H%M%S 86400",
+    error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 86400",
+    proxy_preserve_host          => true,
+    allow_encoded_slashes        => 'on',
+    custom_fragment              => "
+RequestHeader set X-Forwarded-Proto \"https\"
+RequestHeader set X-Forwarded-Port \"${proxy_port}\"
+RequestHeader set X-Forwarded-Host \"${ci_fqdn}\"
+
+RewriteEngine on
+
+RewriteCond %{REQUEST_FILENAME} ^(.*)api/xml(.*)$ [NC]
+RewriteRule ^.* \"https://jenkins.io/infra/ci-redirects/\"  [L]
+
+# Abusive Chinese bot that ignores robots.txt
+RewriteCond %{HTTP_USER_AGENT}  Sogou [NC]
+RewriteRule \".?\" \"-\" [F]
+
+# Black hole all traffic to routes like /view/All/people/ which is pretty much
+# hit illegitimately used anyways
+# See thread dump here: https://gist.github.com/rtyler/f8d02e0c5ff11e03da4e331a0f2ca280
+RewriteCond %{REQUEST_FILENAME} ^(.*)people(.*)$ [NC]
+RewriteRule ^.* \"https://jenkins.io/infra/ci-redirects/\"  [L]
+
+# Send unauthenticated api/json or api/python requests to `empty.json` to prevent abusive clients
+# (checkman) from receiving an invalid JSON response and repeatedly attempting
+# to hammer us to get a better response. Works for Python API as well.
+RewriteCond \"%{HTTP:Authorization}\" !^Basic
+RewriteRule (.*)/api/(json|python)(/|$)(.*) /empty.json
+# Analogously for XML.
+RewriteCond \"%{HTTP:Authorization}\" !^Basic
+RewriteRule (.*)/api/xml(/|$)(.*) /empty.xml
+
+# Loading our Proxy rules ourselves from a custom fragment since the
+# puppetlabs/apache module doesn't support ordering of both proxy_pass and
+# proxy_pass_match configurations
+ProxyRequests Off
+ProxyPreserveHost On
+ProxyPass / http://localhost:8080/ nocanon
+ProxyPassReverse / http://localhost:8080/
 ",
   }
 
   apache::vhost { $ci_resource_domain:
-    require               => [
+    servername                   => $ci_resource_domain,
+    require                      => [
       Docker::Run[$docker_container_name],
       File[$docroot],
       # We need our installation to be secure before we allow access
       File[$groovy_d],
     ],
-    port                  => 443,
-    override              => 'All',
-    ssl                   => true,
-    docroot               => $docroot,
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    port                         => 443,
+    override                     => 'All',
+    ssl                          => true,
+    docroot                      => $docroot,
 
-    access_log_pipe       => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access.log.%Y%m%d%H%M%S 86400",
-    error_log_pipe        => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 86400",
-    proxy_preserve_host   => true,
-    allow_encoded_slashes => 'on',
-    custom_fragment       => "${ci_resource_domain_x_forwarded_host}
-${base_custom_fragment}
-${custom_fragment_api_paths}
+    access_log_pipe              => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access.log.%Y%m%d%H%M%S 86400",
+    error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 86400",
+    proxy_preserve_host          => true,
+    allow_encoded_slashes        => 'on',
+    custom_fragment              => "
+RequestHeader set X-Forwarded-Proto \"https\"
+RequestHeader set X-Forwarded-Port \"${proxy_port}\"
+RequestHeader set X-Forwarded-Host \"${ci_resource_domain}\"
+
+RewriteEngine on
+
+RewriteCond %{REQUEST_FILENAME} ^(.*)api/xml(.*)$ [NC]
+RewriteRule ^.* \"https://jenkins.io/infra/ci-redirects/\"  [L]
+
+# Abusive Chinese bot that ignores robots.txt
+RewriteCond %{HTTP_USER_AGENT}  Sogou [NC]
+RewriteRule \".?\" \"-\" [F]
+
+# Black hole all traffic to routes like /view/All/people/ which is pretty much
+# hit illegitimately used anyways
+# See thread dump here: https://gist.github.com/rtyler/f8d02e0c5ff11e03da4e331a0f2ca280
+RewriteCond %{REQUEST_FILENAME} ^(.*)people(.*)$ [NC]
+RewriteRule ^.* \"https://jenkins.io/infra/ci-redirects/\"  [L]
+
+# Send unauthenticated api/json or api/python requests to `empty.json` to prevent abusive clients
+# (checkman) from receiving an invalid JSON response and repeatedly attempting
+# to hammer us to get a better response. Works for Python API as well.
+RewriteCond \"%{HTTP:Authorization}\" !^Basic
+RewriteRule (.*)/api/(json|python)(/|$)(.*) /empty.json
+# Analogously for XML.
+RewriteCond \"%{HTTP:Authorization}\" !^Basic
+RewriteRule (.*)/api/xml(/|$)(.*) /empty.xml
+
+# Loading our Proxy rules ourselves from a custom fragment since the
+# puppetlabs/apache module doesn't support ordering of both proxy_pass and
+# proxy_pass_match configurations
+ProxyRequests Off
+ProxyPreserveHost On
+ProxyPass / http://localhost:8080/ nocanon
+ProxyPassReverse / http://localhost:8080/
 ",
   }
 
   apache::vhost { "${ci_fqdn} unsecured":
-    serveraliases   => [
+    serveraliases                => [
       # Give all our jenkinscontroller profiles this server alias; it's easier than
       # parameterizing it for compatibility's sake
       'ci.jenkins-ci.org',
     ],
-    servername      => $ci_fqdn,
-    port            => 80,
-    docroot         => $docroot,
-    redirect_status => 'permanent',
-    redirect_dest   => "https://${ci_fqdn}/",
-    error_log_file  => "${ci_fqdn}/error_nonssl.log",
-    access_log_pipe => '/dev/null',
-    require         => Apache::Vhost[$ci_fqdn],
+    servername                   => $ci_fqdn,
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    port                         => 80,
+    docroot                      => $docroot,
+    redirect_status              => 'permanent',
+    redirect_dest                => "https://${ci_fqdn}/",
+    error_log_file               => "${ci_fqdn}/error_unsecured.log",
+    access_log_pipe              => '/dev/null',
+    require                      => Apache::Vhost[$ci_fqdn],
   }
 
   apache::vhost { "${ci_resource_domain} unsecured":
-    servername      => $ci_resource_domain,
-    port            => 80,
-    docroot         => $docroot,
-    redirect_status => 'permanent',
-    redirect_dest   => "https://${ci_resource_domain}/",
-    error_log_file  => "${ci_resource_domain}/error_nonssl.log",
-    access_log_pipe => '/dev/null',
-    require         => Apache::Vhost[$ci_resource_domain],
+    servername                   => $ci_resource_domain,
+    port                         => 80,
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    docroot                      => $docroot,
+    redirect_status              => 'permanent',
+    redirect_dest                => "https://${ci_resource_domain}/",
+    error_log_file               => "${ci_resource_domain}/error_unsecured.log",
+    access_log_pipe              => '/dev/null',
+    require                      => Apache::Vhost[$ci_resource_domain],
   }
 
   firewall { '801 Allow Jenkins web access only on localhost':

--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -409,42 +409,9 @@ RewriteRule (.*)/api/xml(/|$)(.*) /empty.xml
     error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 86400",
     proxy_preserve_host          => true,
     allow_encoded_slashes        => 'on',
-    custom_fragment              => "
-RequestHeader set X-Forwarded-Proto \"https\"
-RequestHeader set X-Forwarded-Port \"${proxy_port}\"
-RequestHeader set X-Forwarded-Host \"${ci_fqdn}\"
-
-RewriteEngine on
-
-RewriteCond %{REQUEST_FILENAME} ^(.*)api/xml(.*)$ [NC]
-RewriteRule ^.* \"https://jenkins.io/infra/ci-redirects/\"  [L]
-
-# Abusive Chinese bot that ignores robots.txt
-RewriteCond %{HTTP_USER_AGENT}  Sogou [NC]
-RewriteRule \".?\" \"-\" [F]
-
-# Black hole all traffic to routes like /view/All/people/ which is pretty much
-# hit illegitimately used anyways
-# See thread dump here: https://gist.github.com/rtyler/f8d02e0c5ff11e03da4e331a0f2ca280
-RewriteCond %{REQUEST_FILENAME} ^(.*)people(.*)$ [NC]
-RewriteRule ^.* \"https://jenkins.io/infra/ci-redirects/\"  [L]
-
-# Send unauthenticated api/json or api/python requests to `empty.json` to prevent abusive clients
-# (checkman) from receiving an invalid JSON response and repeatedly attempting
-# to hammer us to get a better response. Works for Python API as well.
-RewriteCond \"%{HTTP:Authorization}\" !^Basic
-RewriteRule (.*)/api/(json|python)(/|$)(.*) /empty.json
-# Analogously for XML.
-RewriteCond \"%{HTTP:Authorization}\" !^Basic
-RewriteRule (.*)/api/xml(/|$)(.*) /empty.xml
-
-# Loading our Proxy rules ourselves from a custom fragment since the
-# puppetlabs/apache module doesn't support ordering of both proxy_pass and
-# proxy_pass_match configurations
-ProxyRequests Off
-ProxyPreserveHost On
-ProxyPass / http://localhost:8080/ nocanon
-ProxyPassReverse / http://localhost:8080/
+    custom_fragment       => "${ci_fqdn_x_forwarded_host}
+${base_custom_fragment}
+${custom_fragment_api_paths}
 ",
   }
 
@@ -467,42 +434,9 @@ ProxyPassReverse / http://localhost:8080/
     error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 86400",
     proxy_preserve_host          => true,
     allow_encoded_slashes        => 'on',
-    custom_fragment              => "
-RequestHeader set X-Forwarded-Proto \"https\"
-RequestHeader set X-Forwarded-Port \"${proxy_port}\"
-RequestHeader set X-Forwarded-Host \"${ci_resource_domain}\"
-
-RewriteEngine on
-
-RewriteCond %{REQUEST_FILENAME} ^(.*)api/xml(.*)$ [NC]
-RewriteRule ^.* \"https://jenkins.io/infra/ci-redirects/\"  [L]
-
-# Abusive Chinese bot that ignores robots.txt
-RewriteCond %{HTTP_USER_AGENT}  Sogou [NC]
-RewriteRule \".?\" \"-\" [F]
-
-# Black hole all traffic to routes like /view/All/people/ which is pretty much
-# hit illegitimately used anyways
-# See thread dump here: https://gist.github.com/rtyler/f8d02e0c5ff11e03da4e331a0f2ca280
-RewriteCond %{REQUEST_FILENAME} ^(.*)people(.*)$ [NC]
-RewriteRule ^.* \"https://jenkins.io/infra/ci-redirects/\"  [L]
-
-# Send unauthenticated api/json or api/python requests to `empty.json` to prevent abusive clients
-# (checkman) from receiving an invalid JSON response and repeatedly attempting
-# to hammer us to get a better response. Works for Python API as well.
-RewriteCond \"%{HTTP:Authorization}\" !^Basic
-RewriteRule (.*)/api/(json|python)(/|$)(.*) /empty.json
-# Analogously for XML.
-RewriteCond \"%{HTTP:Authorization}\" !^Basic
-RewriteRule (.*)/api/xml(/|$)(.*) /empty.xml
-
-# Loading our Proxy rules ourselves from a custom fragment since the
-# puppetlabs/apache module doesn't support ordering of both proxy_pass and
-# proxy_pass_match configurations
-ProxyRequests Off
-ProxyPreserveHost On
-ProxyPass / http://localhost:8080/ nocanon
-ProxyPassReverse / http://localhost:8080/
+    custom_fragment              => "${ci_resource_domain_x_forwarded_host}
+${base_custom_fragment}
+${custom_fragment_api_paths}
 ",
   }
 

--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -96,57 +96,66 @@ class profile::pkgrepo (
   }
 
   apache::vhost { $repo_fqdn:
-    port            => 443,
+    servername                   => $repo_fqdn,
+    port                         => 443,
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
     # We need FollowSymLinks to ensure our fallback for old APT clients works
     # properly, see debian's htaccess file for more
-    options         => 'Indexes FollowSymLinks MultiViews',
-    override        => ['All'],
-    ssl             => true,
-    docroot         => $docroot,
+    options                      => 'Indexes FollowSymLinks MultiViews',
+    override                     => ['All'],
+    ssl                          => true,
+    docroot                      => $docroot,
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/access.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/error.log.%Y%m%d%H%M%S 604800",
-    require         => File[$docroot],
+    access_log_pipe              => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/access.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/error.log.%Y%m%d%H%M%S 604800",
+    require                      => File[$docroot],
   }
 
   apache::vhost { "${repo_fqdn} unsecured":
-    servername      => $repo_fqdn,
-    port            => 80,
-    override        => ['All'],
-    docroot         => $docroot,
+    servername                   => $repo_fqdn,
+    port                         => 80,
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    override                     => ['All'],
+    docroot                      => $docroot,
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/access_nonssl.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/error_nonssl.log.%Y%m%d%H%M%S 604800",
-    require         => File[$docroot],
+    access_log_pipe              => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/access_unsecured.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir_fqdn}/error_unsecured.log.%Y%m%d%H%M%S 604800",
+    require                      => File[$docroot],
   }
 
   apache::vhost { 'pkg.jenkins-ci.org unsecured':
-    servername      => 'pkg.jenkins-ci.org',
-    port            => 80,
-    docroot         => $docroot,
+    servername                   => 'pkg.jenkins-ci.org',
+    port                         => 80,
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    docroot                      => $docroot,
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/access_nonssl.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/error_nonssl.log.%Y%m%d%H%M%S 604800",
-    redirect_status => 'permanent',
-    redirect_dest   => ['https://pkg.jenkins.io/'],
+    access_log_pipe              => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/access_unsecured.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/error_unsecured.log.%Y%m%d%H%M%S 604800",
+    redirect_status              => 'permanent',
+    redirect_dest                => ['https://pkg.jenkins.io/'],
     # Due to fastly caching on the target domain, it is required to force re-establishing TLS connection to new domain (HTTP/2 tries to reuse connection thinking it is the same server)
-    custom_fragment => 'Protocols http/1.1',
-    require         => File[$docroot],
+    custom_fragment              => 'Protocols http/1.1',
+    require                      => File[$docroot],
   }
 
   apache::vhost { 'pkg.jenkins-ci.org':
-    servername      => 'pkg.jenkins-ci.org',
-    port            => 443,
-    docroot         => $docroot,
-    ssl             => true,
+    servername                   => 'pkg.jenkins-ci.org',
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    port                         => 443,
+    docroot                      => $docroot,
+    ssl                          => true,
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/access.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/error.log.%Y%m%d%H%M%S 604800",
-    redirect_status => 'permanent',
-    redirect_dest   => ['https://pkg.jenkins.io/'],
+    access_log_pipe              => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/access.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir_legacy_fqdn}/error.log.%Y%m%d%H%M%S 604800",
+    redirect_status              => 'permanent',
+    redirect_dest                => ['https://pkg.jenkins.io/'],
     # Due to fastly caching on the target domain, it is required to force re-establishing TLS connection to new domain (HTTP/2 tries to reuse connection thinking it is the same server)
-    custom_fragment => 'Protocols http/1.1',
-    require         => File[$docroot],
+    custom_fragment              => 'Protocols http/1.1',
+    require                      => File[$docroot],
   }
 
   # We can only acquire certs in production due to the way the letsencrypt

--- a/dist/profile/manifests/robobutler.pp
+++ b/dist/profile/manifests/robobutler.pp
@@ -56,13 +56,16 @@ class profile::robobutler (
   }
 
   apache::vhost { 'meetings.jenkins-ci.org':
-      docroot         => $logdir,
-      port            => '80',
-      access_log      => false,
-      error_log_file  => 'meetings.jenkins-ci.org/error.log',
-      log_level       => 'warn',
-      custom_fragment => 'CustomLog "|/usr/bin/rotatelogs /var/log/apache2/meetings.jenkins-ci.org/access.log.%Y%m%d%H%M%S 604800" reverseproxy_combined',
-      notify          => Service['apache2'],
-      require         => File['/var/log/apache2/meetings.jenkins-ci.org'],
+    servername                   => 'meetings.jenkins-ci.org',
+    docroot                      => $logdir,
+    port                         => '80',
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    access_log                   => false,
+    error_log_file               => 'meetings.jenkins-ci.org/error.log',
+    log_level                    => 'warn',
+    custom_fragment              => 'CustomLog "|/usr/bin/rotatelogs /var/log/apache2/meetings.jenkins-ci.org/access.log.%Y%m%d%H%M%S 604800" reverseproxy_combined',
+    notify                       => Service['apache2'],
+    require                      => File['/var/log/apache2/meetings.jenkins-ci.org'],
   }
 }

--- a/dist/profile/manifests/updatesite.pp
+++ b/dist/profile/manifests/updatesite.pp
@@ -34,51 +34,61 @@ class profile::updatesite (
   }
 
   apache::vhost { $update_fqdn:
-    require         => [
+    servername                   => $update_fqdn,
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    require                      => [
       File[$docroot],
     ],
-    port            => 443,
-    override        => ['All'],
-    ssl             => true,
-    docroot         => $docroot,
+    port                         => 443,
+    override                     => ['All'],
+    ssl                          => true,
+    docroot                      => $docroot,
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 604800",
+    access_log_pipe              => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 604800",
   }
 
   apache::vhost { "${update_fqdn} unsecured":
-    servername      => $update_fqdn,
-    port            => 80,
-    docroot         => $docroot,
-    override        => ['All'],
+    servername                   => $update_fqdn,
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    port                         => 80,
+    docroot                      => $docroot,
+    override                     => ['All'],
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_nonssl.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_nonssl.log.%Y%m%d%H%M%S 604800",
-    require         => Apache::Vhost[$update_fqdn],
+    access_log_pipe              => "|/usr/bin/rotatelogs -t ${apache_log_dir}/access_unsecured.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_log_dir}/error_unsecured.log.%Y%m%d%H%M%S 604800",
+    require                      => Apache::Vhost[$update_fqdn],
   }
 
   apache::vhost { 'updates.jenkins-ci.org':
-    docroot         => $docroot,
-    port            => 443,
-    ssl             => true,
-    override        => ['All'],
+    servername                   => 'updates.jenkins-ci.org',
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    docroot                      => $docroot,
+    port                         => 443,
+    ssl                          => true,
+    override                     => ['All'],
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_legacy_log_dir}/access.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_legacy_log_dir}/error.log.%Y%m%d%H%M%S 604800",
-    require         => [
+    access_log_pipe              => "|/usr/bin/rotatelogs -t ${apache_legacy_log_dir}/access.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_legacy_log_dir}/error.log.%Y%m%d%H%M%S 604800",
+    require                      => [
       File[$apache_legacy_log_dir],
     ],
   }
 
   apache::vhost { 'updates.jenkins-ci.org unsecured':
-    servername      => 'updates.jenkins-ci.org',
-    docroot         => $docroot,
-    port            => 80,
-    override        => ['All'],
+    servername                   => 'updates.jenkins-ci.org',
+    use_servername_for_filenames => true,
+    use_port_for_filenames       => true,
+    docroot                      => $docroot,
+    port                         => 80,
+    override                     => ['All'],
 
-    access_log_pipe => "|/usr/bin/rotatelogs -t ${apache_legacy_log_dir}/access_nonssl.log.%Y%m%d%H%M%S 604800",
-    error_log_pipe  => "|/usr/bin/rotatelogs -t ${apache_legacy_log_dir}/error_nonssl.log.%Y%m%d%H%M%S 604800",
-    require         => Apache::Vhost['updates.jenkins-ci.org'],
+    access_log_pipe              => "|/usr/bin/rotatelogs -t ${apache_legacy_log_dir}/access_unsecured.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -t ${apache_legacy_log_dir}/error_unsecured.log.%Y%m%d%H%M%S 604800",
+    require                      => Apache::Vhost['updates.jenkins-ci.org'],
   }
 
   ##################################

--- a/spec/classes/profile/pkgrepo_spec.rb
+++ b/spec/classes/profile/pkgrepo_spec.rb
@@ -148,8 +148,8 @@ describe 'profile::pkgrepo' do
         :servername => 'pkg.origin.jenkins.io',
         :port => 80,
         :docroot => params[:docroot],
-        :access_log_pipe => "|/usr/bin/rotatelogs -t /var/log/apache2/pkg.origin.jenkins.io/access_nonssl.log.%Y%m%d%H%M%S 604800",
-        :error_log_pipe  => "|/usr/bin/rotatelogs -t /var/log/apache2/pkg.origin.jenkins.io/error_nonssl.log.%Y%m%d%H%M%S 604800",
+        :access_log_pipe => "|/usr/bin/rotatelogs -t /var/log/apache2/pkg.origin.jenkins.io/access_unsecured.log.%Y%m%d%H%M%S 604800",
+        :error_log_pipe  => "|/usr/bin/rotatelogs -t /var/log/apache2/pkg.origin.jenkins.io/error_unsecured.log.%Y%m%d%H%M%S 604800",
       })
     end
 
@@ -181,8 +181,8 @@ describe 'profile::pkgrepo' do
         :redirect_status => 'permanent',
         :redirect_dest => ['https://pkg.jenkins.io/'],
         :custom_fragment => 'Protocols http/1.1',
-        :access_log_pipe => "|/usr/bin/rotatelogs -t /var/log/apache2/pkg.jenkins-ci.org/access_nonssl.log.%Y%m%d%H%M%S 604800",
-        :error_log_pipe  => "|/usr/bin/rotatelogs -t /var/log/apache2/pkg.jenkins-ci.org/error_nonssl.log.%Y%m%d%H%M%S 604800",
+        :access_log_pipe => "|/usr/bin/rotatelogs -t /var/log/apache2/pkg.jenkins-ci.org/access_unsecured.log.%Y%m%d%H%M%S 604800",
+        :error_log_pipe  => "|/usr/bin/rotatelogs -t /var/log/apache2/pkg.jenkins-ci.org/error_unsecured.log.%Y%m%d%H%M%S 604800",
       })
     end
   end

--- a/updatecli/weekly.d/puppet-modules/apache.yaml
+++ b/updatecli/weekly.d/puppet-modules/apache.yaml
@@ -1,0 +1,57 @@
+---
+title: Bump the Apache Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppetlab/apache module version
+    spec:
+      owner: puppetlabs
+      repository: puppetlabs-apache
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppetlabs-apache-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest apache module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppetlabs/apache'(.*)
+      replacepattern: >
+        mod 'puppetlabs/apache', '{{ source "latestVersion" }}'
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - puppetfile
+    spec:
+      labels:
+        - puppet-module
+        - dependencies


### PR DESCRIPTION
Blocked by #2263 and #2270

This PR bumps the Apache Puppet module to its latest stable version.

⚠️ It's a huge change (current `3.5.0` was release in Dec. 2018 while `7.0.0` in Oct. 2021).

Please do not merge it: it will be a team task that implies stopping puppet agent everywhere, then diffing before applying (see runbooks).


It introduces the following changes:

- Bump module to latst stable (`7.0.0`)
- Add an updatecli manifest to track this module version (and keep it up to date in  the future)
- As a consequence of the module upgrade (with deprecated attributes and behaviors changes in `apache::vhosts` resources):
  - Homogenize naming convention for `apache::vhosts` resources:
    - Resource Name: either it's named `$fqdn` for default TLS virtual host, or it's named `$fqdn unsecure` for HTTP virtual host
    - Log files: same: (suffix `_unsecured` for non tls access/error logs)
   - Specify `servername` attribute for ALL `apache::vhosts` resources
   - Specify `use_servername_for_filenames` and `use_port_for_filenames` attributes to avoid depreciation messages
   - Formatting puppet code with latest linter