### PR TITLE
Revert "fix(ci.jenkins.io) use public IP for Azure VM agents"

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -276,7 +276,7 @@ profile::buildmaster::cloud_agents:
         maxInstances: 10
         useAsMuchAsPosible: true
         credentialsId: "jenkinsvmagents-userpass"
-        usePrivateIP: false
+        usePrivateIP: true
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
         subnetName: "ci.j-agents-vm"
@@ -295,7 +295,7 @@ profile::buildmaster::cloud_agents:
           - docker-highmem
         maxInstances: 20
         useAsMuchAsPosible: false
-        usePrivateIP: false
+        usePrivateIP: true
         credentialsId: "jenkinsvmagents-userpass"
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
@@ -316,7 +316,7 @@ profile::buildmaster::cloud_agents:
         useAsMuchAsPosible: true
         credentialsId: "jenkinsvmagents-userpass"
         useEphemeralOSDisk: false
-        usePrivateIP: false
+        usePrivateIP: true
         virtualNetworkName: "prod-jenkins-public-prod"
         virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
         subnetName: "ci.j-agents-vm"


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2227 because https://github.com/jenkins-infra/helpdesk/issues/2961#issuecomment-1176458104 .

That should help for https://github.com/jenkins-infra/helpdesk/issues/3031#issuecomment-1175140931 (cc @MarkEWaite for info) because we won't reach the "max public IP" threshold