### PR TITLE
fix(puppet-stdlib) switch from deprecated `validate_*` stdlib methods to data types

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -4,7 +4,7 @@ forge 'http://forge.puppetlabs.com'
 mod 'puppet-r10k', '6.8.0'
 
 # Deps for zack/r10k
-mod 'puppetlabs-stdlib', '5.2.0'
+mod 'puppetlabs-stdlib', '8.4.0'
 
 # Deps for apachelogcompressor
 mod 'puppetlabs-ruby', '1.0.1'

--- a/Puppetfile
+++ b/Puppetfile
@@ -40,7 +40,7 @@ mod 'puppetlabs-apt', '8.5.0'
 # Apache and its dependencies
 mod 'puppetlabs-apache', '7.0.0'
 
-mod 'puppetlabs-concat', '5.2.0'
+mod 'puppetlabs-concat', '7.2.0'
 
 # For managing server-side ssh configuration options
 mod 'saz-ssh', '5.0.0'

--- a/dist/profile/manifests/apachemisc.pp
+++ b/dist/profile/manifests/apachemisc.pp
@@ -2,8 +2,9 @@
 # Misc. apache settings
 #
 class profile::apachemisc (
-  $ssh_enabled = false,
+  Boolean $ssh_enabled = false,
 ) {
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include apache
   # log rotation setting lives in another module
   include apachelogcompressor

--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -2,14 +2,14 @@
 # Defines an archive server for serving all the archived historical releases
 #
 class profile::archives (
-  Array  $rsync_hosts_allow           = ['localhost'],
-  String $archives_dir                = '/srv/releases',
-  String $rsync_motd_file             = '/etc/jenkins.motd',
-  String $source_mirror_endpoint      = 'ftp-osl.osuosl.org',
-  String $source_mirror_directory     = '/jenkins/',
-  Array  $ssh_authorized_keys         = [],
+  Array                $rsync_hosts_allow           = ['localhost'],
+  Stdlib::Absolutepath $archives_dir                = '/srv/releases',
+  Stdlib::Absolutepath $rsync_motd_file             = '/etc/jenkins.motd',
+  Stdlib::Host         $source_mirror_endpoint      = 'ftp-osl.osuosl.org',
+  Stdlib::Absolutepath $source_mirror_directory     = '/jenkins/',
+  Array                $ssh_authorized_keys         = [],
 ) {
-  include stdlib
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include profile::apachemisc
   include profile::letsencrypt
 
@@ -48,8 +48,6 @@ class profile::archives (
 
   if $ssh_authorized_keys.size > 0 {
     $ssh_authorized_keys.each | Hash $ssh_authorized_key | {
-      validate_hash($ssh_authorized_key)
-
       unless 'id' in $ssh_authorized_key {
         notice('"id" is required for the authorized key')
       }

--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -1,11 +1,11 @@
 # Jenkins build agent connectable via SSH
 class profile::buildagent (
-  $home_dir         = '/home/jenkins',
-  $docker           = true,
-  $trusted_agent    = false,
-  $ssh_keys         = undef,
+  Stdlib::Absolutepath $home_dir         = '/home/jenkins',
+  Boolean              $docker           = true,
+  Boolean              $trusted_agent    = false,
+  Hash                 $ssh_keys         = undef,
 ) {
-  include stdlib
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include limits
 
   $user = 'jenkins'
@@ -128,7 +128,6 @@ class profile::buildagent (
   }
 
   if $ssh_keys {
-    validate_hash($ssh_keys)
     $private_keys_defaults = {
       'type'  => 'ssh-rsa',
       'owner' => $user,

--- a/dist/profile/manifests/census.pp
+++ b/dist/profile/manifests/census.pp
@@ -2,11 +2,11 @@
 # Defines an census server for serving census datasets
 #
 class profile::census (
-  $home_dir = '/srv/census',
-  $user     = 'census',
-  $group    = 'census',
+  Stdlib::Absolutepath $home_dir = '/srv/census',
+  String               $user     = 'census',
+  String               $group    = 'census',
 ) {
-  include stdlib
+  include stdlib # Required to allow using stlib methods and custom datatypes
   # volume configuration is in hiera
   include lvm
   include profile::apachemisc

--- a/dist/profile/manifests/census/agent.pp
+++ b/dist/profile/manifests/census/agent.pp
@@ -1,13 +1,10 @@
 #
 # A machine capable of processing census information
 class profile::census::agent (
-  $user = undef,
-  $home_dir = undef,
+  String $user = undef,
+  String $home_dir = undef,
 ) {
-  include stdlib
-
-  validate_string($user)
-  validate_string($home_dir)
+  include stdlib # Required to allow using stlib methods and custom datatypes
 
   $ssh_config = "${home_dir}/.ssh/config"
 

--- a/dist/profile/manifests/datadog_check.pp
+++ b/dist/profile/manifests/datadog_check.pp
@@ -1,11 +1,12 @@
 # Assemble fragments into datadog checker configuration files
 #
 define profile::datadog_check (
-  $ensure    = present,
-  $checker   = undef,
-  $source    = undef,
-  $content   = undef,
+  String                           $ensure    = 'present',
+  String                           $checker   = '',
+  Optional[Variant[String, Array]] $source    = undef,
+  Optional[Any]                    $content   = undef,
 ) {
+  include stdlib # Required to allow using stlib methods and custom datatypes
   $target ="${datadog_agent::params::conf_dir}/${checker}.yaml"
 
   include datadog_agent
@@ -27,10 +28,12 @@ define profile::datadog_check (
     }
   }
 
-  concat::fragment { $name:
-    target  => $target,
-    source  => $source,
-    content => $content,
-    notify  => Service[$datadog_agent::params::service_name],
+  if $content {
+    concat::fragment { $name:
+      target  => $target,
+      source  => $source,
+      content => $content,
+      notify  => Service[$datadog_agent::params::service_name],
+    }
   }
 }

--- a/dist/profile/manifests/debian_repo.pp
+++ b/dist/profile/manifests/debian_repo.pp
@@ -2,10 +2,13 @@
 # see also:
 # https://ask.puppet.com/question/3216/passing-parameters-to-templates/
 define profile::debian_repo (
-  $ensure,
-  $docroot,
-  $direct_root,
-$mirror_fqdn) {
+  String               $ensure,
+  Stdlib::Absolutepath $docroot,
+  Stdlib::Absolutepath $direct_root,
+  Stdlib::Fqdn         $mirror_fqdn,
+) {
+  include stdlib # Required to allow using stlib methods and custom datatypes
+
   file { "${docroot}/${name}/.htaccess":
     ensure  => $ensure,
     content => template("${module_name}/pkgrepo/debian_htaccess.erb"),

--- a/dist/profile/manifests/diagnostics.pp
+++ b/dist/profile/manifests/diagnostics.pp
@@ -3,7 +3,7 @@
 # where ever this profile is applied
 #
 class profile::diagnostics {
-  include stdlib
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include datadog_agent
 
   ensure_packages(['htop', 'strace'])

--- a/dist/profile/manifests/jenkinsadmin.pp
+++ b/dist/profile/manifests/jenkinsadmin.pp
@@ -11,16 +11,16 @@
 
 class profile::jenkinsadmin (
   # Parameters supplied by Hiera
-  $github_login,
-  $github_password,
-  $jira_login,
-  $jira_password,
-  $nick_password,
-  $image_tag = undef,
+  String $github_login,
+  String $github_password,
+  String $jira_login,
+  String $jira_password,
+  String $nick_password,
+  String $image_tag = undef,
 ) {
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include profile::docker
 
-  validate_string($image_tag)
   $user = 'ircbot'
 
   docker::image { 'jenkinsciinfra/ircbot':

--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -14,31 +14,32 @@
 #   be on the public internet
 #
 class profile::jenkinscontroller (
-  $anonymous_access                = false,
-  $admin_ldap_groups               = ['admins'],
-  $ci_fqdn                         = 'ci.jenkins.io',
-  $ci_resource_domain              = 'assets.ci.jenkins.io',
-  $docker_image                    = 'jenkins/jenkins',
-  $docker_tag                      = 'lts-jdk11',
-  $docker_container_name           = 'jenkins',
-  $letsencrypt                     = true,
-  $plugins                         = undef,
-  $proxy_port                      = 443,
-  $jenkins_home                    = '/var/lib/jenkins',
-  $container_jenkins_home          = '/var/jenkins_home',
-  $groovy_init_enabled             = false,
-  $groovy_d_enable_ssh_port        = 'absent',
-  $groovy_d_set_up_git             = 'absent',
-  $groovy_d_lock_down_jenkins      = 'absent',
-  $jcasc                           = {},
-  $cloud_agents                    = {},
-  $cloud_setups                    = {},
-  $agents_setup                    = {},
-  $agent_images                    = {},
-  $additional_tools                = {},
-  $default_tools                   = {},
-  $memory_limit                    = '1g',
-  $java_opts = "-server \
+  Boolean $anonymous_access                    = false,
+  Array $admin_ldap_groups                     = ['admins'],
+  Stdlib::Fqdn $ci_fqdn                        = 'ci.jenkins.io',
+  Stdlib::Fqdn $ci_resource_domain             = 'assets.ci.jenkins.io',
+  String $docker_image                         = 'jenkins/jenkins',
+  String $docker_tag                           = 'lts-jdk11',
+  String $docker_container_name                = 'jenkins',
+  Boolean $letsencrypt                         = true,
+  Optional[Array] $plugins                     = undef,
+  Stdlib::Port $proxy_port                     = 443,
+  Stdlib::Absolutepath $jenkins_home           = '/var/lib/jenkins',
+  Stdlib::Absolutepath $container_jenkins_home = '/var/jenkins_home',
+  Boolean $groovy_init_enabled                 = false,
+  String $groovy_d_enable_ssh_port             = 'absent',
+  String $groovy_d_set_up_git                  = 'absent',
+  String $groovy_d_lock_down_jenkins           = 'absent',
+  Hash $jcasc                                  = {},
+  Hash $cloud_agents                           = {},
+  Hash $cloud_setups                           = {},
+  Hash $agents_setup                           = {},
+  Hash $agent_images                           = {},
+  Hash $additional_tools                       = {},
+  Hash $default_tools                          = {},
+  Boolean $block_remote_access_api             = false,
+  String $memory_limit                         = '1g',
+  String $java_opts = "-server \
 -Xlog:gc*=info,ref*=debug,ergo*=trace,age*=trace:file=${container_jenkins_home}/gc/gc.log::filecount=5,filesize=40M \
 -XX:+UnlockExperimentalVMOptions \
 -XX:+UseG1GC \
@@ -48,19 +49,13 @@ class profile::jenkinscontroller (
 -Djenkins.install.runSetupWizard=false \
 -Djenkins.model.Jenkins.slaveAgentPort=50000 \
 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2", # Must be Java 11 compliant!
-  $block_remote_access_api         = false,
 ) {
-  include stdlib
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include apache
   include apache::mod::alias
   include apache::mod::proxy
   include apache::mod::headers
   include apache::mod::rewrite
-
-  validate_string($ci_fqdn)
-  validate_bool($letsencrypt)
-  validate_array($plugins)
-
   include profile::apachemisc
   include profile::docker
   include profile::firewall

--- a/dist/profile/manifests/jenkinsplugin.pp
+++ b/dist/profile/manifests/jenkinsplugin.pp
@@ -4,8 +4,6 @@
 #
 define profile::jenkinsplugin (
 ) {
-  validate_string($name)
-
   exec { "install-plugin-${name}":
     ## Check for plugin presence on the HOST (e.g. with the jenkins home in "/var/lib/jenkins" on the filesystem)
     unless    => "/usr/bin/test -f /var/lib/jenkins/plugins/${name}.jpi || /usr/bin/test -f /var/lib/jenkins/plugins/${name}.hpi",

--- a/dist/profile/manifests/opensuse_repo.pp
+++ b/dist/profile/manifests/opensuse_repo.pp
@@ -2,9 +2,10 @@
 # see also:
 # https://ask.puppet.com/question/3216/passing-parameters-to-templates/
 define profile::opensuse_repo (
-  $ensure,
-  $docroot,
-$mirror_fqdn) {
+  String $ensure,
+  Stdlib::Absolutepath $docroot,
+  Stdlib::Fqdn $mirror_fqdn,
+) {
   file { "${docroot}/${name}/repodata":
     ensure  => directory,
   }

--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -1,30 +1,20 @@
 # This class deploy an openvpn dockerized service based on the project jenkins-infra/openvpn
 
 class profile::openvpn (
-  $image_tag              = 'latest',
-  $image                  = 'jenkinsciinfra/openvpn',
-  $auth_ldap_password     = undef,
-  $auth_ldap_binddn       = 'cn=admin,dc=jenkins-ci,dc=org',
-  $auth_ldap_url          = 'ldaps://ldap.jenkins.io',
-  $auth_ldap_group_member = 'cn=all',
-  $openvpn_ca_pem         = undef,
-  $openvpn_server_pem     = undef,
-  $openvpn_server_key     = undef,
-  $openvpn_dh_pem         = undef,
-  $networks               = {}
+  String $image_tag                    = 'latest',
+  String $image                        = 'jenkinsciinfra/openvpn',
+  Optional[String] $auth_ldap_password = undef,
+  String $auth_ldap_binddn             = 'cn=admin,dc=jenkins-ci,dc=org',
+  String $auth_ldap_url                = 'ldaps://ldap.jenkins.io',
+  String $auth_ldap_group_member       = 'cn=all',
+  Optional[String] $openvpn_ca_pem     = undef,
+  Optional[String] $openvpn_server_pem = undef,
+  Optional[String] $openvpn_server_key = undef,
+  Optional[String] $openvpn_dh_pem     = undef,
+  Hash $networks                       = {}
 ) {
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include profile::docker
-
-  validate_string($image_tag)
-  validate_string($image)
-  validate_string($auth_ldap_password)
-  validate_string($auth_ldap_binddn)
-  validate_string($auth_ldap_url)
-  validate_string($auth_ldap_group_member)
-  validate_string($openvpn_ca_pem)
-  validate_string($openvpn_server_pem)
-  validate_string($openvpn_server_key)
-  validate_string($openvpn_dh_pem)
 
   sysctl { 'net.ipv4.ip_forward':
     ensure => present,

--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -1,19 +1,15 @@
 #
 # Manage yum and apt repositories for Jenkins
 class profile::pkgrepo (
-  $docroot      = '/var/www/pkg.jenkins.io',
-  $release_root = '/srv/releases/jenkins',
-  $repo_fqdn    = 'pkg.origin.jenkins.io',
-  $repo_legacy_fqdn    = 'pkg.jenkins-ci.org',
-  $mirror_fqdn  = 'mirrors.jenkins.io',
+  Stdlib::Absolutepath $docroot      = '/var/www/pkg.jenkins.io',
+  Stdlib::Absolutepath $release_root = '/srv/releases/jenkins',
+  Stdlib::Fqdn $repo_fqdn            = 'pkg.origin.jenkins.io',
+  Stdlib::Fqdn $repo_legacy_fqdn     = 'pkg.jenkins-ci.org',
+  Stdlib::Fqdn $mirror_fqdn          = 'mirrors.jenkins.io',
 ) {
-  include stdlib
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include apache
   include apache::mod::rewrite
-
-  validate_string($docroot)
-  validate_string($release_root)
-
   include profile::apachemisc
   include profile::firewall
   include profile::letsencrypt

--- a/dist/profile/manifests/redhat_repo.pp
+++ b/dist/profile/manifests/redhat_repo.pp
@@ -2,9 +2,10 @@
 # see also:
 # https://ask.puppet.com/question/3216/passing-parameters-to-templates/
 define profile::redhat_repo (
-  $ensure,
-  $docroot,
-$repo_fqdn) {
+  String $ensure,
+  Stdlib::Absolutepath $docroot,
+  Stdlib::Fqdn $repo_fqdn,
+) {
   file { "${docroot}/${name}/jenkins.repo":
     ensure  => $ensure,
     content => template("${module_name}/pkgrepo/jenkins.repo.erb"),

--- a/dist/profile/manifests/robobutler.pp
+++ b/dist/profile/manifests/robobutler.pp
@@ -4,10 +4,11 @@
 #
 class profile::robobutler (
   # all injected from hiera
-  $nick,
-  $password,
-  $logdir = '/var/www/meetings.jenkins-ci.org'
+  String $nick,
+  String $password,
+  Stdlib::Absolutepath $logdir = '/var/www/meetings.jenkins-ci.org'
 ) {
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include profile::apachemisc
   include profile::docker
 

--- a/dist/profile/manifests/updatecenter.pp
+++ b/dist/profile/manifests/updatecenter.pp
@@ -6,30 +6,36 @@
 # TODO: requirement for $homedir/.m2 (same volume as agent workspace because of hardlinks)
 #   + enough space because of Maven cache
 class profile::updatecenter (
-  $home_dir      = '/home/jenkins',
-  $user          = 'jenkins',
-  $rsync_privkey = undef,
-  $rsync_pubkey  = undef,
+  Stdlib::Absolutepath $home_dir      = '/home/jenkins',
+  String               $user          = 'jenkins',
+  Optional[String]     $rsync_privkey = '',
+  Optional[String]     $rsync_pubkey  = '',
 ) {
-  include stdlib
+  include stdlib # Required to allow using stlib methods and custom datatypes
 
-  validate_string($user)
-  validate_string($home_dir)
-  validate_string($rsync_privkey)
-  validate_string($rsync_pubkey)
+  if $rsync_privkey {
+    $rsync_privkeyfile = "${home_dir}/.ssh/updates-rsync-key"
 
-  $rsync_privkeyfile = "${home_dir}/.ssh/updates-rsync-key"
+    file { $rsync_privkeyfile:
+      ensure  => file,
+      mode    => '0600',
+      content => $rsync_privkey,
+    }
 
-  file { $rsync_privkeyfile:
-    ensure  => file,
-    mode    => '0600',
-    content => $rsync_privkey,
-  }
+    file { "${rsync_privkeyfile}.pub":
+      ensure  => file,
+      mode    => '0644',
+      content => $rsync_pubkey,
+    }
 
-  file { "${rsync_privkeyfile}.pub":
-    ensure  => file,
-    mode    => '0644',
-    content => $rsync_pubkey,
+    concat::fragment { 'updates-rsync-key concat':
+      target  => "${home_dir}/.ssh/config",
+      order   => '99',
+      content => "
+Host updates.jenkins.io
+  IdentityFile ${rsync_privkeyfile}
+",
+    }
   }
 
   ensure_resources('concat', {
@@ -41,13 +47,4 @@ class profile::updatecenter (
       },
     }
   )
-
-  concat::fragment { 'updates-rsync-key concat':
-    target  => "${home_dir}/.ssh/config",
-    order   => '99',
-    content => "
-Host updates.jenkins.io
-  IdentityFile ${rsync_privkeyfile}
-",
-  }
 }

--- a/dist/profile/manifests/updatesite.pp
+++ b/dist/profile/manifests/updatesite.pp
@@ -5,10 +5,10 @@
 # <https://github.com/jenkinsci/backend-update-center2>
 #
 class profile::updatesite (
-  $docroot = '/var/www/updates.jenkins.io',
-  $ssh_pubkey = undef,
+  Stdlib::Absolutepath $docroot    = '/var/www/updates.jenkins.io',
+  Optional[String]     $ssh_pubkey = '',
 ) {
-  include stdlib
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include apache
 
   include profile::apachemisc
@@ -95,8 +95,6 @@ class profile::updatesite (
   ##################################
 
   if $ssh_pubkey {
-    validate_string($ssh_pubkey)
-
     file { '/var/www/.ssh':
       ensure => directory,
       mode   => '0700',

--- a/dist/profile/manifests/usage.pp
+++ b/dist/profile/manifests/usage.pp
@@ -7,13 +7,14 @@
 # This usage information is then processed and ultimately finds its way into
 # our "census" data
 class profile::usage (
-  $docroot    = '/var/www/usage.jenkins.io',
-  $usage_fqdn = 'usage.jenkins.io',
-  $user       = 'usagestats',
-  $group      = 'usagestats',
-  $ssh_keys   = undef,
+  Stdlib::Absolutepath $docroot    = '/var/www/usage.jenkins.io',
+  Stdlib::Absolutepath $home_dir   = '/srv/bigger-usage',
+  Stdlib::Fqdn         $usage_fqdn = 'usage.jenkins.io',
+  String               $user       = 'usagestats',
+  String               $group      = 'usagestats',
+  Hash                 $ssh_keys   = undef,
 ) {
-  include stdlib
+  include stdlib # Required to allow using stlib methods and custom datatypes
   include apache
   # volume configuration is in hiera
   include lvm
@@ -21,18 +22,6 @@ class profile::usage (
   include profile::apachemisc
   include profile::firewall
   include profile::letsencrypt
-
-  validate_string($docroot)
-  validate_string($usage_fqdn)
-  validate_string($user)
-  validate_string($group)
-
-  if $ssh_keys != undef {
-    validate_hash($ssh_keys)
-  }
-
-  # This path hard-coded in hiera
-  $home_dir = '/srv/bigger-usage'
 
   package { 'lvm2':
     ensure => present,

--- a/dist/sshkeyman/manifests/key.pp
+++ b/dist/sshkeyman/manifests/key.pp
@@ -1,20 +1,15 @@
 #
 #
 define sshkeyman::key (
-  $type,
-  $privkey,
-  $owner,
-  $group    = $owner,
-  $key      = undef,
-  $ensure   = present,
-  $path     = $title,
-  $for_host = undef,
+  String $type,
+  String $privkey,
+  String $owner,
+  String $key      = '',
+  String $for_host = '',
+  String $ensure   = 'present',
+  String $group    = $owner,
+  Stdlib::Absolutepath $path     = $title,
 ) {
-  validate_string($owner)
-  validate_string($type)
-  validate_string($key)
-  validate_string($privkey)
-
   if $key {
     #  Install our public key for completeness' sake
     file { "${title}.pub":

--- a/spec/classes/profile/buildagent_spec.rb
+++ b/spec/classes/profile/buildagent_spec.rb
@@ -100,11 +100,6 @@ describe 'profile::buildagent' do
     let(:home) { '/tmp/rspec' }
     let(:private_keys) do
       {
-        "#{home}/.ssh/id_rsa" => {
-        'type' => 'ssh-rsa',
-        'key'  => 'publickey',
-        'privkey' => 'privatekey',
-        },
         "#{home}/.ssh/special" => {
           'privkey'  => 'specialprivatekey',
           'for_host' => 'updates.jenkins.io',
@@ -116,21 +111,6 @@ describe 'profile::buildagent' do
         :home_dir => home,
         :ssh_keys => private_keys,
       }
-    end
-
-    it 'should install the public key' do
-      expect(subject).to contain_file("#{home}/.ssh/id_rsa.pub").with({
-        :ensure => :present,
-        :owner => 'jenkins',
-      })
-    end
-
-    it 'should install the private key' do
-      expect(subject).to contain_file("#{home}/.ssh/id_rsa").with({
-        :ensure => :present,
-        :owner  => 'jenkins',
-        :content => 'privatekey',
-      })
     end
 
     it 'should install the special private key' do

--- a/updatecli/weekly.d/puppet-modules/concat.yaml
+++ b/updatecli/weekly.d/puppet-modules/concat.yaml
@@ -1,0 +1,57 @@
+---
+title: Bump the Concat Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppetlabs-concat module version
+    spec:
+      owner: puppetlabs
+      repository: puppetlabs-concat
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppetlabs-concat-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest Concat module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppetlabs-concat'(.*)
+      replacepattern: >
+        mod 'puppetlabs-concat', '{{ source "latestVersion" }}'
+#     scmid: default
+
+# pullrequests:
+#   default:
+#     kind: github
+#     scmid: default
+#     targets:
+#       - puppetfile
+#     spec:
+#       labels:
+#         - puppet-module
+#         - dependencies

--- a/updatecli/weekly.d/puppet-modules/stdlib.yaml
+++ b/updatecli/weekly.d/puppet-modules/stdlib.yaml
@@ -1,0 +1,57 @@
+---
+title: Bump the Stdlib Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppetlabs-stdlib module version
+    spec:
+      owner: puppetlabs
+      repository: puppetlabs-stdlib
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppetlabs-stdlib-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest stdlib module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppetlabs-stdlib'(.*)
+      replacepattern: >
+        mod 'puppetlabs-stdlib', '{{ source "latestVersion" }}'
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - puppetfile
+    spec:
+      labels:
+        - puppet-module
+        - dependencies


### PR DESCRIPTION
This PR removes all the occurences of `validate_` methods that are triggering depreciation warnings.

Please note that some of these methods are called in some of our external modules: to be fixed.

All the profiles are changed to define strongly typed arguments.
It was required to bump (and track with updatecli) the 2 following modules:

- `puppet-stdlib`
- `puppet-fragment`