### PR TITLE
fix(datadog) correct error message about unknwown variable conf6dir

### DIFF
--- a/dist/profile/manifests/datadog_check.pp
+++ b/dist/profile/manifests/datadog_check.pp
@@ -1,12 +1,12 @@
 # Assemble fragments into datadog checker configuration files
 #
-define profile::datadog_check(
+define profile::datadog_check (
   $ensure    = present,
   $checker   = undef,
   $source    = undef,
   $content   = undef,
 ) {
-  $target ="${datadog_agent::params::conf6_dir}/${checker}.yaml"
+  $target ="${datadog_agent::params::conf_dir}/${checker}.yaml"
 
   include datadog_agent
 
@@ -16,14 +16,14 @@ define profile::datadog_check(
       ensure => $ensure,
       owner  => 'root',
       group  => 'root',
-      notify => Service[$datadog_agent::params::service_name]
+      notify => Service[$datadog_agent::params::service_name],
     }
 
     concat::fragment { "${target}-header":
       target  => $target,
       content => "init_config:\n\ninstances:\n",
       order   => '00',
-      notify  => Service[$datadog_agent::params::service_name]
+      notify  => Service[$datadog_agent::params::service_name],
     }
   }
 
@@ -31,6 +31,6 @@ define profile::datadog_check(
     target  => $target,
     source  => $source,
     content => $content,
-    notify  => Service[$datadog_agent::params::service_name]
+    notify  => Service[$datadog_agent::params::service_name],
   }
 }

--- a/dist/profile/manifests/datadog_pluginsite_check.pp
+++ b/dist/profile/manifests/datadog_pluginsite_check.pp
@@ -4,24 +4,24 @@
 #
 class profile::datadog_pluginsite_check (
   $sites = [],
-){
+) {
   require datadog_agent
 
   file { 'plugins_api_check.py':
-    ensure => present,
+    ensure => file,
     source => "puppet:///modules/${module_name}/datadog_pluginsite_check/plugins_api_check.py",
     path   => '/etc/datadog-agent/checks.d/plugins_api_check.py',
     owner  => $::datadog_agent::params::dd_user,
     group  => $::datadog_agent::params::dd_group,
-    notify => Service[$datadog_agent::params::service_name]
+    notify => Service[$datadog_agent::params::service_name],
   }
 
   file { 'plugins_api_check.yaml':
-    ensure  => present,
+    ensure  => file,
     content => template("${module_name}/datadog_pluginsite_check/plugins_api_check.yaml.erb"),
     owner   => $::datadog_agent::params::dd_user,
     group   => $::datadog_agent::params::dd_group,
-    path    => "${::datadog_agent::params::conf6_dir}/plugins_api_check.yaml",
-    notify  => Service[$datadog_agent::params::service_name]
+    path    => "${facts['datadog_agent::params::conf_dir']}/plugins_api_check.yaml",
+    notify  => Service[$datadog_agent::params::service_name],
   }
 }

--- a/updatecli/weekly.d/puppet-modules/apt.yaml
+++ b/updatecli/weekly.d/puppet-modules/apt.yaml
@@ -16,7 +16,7 @@ scms:
 sources:
   latestVersion:
     kind: githubrelease
-    name: Get the latest puppetlabe/apt module version
+    name: Get the latest puppetlab/apt module version
     spec:
       owner: puppetlabs
       repository: puppetlabs-apt

--- a/updatecli/weekly.d/puppet-modules/datadog.yaml
+++ b/updatecli/weekly.d/puppet-modules/datadog.yaml
@@ -1,5 +1,5 @@
 ---
-title: Bump the Docker Puppet Module
+title: Bump the Datadog Puppet Module
 
 scms:
   default:
@@ -16,10 +16,10 @@ scms:
 sources:
   latestVersion:
     kind: githubrelease
-    name: Get the latest puppetlab/docker module version
+    name: Get the latest datadog/datadog_agent module version
     spec:
-      owner: puppetlabs
-      repository: puppetlabs-docker
+      owner: DataDog
+      repository: puppet-datadog-agent
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionfilter:
@@ -30,19 +30,19 @@ conditions:
     kind: shell
     disablesourceinput: true
     spec:
-      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppetlabs-docker-{{ source "latestVersion" }}.tar.gz
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/datadog-datadog_agent-{{ source "latestVersion" }}.tar.gz
 
 targets:
   puppetfile:
-    name: "Update Puppetfile with the latest docker module version"
+    name: "Update Puppetfile with the latest datadog module version"
     kind: file
     sourceid: latestVersion
     spec:
       file: Puppetfile
       matchpattern: >
-        mod 'puppetlabs/docker'(.*)
+        mod 'datadog/datadog_agent'(.*)
       replacepattern: >
-        mod 'puppetlabs/docker', '{{ source "latestVersion" }}'
+        mod 'datadog/datadog_agent', '{{ source "latestVersion" }}'
     scmid: default
 
 pullrequests:


### PR DESCRIPTION
This PR fixes an error messages that was caused by #2198 when we bumped datadog's puppet module.
This error message was blocking the updatesite/pkg provisionning with vagrant.

The fix is described in the Datadog puppet module's upgrade guide at https://forge.puppet.com/modules/datadog/datadog_agent/3.16.0#upgrading:

> `conf_dir` and `conf6_dir` become `conf_dir` for all Agent versions.

It also adds an updatecli manifest to track the datadog module version.
