### PR TITLE
chore(updatecli) fix the manifest of the puppet module cron with the correct GitHub repository

### DIFF
--- a/updatecli/weekly.d/puppet-modules/cron.yaml
+++ b/updatecli/weekly.d/puppet-modules/cron.yaml
@@ -18,8 +18,8 @@ sources:
     kind: githubrelease
     name: Get the latest puppetlabs-cron module version
     spec:
-      owner: voxpupuli
-      repository: puppet-cron
+      owner: puppetlabs
+      repository: puppetlabs-cron_core
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionfilter:


### PR DESCRIPTION
This PR closes and fixes https://github.com/jenkins-infra/jenkins-infra/pull/2287 which as mistakenly opened due to an incorrect repository being used as source.