### PR TITLE
chore(puppet-r10k) bump to 10.2.0 + fix ruby_bin to use PE 2019's ruby + track version with updatecli

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,7 +1,7 @@
 forge 'http://forge.puppetlabs.com'
 
 # Install and manage r10k
-mod 'puppet-r10k', '6.8.0'
+mod 'puppet-r10k', '10.2.0'
 
 # Deps for zack/r10k
 mod 'puppetlabs-stdlib', '8.4.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -2,8 +2,8 @@ forge 'http://forge.puppetlabs.com'
 
 # Install and manage r10k
 mod 'puppet-r10k', '10.2.0'
+mod 'puppet-systemd', '3.10.0'
 
-# Deps for zack/r10k
 mod 'puppetlabs-stdlib', '8.4.0'
 
 # Deps for apachelogcompressor

--- a/dist/profile/manifests/r10k.pp
+++ b/dist/profile/manifests/r10k.pp
@@ -21,6 +21,7 @@ class profile::r10k {
     user            => 'root',
     group           => '0',
     require         => Class['r10k::webhook::config'],
+    ruby_bin        => '/opt/puppetlabs/puppet/bin/ruby', # Defaults to /opt/puppet/bin/ruby which does not exists on PE 2019
   }
 
   firewall { '011 allow r10k webhooks':

--- a/updatecli/weekly.d/puppet-modules/r10k.yaml
+++ b/updatecli/weekly.d/puppet-modules/r10k.yaml
@@ -1,0 +1,57 @@
+---
+title: Bump the R10k Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppet-r10k module version
+    spec:
+      owner: voxpupuli
+      repository: puppet-r10k
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppet-r10k-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest R10k module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppet-r10k'(.*)
+      replacepattern: >
+        mod 'puppet-r10k', '{{ source "latestVersion" }}'
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - puppetfile
+    spec:
+      labels:
+        - puppet-module
+        - dependencies

--- a/updatecli/weekly.d/puppet-modules/systemd.yaml
+++ b/updatecli/weekly.d/puppet-modules/systemd.yaml
@@ -1,0 +1,57 @@
+---
+title: Bump the SystemD Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppet-systemd module version
+    spec:
+      owner: voxpupuli
+      repository: puppet-systemd
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppet-systemd-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest SystemD module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppet-systemd'(.*)
+      replacepattern: >
+        mod 'puppet-systemd', '{{ source "latestVersion" }}'
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - puppetfile
+    spec:
+      labels:
+        - puppet-module
+        - dependencies


### PR DESCRIPTION
When deplyoing #2330 to the puppetmaster, the default value for the ruby_bin defined in the shebang of the webhooks script for r10K was set to a non-existing version. It seems that the default is for puppet 7 / PE 2021.

This is the opportunity to bump the r10k module to latest version, track it with updatecli, and specify the custom ruby_bin.

Please note that this PR adds the puppet module `puppet-systemd` which is a dependency for `puppet-10k`.