### PR TITLE
fix(ci.jenkins.io) make arm64 VM EC2 agents exclusives

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -255,7 +255,7 @@ profile::buildmaster::cloud_agents:
           architecture: "arm64"
           labels:
             - arm64docker
-            - linux
+            - arm64linux
           useAsMuchAsPosible: false
   azure-vm-agents:
     azureCredentialsId: "azure-credentials"


### PR DESCRIPTION
Closes https://github.com/jenkins-infra/helpdesk/issues/3039 by ensuring that the label `linux` only executed on Intel machines for now.