### PR TITLE
chore(apt) bump puppet module for apt to 8.4.1 + track its version with updatecli

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -28,11 +28,10 @@ mod 'reidmv/yamlfile'
 # Needed by `yamlfile`
 mod 'adrien/filemapper'
 
-mod 'puppetlabs-docker', '4.4.0'
+mod 'puppetlabs/docker', '4.4.0'
 
 # Deps for docker
-mod 'puppetlabs/apt', '8.0.2'
-mod 'puppet/epel', '3.0.1'
+mod 'puppetlabs/apt', '8.4.1'
 
 # Dependencies for the Puppet IRC report processor, using our forked version
 # which updates on any changed status

--- a/updatecli/weekly.d/puppet-modules/apt.yaml
+++ b/updatecli/weekly.d/puppet-modules/apt.yaml
@@ -1,0 +1,57 @@
+---
+title: Bump the APT Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppetlabe/apt module version
+    spec:
+      owner: puppetlabs
+      repository: puppetlabs-apt
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppetlabs-apt-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest APT module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppetlabs/apt'(.*)
+      replacepattern: >
+        mod 'puppetlabs/apt', '{{ source "latestVersion" }}'
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - puppetfile
+    spec:
+      labels:
+        - puppet-module
+        - dependencies


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/jenkins-infra/pull/2235#discussion_r912870122

Changelogs:
- https://forge.puppet.com/modules/puppetlabs/apt/changelog#v810-2021-07-26 (nothing interesting for us)
- https://forge.puppet.com/modules/puppetlabs/apt/changelog#v820-2021-08-25 (support of Debian 11)
- https://forge.puppet.com/modules/puppetlabs/apt/changelog#v830-2021-10-04 (nothing interesting for us)
- https://forge.puppet.com/modules/puppetlabs/apt/changelog#v840---2022-06-06 (fix for arm64/aarch64 that we will benefit from)
- https://forge.puppet.com/modules/puppetlabs/apt/changelog#v841---2022-06-20 (nothing interesting for us)