### PR TITLE
feat(trusted): for agent-1 add jdk 11 path and ssh key verification strategy as code

### DIFF
--- a/dist/profile/templates/trusted.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/trusted.ci.jenkins.io/agents.yaml.erb
@@ -12,10 +12,13 @@ jenkins:
         ssh:
           credentialsId: "0e73a07a-5f72-4a90-bcce-5dcfcd10aea8"
           host: "172.31.5.190"
+          javaPath: "/opt/jdk-11/bin/java"
           maxNumRetries: 0
           port: 22
           retryWaitTime: 0
-          sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+          sshHostKeyVerificationStrategy:
+            manuallyTrustedKeyVerificationStrategy:
+              requireInitialManualTrust: false
       mode: EXCLUSIVE
       name: "agent-1"
       numExecutors: 2


### PR DESCRIPTION
as per https://github.com/jenkins-infra/update-center2/pull/629/files
needed to update the puppet configuration as code for the agent-1 to use the jdk-11 path and a new verification strategy for ssh key.