### PR TITLE
fix(ci.jenkins.io) set maven-11* container templates to use the default java installation

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -184,10 +184,10 @@ jenkins:
             envVars:
               - envVar:
                   key: "JENKINS_JAVA_OPTS"
-                  value: "<%= @agents_setup["ubuntu"]["agentJavaOpts"] %>"
+                  value: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @agents_setup["ubuntu"]["agentJavaOpts"] %>"
               - envVar:
                   key: "JENKINS_JAVA_BIN"
-                  value: "<%= @agents_setup["ubuntu"]["agentJavaBin"] %>"
+                  value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @agents_setup["ubuntu"]["agentJavaBin"] %>"
             livenessProbe:
               failureThreshold: 0
               initialDelaySeconds: 0

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -103,6 +103,7 @@ profile::jenkinscontroller::cloud_agents:
             - jdk11
           cpus: 4
           memory: 8
+          agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
           imagePullSecrets: dockerhub-credential
         - name: jnlp-maven-17
           labels:
@@ -188,6 +189,7 @@ profile::jenkinscontroller::cloud_agents:
             - jdk11
           cpus: 4
           memory: 8
+          agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
           imagePullSecrets: dockerhub-credential
         - name: jnlp-maven-17
           labels:
@@ -343,6 +345,7 @@ profile::jenkinscontroller::cloud_agents:
           command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
           cpus: 4
           memory: 8
+          agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
           labels:
             - maven-11-windows
 # These are plugins we need in our ci environment


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3096

The goal of this PR is to set up an exception for the maven-11 (linux and windows) containers to use the default `java` binary (from the default PATH) like it was before #2318 .

Core reason is that the JDK11 container images directly inherits from the `maven` image which does not have the same JDK installation pattern as us in `/opt`.