### PR TITLE
Revert "feat(ci.jenkins.io) enable spot instances for EC2 VM agents (INFRA-3101)"

### DIFF
--- a/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
+++ b/dist/profile/templates/buildmaster/casc/clouds.yaml.erb
@@ -127,9 +127,6 @@ jenkins:
         remoteAdmin: "<%= @agents_setup[agent["os"].to_s]["remoteAdmin"] %>"
         remoteFS: "<%= @agents_setup[agent["os"].to_s]["agentDir"] %>"
         securityGroups: "ci-agents"
-        spotConfig:
-          fallbackToOndemand: true
-          useBidPrice: false
         stopOnTerminate: false
         t2Unlimited: false
         tags:


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#1956

[Disable “spot” for highmem EC2 instances (so we can check the impact on budget and confirm that spot is the major culprit)](https://github.com/jenkins-infra/helpdesk/issues/3031#issuecomment-1177498315)

Ref: https://github.com/jenkins-infra/helpdesk/issues/3031