### PR TITLE
chore(apt) bump puppet module for lvm to 1.4.0 + track its version with updatecli

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -46,7 +46,7 @@ mod 'saz-ssh', '5.0.0'
 # Dependency
 mod 'puppetlabs-sshkeys_core', '1.0.2'
 
-mod 'puppetlabs-lvm', '0.3.2'
+mod 'puppetlabs-lvm', '1.4.0'
 mod 'datadog-datadog_agent', '3.17.0'
 
 # Used for grabbing certificates for jenkins.io

--- a/updatecli/weekly.d/puppet-modules/lvm.yaml
+++ b/updatecli/weekly.d/puppet-modules/lvm.yaml
@@ -1,0 +1,57 @@
+---
+title: Bump the LVM Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppetlabs-lvm module version
+    spec:
+      owner: puppetlabs
+      repository: puppetlabs-lvm
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppetlabs-lvm-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest lvm module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppetlabs-lvm'(.*)
+      replacepattern: >
+        mod 'puppetlabs-lvm', '{{ source "latestVersion" }}'
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - puppetfile
+    spec:
+      labels:
+        - puppet-module
+        - dependencies


### PR DESCRIPTION
This PR tracks the version of the puppet-lvm module and bumps it from `0.3.2` to `1.4.0` (latest).

It blocks https://github.com/jenkins-infra/jenkins-infra/pull/2275.


⚠️ Don't forget to deploy this change carefully (disable all puppet agent and then run a noop operation for each machine) as per the runbooks instructions.