### PR TITLE
chore: bump Puppet version to latest 6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'parallel_tests'
 # Needed for integration tests
 gem 'beaker'
 gem 'puppet-lint'
-gem 'puppet', '~> 6.23.0' # Version of the puppetmaster in production
+gem 'puppet', '6.27.0' # Version of the puppetmaster in production
 gem 'r10k'
 gem 'puppetlabs_spec_helper'
 gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'parallel_tests'
 # Needed for integration tests
 gem 'beaker'
 gem 'puppet-lint'
-gem 'puppet', '6.27.0' # Version of the puppetmaster in production
+gem 'puppet', '6.28.0' # Version of the puppetmaster in production
 gem 'r10k'
 gem 'puppetlabs_spec_helper'
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     pry-byebug (3.8.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    puppet (6.23.0)
+    puppet (6.27.0)
       concurrent-ruby (~> 1.0)
       deep_merge (~> 1.0)
       facter (> 2.0.1, < 5)
@@ -207,7 +207,7 @@ DEPENDENCIES
   hiera-eyaml
   parallel_tests
   pry
-  puppet (~> 6.23.0)
+  puppet (= 6.27.0)
   puppet-lint
   puppetlabs_spec_helper
   r10k

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    beaker (4.26.0)
+    beaker (4.38.0)
       beaker-hostgenerator
+      ed25519 (~> 1.0)
       hocon (~> 1.0)
       in-parallel (~> 0.1)
       inifile (~> 3.0)
       minitar (~> 0.6)
       minitest (~> 5.4)
-      net-scp (~> 1.2)
+      net-scp (>= 1.2, < 4.0)
       net-ssh (>= 5.0)
       open_uri_redirections (~> 0.2.1)
-      pry-byebug (~> 3.6)
-      rb-readline (~> 0.5.3)
+      rexml
       rsync (~> 1.0.9)
       stringify-hash (~> 0.0)
       thor (>= 1.0.1, < 2.0)
@@ -36,11 +36,12 @@ GEM
     debugger-ruby_core_source (1.3.8)
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
-    erubi (1.10.0)
-    facter (4.2.10)
+    ed25519 (1.3.0)
+    erubi (1.11.0)
+    facter (4.2.11)
       hocon (~> 1.3)
       thor (>= 1.0.1, < 2.0)
-    faraday (1.10.0)
+    faraday (1.10.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -78,7 +79,7 @@ GEM
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2)
       locale
-    hiera (3.9.0)
+    hiera (3.10.0)
     hiera-eyaml (3.3.0)
       highline
       optimist
@@ -112,10 +113,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.8.0)
-      byebug (~> 11.0)
-      pry (~> 0.10)
-    puppet (6.27.0)
+    puppet (6.28.0)
       concurrent-ruby (~> 1.0)
       deep_merge (~> 1.0)
       facter (> 2.0.1, < 5)
@@ -155,7 +153,7 @@ GEM
       multi_json (~> 1.10)
       puppet_forge (>= 2.3.0)
     rake (13.0.6)
-    rb-readline (0.5.5)
+    rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -171,7 +169,7 @@ GEM
     rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-puppet (2.11.1)
+    rspec-puppet (2.12.0)
       rspec
     rspec-support (3.11.0)
     rspec_junit_formatter (0.5.1)
@@ -186,7 +184,7 @@ GEM
       specinfra (~> 2.72)
     sfl (2.3)
     singleton (0.1.1)
-    specinfra (2.83.2)
+    specinfra (2.83.3)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
@@ -207,7 +205,7 @@ DEPENDENCIES
   hiera-eyaml
   parallel_tests
   pry
-  puppet (= 6.27.0)
+  puppet (= 6.28.0)
   puppet-lint
   puppetlabs_spec_helper
   r10k

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,9 +64,9 @@ RSpec.configure do |c|
     # Needed for conditionals like:
     # <https://github.com/saz/puppet-sudo/blob/v3.0.6/manifests/init.pp#L147>
     # Get versions matrix at https://puppet.com/docs/puppet/7/platform_lifecycle.html#about_agent-platform-releases
-    :puppetversion => '6.27.1',
-    :facterversion => '3.14.23', # Must be the version installed with the puppet-agent package
-    :pe_version => '6.19.0',
+    :puppetversion => '6.28.0',
+    :facterversion => '3.14.24', # Must be the version installed with the puppet-agent package
+    :pe_version => '6.27.1',
     :pe_server_version => '2019.8.11',
     :apt_update_last_success => '1657469796',
     :vagrant => false,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,10 +63,11 @@ RSpec.configure do |c|
     :is_pe => true,
     # Needed for conditionals like:
     # <https://github.com/saz/puppet-sudo/blob/v3.0.6/manifests/init.pp#L147>
-    :puppetversion => '6.0.4', # 6.23.0 on some machines
-    :facterversion => '3.12.1', # 3.14.18 on some machines
-    :pe_version => '6.0.4',
-    :pe_server_version => '2019.0.1',
+    # Get versions matrix at https://puppet.com/docs/puppet/7/platform_lifecycle.html#about_agent-platform-releases
+    :puppetversion => '6.27.1',
+    :facterversion => '3.14.23', # Must be the version installed with the puppet-agent package
+    :pe_version => '6.19.0',
+    :pe_server_version => '2019.8.11',
     :apt_update_last_success => '1657469796',
     :vagrant => false,
     :staging_http_get => 'curl',


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3056#issuecomment-1185321082


Ref. https://puppet.com/docs/puppet/7/platform_lifecycle.html#about_agent-platform-releases



[edit] bumped to 6.28.0