### PR TITLE
fix(ci.jenkins.io, trusted.jenkins.io) ensure that all cloud agents -except EC2 Windows- uses JDK11 for agent process

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -33,7 +33,8 @@ jenkins:
         installDocker: false
         installGit: false
         installMaven: false
-        javaPath: "java"
+        javaPath: "<%= @agents_setup[agent["os"].to_s]["agentJavaBin"] %>"
+        jvmOptions: "<%= @agents_setup[agent["os"].to_s]["agentJavaOpts"] %>"
         labels: "<%= agent["os"] %> <%= agent["architecture"] %> azure vm <%= agent["labels"].join(' ') %>"
         location: "<%= agent["location"] %>"
         noOfParallelJobs: 1
@@ -82,6 +83,12 @@ jenkins:
         retentionStrategy: "containerOnce"
         rootFs: "<%= @agents_setup[agent["os"].to_s]["agentDir"] %>"
         timeout: 60
+        # Please note that envVars are specified differently than permanent or Kubernetes agents
+        envVars:
+          - key: "JENKINS_JAVA_OPTS"
+            value: "<%= @agents_setup[agent["os"].to_s]["agentJavaOpts"] %>"
+          - key: "JENKINS_JAVA_BIN"
+            value: "<%= @agents_setup[agent["os"].to_s]["agentJavaBin"] %>"
       <%- end -%>
   <%- end -%>
 <%- end -%>
@@ -103,6 +110,10 @@ jenkins:
         amiOwners: "200564066411"
         amiType:
           unixData:
+            <%# Windows VM agent are not supported yet: https://issues.jenkins.io/browse/JENKINS-69304 %>
+            <%- if agent["os"].to_s != 'windows' -%>
+            slaveCommandPrefix: "PATH=<%= scope.call_function('dirname', [@agents_setup["ubuntu"]["agentJavaBin"]]) %>:${PATH}"
+            <%- end -%>
             sshPort: "22"
         associatePublicIp: true
         connectBySSHProcess: false
@@ -116,6 +127,7 @@ jenkins:
         idleTerminationMinutes: "<%= agent["idleTerminationMinutes"] %>"
         <%- end -%>
         instanceCapStr: "<%= agent["maxInstances"] %>"
+        jvmopts: "<%= @agents_setup[agent["os"].to_s]["agentJavaOpts"] %>"
         labelString: "<%= agent["os"] %> <%= agent["architecture"] %> aws ec2 vm <%= agent["labels"].join(' ') %>"
         launchTimeoutStr: "1000"
         maxTotalUses: 1 # Throw away the VMs after a build
@@ -168,10 +180,14 @@ jenkins:
         - containers:
           - alwaysPullImage: false
             image: "<%= @agent_images["container_images"][agent["name"]] %>"
+            # Please note that envVars are specified differently than permanent or ACI agents
             envVars:
               - envVar:
-                   key: "JENKINS_JAVA_OPTS"
-                   value: "-XX:+PrintCommandLineFlags"
+                  key: "JENKINS_JAVA_OPTS"
+                  value: "<%= @agents_setup["ubuntu"]["agentJavaOpts"] %>"
+              - envVar:
+                  key: "JENKINS_JAVA_BIN"
+                  value: "<%= @agents_setup["ubuntu"]["agentJavaBin"] %>"
             livenessProbe:
               failureThreshold: 0
               initialDelaySeconds: 0
@@ -188,7 +204,7 @@ jenkins:
             workingDir: "/home/jenkins"
           label: "container kubernetes <%= k8s_name %> <%= agent["labels"] ? agent["labels"].join(' ') : '' %>"
           name: "<%= agent["name"] %>"
-           <%- if agent["imagePullSecrets"] -%>
+          <%- if agent["imagePullSecrets"] -%>
           imagePullSecrets:
           - name: "<%= agent["imagePullSecrets"] %>"
           <%- end -%>

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -177,15 +177,19 @@ profile::jenkinscontroller::plugins:
   - beer
 profile::jenkinscontroller::agents_setup:
   windows:
-    agentDir: 'C:\\Jenkins'
-    tempDir: 'C:\\\\temp'
+    agentDir: 'C:/Jenkins'
+    tempDir: 'C:/temp'
     remoteAdmin: Administrator
-    osDiskSize: "128"
+    osDiskSize: 128
+    agentJavaBin: 'C:/tools/jdk-11/bin/java'
+    agentJavaOpts: '-XX:+PrintCommandLineFlags'
   ubuntu:
     agentDir: "/home/jenkins"
     remoteAdmin: jenkins
     tempDir: "/tmp"
     osDiskSize: 90
+    agentJavaBin: '/opt/jdk-11/bin/java'
+    agentJavaOpts: '-XX:+PrintCommandLineFlags'
 profile::jenkinscontroller::agent_images:
   ec2_amis:
     ubuntu-amd64: "ami-0efe0668ca5417fa3"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3090