### PR TITLE
feat(puppetmaster) set r10k to ignore branches created by updatecli to avoid weird HTTP/500 errors when changing puppet modules

### DIFF
--- a/dist/profile/files/r10k/r10k.yaml
+++ b/dist/profile/files/r10k/r10k.yaml
@@ -6,6 +6,9 @@ sources:
   infra:
     remote: 'https://github.com/jenkins-infra/jenkins-infra.git'
     basedir: '/etc/puppetlabs/code/environments'
+    ignore_branch_prefixes:
+      # Ignore branches created by updatecli
+      - 'updatecli_'
 
 git:
   provider: 'shellgit'


### PR DESCRIPTION
Tested manually with success on the puppetmaster