### PR TITLE
Switch s390x agent to exclusive

### DIFF
--- a/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
+++ b/dist/profile/templates/azure.ci.jenkins.io/agents.yaml.erb
@@ -43,6 +43,7 @@ jenkins:
             manuallyProvidedKeyVerificationStrategy:
               key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCYwX3Fu4fWEb9hPlan3FsiUsZoCsMD7CMqFNT/+Uh11HhvKU5ZFiF3sGNI7FrhNNbqBFd0HnS1t3zIkP3FFlKToSTrkcXPUyw+svFf5YbPbDxQUNE0kclTUsERzC3GNB5eXUlyNxCiGksqGtinXgknF2Z5cOO8osODP7ddRc6L3H4gvDi0/smz9QukZB2N0FqBJ3EZGbv0X9V3iwRu6Cu9lhcl/ue5fuIjKAgGzGQgWgCEg0k9xkK0OmxyJalI0eiqBRbdES/bXkkxp+4TQNOsxN/ZrZqxtlN7o9Fq9y+dp7xQFEoivSAjn6WQ6izjkMGKon7rcFJ4t4g6FJoQYv2Z"
       name: "s390x-agent"
+      mode: EXCLUSIVE
       nodeProperties:
       - envVars:
           env:


### PR DESCRIPTION
The SSH connection is timing out but node requests that don't specify a label try use this agent first, I had an ATH build that waited ages for this.

The PPC agent already uses the exclusive mode

(note: already manually changed)