### PR TITLE
feat(oracle.updates.jenkins.io): add rsync to oracle.update.jenkins.io

### DIFF
--- a/dist/profile/manifests/updatesoracle.pp
+++ b/dist/profile/manifests/updatesoracle.pp
@@ -1,0 +1,45 @@
+#
+# Defines specifications for the oracle VM for updates.jenkins.io (oracle.updates.jenkins.io)
+#
+
+class profile::updatesoracle (
+  Array  $rsync_hosts_allow           = ['pkg.origin.jenkins.io'], # only pkg can update this VM with rsync
+  String $rsynched_dir                = '/var/www/updates.jenkins.io',
+  String $rsync_motd_file             = '/etc/jenkins.motd',
+) {
+
+  # Install Rsync
+  #
+  # Rsync is needed to synchronise data from pkg machine : updates.jenkins.io to this one (oracle.updates.jenkins.io)
+  #
+  package { 'rsync':
+    ensure => present,
+  }
+
+  file { '/etc/rsyncd.conf':
+    ensure  => file,
+    content => template("${module_name}/oracle.updates.jenkins.io/rsyncd.conf.erb"),
+    owner   => 'root',
+    mode    => '0600',
+    require => Package['rsync'],
+  }
+
+  file { $rsync_motd_file:
+    ensure  => file,
+    source  => "puppet:///modules/${module_name}/updates/jenkins.motd",
+    owner   => 'root',
+    mode    => '0644',
+    require => Package['rsync'],
+  }
+
+  service { 'rsync':
+    ensure => running,
+    enable => true,
+  }
+
+  firewall { '100 all inbound rsync':
+    proto  => 'tcp',
+    dport  => '873',
+    action => 'accept',
+  }
+}

--- a/dist/profile/templates/oracle.updates.jenkins.io/rsyncd.conf.erb
+++ b/dist/profile/templates/oracle.updates.jenkins.io/rsyncd.conf.erb
@@ -1,0 +1,36 @@
+# /etc/rsyncd: configuration file for
+rsync daemon mode
+
+# See rsyncd.conf man page for more options.
+
+# configuration example:
+
+uid = nobody
+gid = nogroup
+use chroot = yes
+max connections = 0
+pid file = /var/run/rsyncd.pid
+exclude = lost+found/
+transfer logging = yes
+log file = /var/log/rsyncd.log
+ignore nonreadable = yes
+dont compress   = *.gz *.tgz *.zip *.z *.Z *.rpm *.deb *.bz2
+port = 873
+motd file = <%= @rsync_motd_file %>
+
+# Timeout in seconds
+timeout = 300
+
+# Any attempted uploads will fail
+read only = true
+
+# Downloads will be possible if file permissions on the daemon side allow them
+write only = false
+
+<% unless @rsync_hosts_allow.empty? -%>
+hosts allow = <%= @rsync_hosts_allow.join(',') %>
+<% end -%>
+
+[updates.jenkins]
+path = <%= @rsynched_dir %>
+comment = "Updates Oracle Mirror"

--- a/dist/role/manifests/updates.pp
+++ b/dist/role/manifests/updates.pp
@@ -3,6 +3,7 @@
 class role::updates {
   include profile::base
   include profile::updatesite
+  include profile::updatesoracle
 
   package { 'lvm2':
     ensure => present,


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2649

specifically : https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1122478516

add the rsync daemon to populate the VM with pkg updates.jenkins.io data

complementary of https://github.com/jenkins-infra/jenkins-infra/pull/2296