### PR TITLE
Remove `basic-branch-build-strategies` from `cert.ci`

### DIFF
--- a/hieradata/clients/cert-ci.yaml
+++ b/hieradata/clients/cert-ci.yaml
@@ -59,7 +59,6 @@ profile::jenkinscontroller::plugins:
   - matrix-auth
 
   # Basic Pipeline configuration
-  - basic-branch-build-strategies
   - github-branch-source
   - inline-pipeline
   - pipeline-groovy-lib


### PR DESCRIPTION
Jobs are already reconfigured to make this obsolete. Remove from enforced config to allow later uninstallation once we've determined we really don't need it.