### PR TITLE
chore(tests) fix spec test errors due to a badly filled mock

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,9 @@ RSpec.configure do |c|
   c.hiera_config = File.join(FIXTURES_PATH, 'hiera.yaml')
 
   c.default_facts = {
-    :architecture => 'amd64',
+    :os => {
+      :architecture => 'amd64',
+    },
     :osfamily => 'Debian',
     :kernel => 'Linux',
     :lsbdistid => 'Ubuntu',


### PR DESCRIPTION
This PR corrects the unit test mocking framework that is failing since #2241 .