### PR TITLE
fix(census) correct logical volume size to map to production and avoid failing the puppet run

### DIFF
--- a/hieradata/clients/census.yaml
+++ b/hieradata/clients/census.yaml
@@ -5,5 +5,5 @@ lvm::volume_groups:
       - /dev/xvdb
     logical_volumes:
       census:
-        size: 30G
+        size: 64G
         mountpath: /srv/census


### PR DESCRIPTION
Puppet run on census.jenkins.io fails with the following error:

```console
# ...
Jul 01 17:58:09 ip-172-31-19-158 puppet-agent[20963]: Decreasing the size requires manual intervention (30G < 64G)
Jul 01 17:58:09 ip-172-31-19-158 puppet-agent[20963]: (/Stage[main]/Lvm/Lvm::Volume_group[data]/Lvm::Logical_volume[census]/Logical_volume[census]/size) change from '64G' to '30G' failed: Decreasing the size requires manual intervention (30G < 64G)
Jul 01 17:58:09 ip-172-31-19-158 puppet-agent[20963]: (/Stage[main]/Lvm/Lvm::Volume_group[data]/Lvm::Logical_volume[census]/Filesystem[/dev/data/census]) Dependency Logical_volume[census] has failures: true
Jul 01 17:58:09 ip-172-31-19-158 puppet-agent[20963]: (/Stage[main]/Lvm/Lvm::Volume_group[data]/Lvm::Logical_volume[census]/Filesystem[/dev/data/census]) Skipping because of failed dependencies
# ...
```


This PR correct the hieradata values for this