### PR TITLE
chore: remove groovy plugin from cert.ci.jenkins.io jcasc

### DIFF
--- a/dist/profile/templates/cert.ci.jenkins.io/tools.yaml.erb
+++ b/dist/profile/templates/cert.ci.jenkins.io/tools.yaml.erb
@@ -3,14 +3,6 @@ tool:
   git:
     installations:
     - name: "jgit"
-  groovy:
-    installations:
-    - name: "groovy-3.0.6"
-      properties:
-      - installSource:
-          installers:
-          - groovyInstaller:
-              id: "3.0.6"
   jdk:
     installations:
     - name: "jdk-8"


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3036