### PR TITLE
hotfix: remove groovy plugin on cert.ci from puppet too

### DIFF
--- a/hieradata/clients/cert-ci.yaml
+++ b/hieradata/clients/cert-ci.yaml
@@ -66,7 +66,6 @@ profile::jenkinscontroller::plugins:
   # Pipeline steps
   - build-timeout
   - config-file-provider
-  - groovy # Provides groovy tool in some pipelines
   - junit-realtime-test-reporter
   - pipeline-stage-step # Used in mavenBuild
   - timestamper


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/jenkins-infra/pull/2271
Ref: https://github.com/jenkins-infra/helpdesk/issues/3036