### PR TITLE
fix(vagrant) ensure that LVM volumes are created without requiring udev 

### DIFF
--- a/dist/profile/manifests/census.pp
+++ b/dist/profile/manifests/census.pp
@@ -13,16 +13,6 @@ class profile::census (
 
   $docroot = "${home_dir}/census"
 
-  if str2bool($facts['vagrant']) {
-    # during serverspec test, fake /dev/xvdb by a loopback device
-    exec { 'create /tmp/xvdb':
-      command => 'dd if=/dev/zero of=/tmp/xvdb bs=1M count=16; losetup /dev/loop0; losetup /dev/loop0 /tmp/xvdb',
-      unless  => 'test -f /tmp/xvdb',
-      path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-      before  => Physical_volume['/dev/loop0'],
-    }
-  }
-
   package { 'lvm2':
     ensure => present,
   }

--- a/dist/profile/manifests/usage.pp
+++ b/dist/profile/manifests/usage.pp
@@ -34,18 +34,6 @@ class profile::usage (
   # This path hard-coded in hiera
   $home_dir = '/srv/bigger-usage'
 
-  ## Volume setup
-  ############################
-  if str2bool($facts['vagrant']) {
-    # during serverspec test, fake /dev/xvdb by a loopback device
-    exec { 'create /tmp/xvdb':
-      command => 'dd if=/dev/zero of=/tmp/xvdb bs=1M count=16; losetup /dev/loop0; losetup /dev/loop0 /tmp/xvdb',
-      unless  => 'test -f /tmp/xvdb',
-      path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-      before  => Physical_volume['/dev/loop0'],
-    }
-  }
-
   package { 'lvm2':
     ensure => present,
   }

--- a/dist/profile/manifests/vagrant.pp
+++ b/dist/profile/manifests/vagrant.pp
@@ -6,7 +6,85 @@ class profile::vagrant {
 
   # Vagrant defines a default user `vagrant` which should have passwordless sudo permission
   sudo::conf { 'vagrant':
+    ensure   => file,
     priority => '10',
     content  => 'vagrant ALL=(ALL) NOPASSWD: ALL',
   }
+
+  ######
+  # The following code block is a hack to ensure that LVM volumes are created without any errors in the Vagrant environment.
+  # Challenge comes from LVM requiring `udev` to discover and manage devices. But udev is not working inside a docker container (other than sharing the host udev).
+  # The trick is to run the custom lv commands and then delegate to the lvm the missing part
+  # Main point is the "lvcreate" that should use the flag `--zero n` but the puppet module does not allow it alas.
+  lookup('lvm::volume_groups').each | $vg_name, $vg_config| {
+    # Create an array with the list of specified logicial volumes sizes in bytes
+    # Ref. https://puppet.com/docs/puppet/6/function.html#reduce
+    $lv_sizes_in_byte = $vg_config['logical_volumes'].reduce([]) |$memo, $value| {
+      $memo + to_bytes($value[1]['size'])
+    }
+
+    # Calculate the sum of all these sizes from the array
+    $total_lv_size_in_bytes = $lv_sizes_in_byte.reduce |$memo, $value| { $memo + $value }
+
+    # How much PV to create ?
+    $pv_count = $vg_config['physical_volumes'].size
+
+    # Size per PV. Adding 1 Mb margin per PV
+    $pv_size_in_megabyte = (($total_lv_size_in_bytes / $pv_count) / 1024 / 1024) + 1
+
+    $vg_config['physical_volumes'].each | $index, $loopback_device| {
+      $dummy_device = "/dev/dummy${index}"
+
+      exec { "create ${dummy_device}":
+        command => "dd if=/dev/zero of=${dummy_device} bs=1M count=${pv_size_in_megabyte}",
+        unless  => "test -f ${dummy_device}",
+        path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+      }
+
+      exec { "setup ${dummy_device} dummy device to ${loopback_device} loop device":
+        # dmsetup is used to "force" remove the loopback
+        command => "dmsetup remove data-census || true && losetup --detach-all && losetup --partscan ${loopback_device} ${dummy_device}",
+        unless  => "losetup --associated ${dummy_device} | grep '${loopback_device}'",
+        path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+        require => Exec["create ${dummy_device}"],
+      }
+
+      # The lvm puppet module does not provide a 'disable zeroing' feature that would avoid requiring udev in the vagrant docker-container
+      exec { "setup ${loopback_device} as a physical volume":
+        command => "pvcreate ${loopback_device}",
+        unless  => "pvscan | grep ${loopback_device}",
+        path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+        require => Exec["setup ${dummy_device} dummy device to ${loopback_device} loop device"],
+        before  => Exec["setup volume group ${vg_name}"],
+      }
+    }
+
+    # Create Volume Group
+    $pv_list = join($vg_config['physical_volumes'], ' ')
+    exec { "setup volume group ${vg_name}":
+      command => "vgcreate ${vg_name} ${pv_list}",
+      unless  => "vgscan | grep ${vg_name}",
+      path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+      notify  => Exec['ensure vg nodes are created'],
+    }
+
+    # Create Logical Volumes
+    $vg_config['logical_volumes'].each | $lv_name, $lv_config| {
+      exec { "setup logical volume ${lv_name}":
+        # Note the `--zero n` flag: it disable zeroing blocks to avoid requiring udev (nifty part)
+        command => "lvcreate --name ${lv_name} --size ${lv_config['size']} --zero n data",
+        unless  => "lvscan | grep ${lv_name}",
+        path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+        require => Exec["setup volume group ${vg_name}"],
+        before  => Exec['ensure vg nodes are created'],
+      }
+    }
+
+    # To avoid the mkfs errors 'The file <whatever> does not exist and no size was specified'
+    exec { 'ensure vg nodes are created':
+      command => 'vgscan --mknodes',
+      path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+    }
+  }
+  ###### End custom hack LVM for Docker
 }

--- a/dist/profile/manifests/vagrant.pp
+++ b/dist/profile/manifests/vagrant.pp
@@ -16,7 +16,7 @@ class profile::vagrant {
   # Challenge comes from LVM requiring `udev` to discover and manage devices. But udev is not working inside a docker container (other than sharing the host udev).
   # The trick is to run the custom lv commands and then delegate to the lvm the missing part
   # Main point is the "lvcreate" that should use the flag `--zero n` but the puppet module does not allow it alas.
-  lookup('lvm::volume_groups').each | $vg_name, $vg_config| {
+  lookup('lvm::volume_groups', undef, undef, {}).each | $vg_name, $vg_config| {
     # Create an array with the list of specified logicial volumes sizes in bytes
     # Ref. https://puppet.com/docs/puppet/6/function.html#reduce
     $lv_sizes_in_byte = $vg_config['logical_volumes'].reduce([]) |$memo, $value| {

--- a/vagrant-docker/Dockerfile
+++ b/vagrant-docker/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
   curl \
   iproute2 \
   locales \
+  lvm2 \
   openssh-server \
   passwd \
   rsyslog \


### PR DESCRIPTION
This PRs allows the `lvm` module to be usable with the Vagrant Docker boxes.

The main issue comes from the fact that `udev` does not workin inside a container (ref. https://lwn.net/Articles/676831/).
Not having `udev` means that a lot of the LVM commands fails while expecting it (udev device filter rules, zeroing volumes, etc.).

Since the `lvm` module that we use is:

. Not recent (0.3.2 version)
. Hard to hack

I've set up this method that defines custom `exec` resources to run a set of shell commands (with idempotency to avoid re)fromatting on each provisionning of the container).
The scope is only the profile `vagrant`: all the "dummy devices set up to loopbacks" had been removed from production profiles and moved into the vagrant profile.


The following "nifty tricks" had been used to ensure it's successfull:

- When creating a logical volume, the flag `--zero n` is provided to disable the blocks zero-ing, removing the need for `udev` for this step
  - Since the logical volumes are not cleared due to this flag, the addition command `vgscan -mknodes` is used to initialize the volume groups 's nodes "as if" they were zero-ed

- The "dummy devices" which are mapped to the `/dev/loopXX` virtual loopbacks had been renamed to `/dev/dummyXX` to support multiples instances and follow usual device paths

- The size of the dummy devices is calculated by parsing the hieradata, calculating the total specified size for the LVs and divided by the amount of specified devices (plus a margin of 1M, the size of a block)

