### PR TITLE
chore(vagrant) optimize vagrant+puppet workflow

### DIFF
--- a/dist/profile/manifests/vagrant.pp
+++ b/dist/profile/manifests/vagrant.pp
@@ -2,7 +2,8 @@
 # Vagrant profile for capturing some of the spceifics we need for Vagrant boxes
 # to pvoision cleanly
 class profile::vagrant {
-  include apt # trigger an apt update
+  Exec { '/usr/bin/apt-get update --quiet':
+  }
   include sudo
 
   # Vagrant defines a default user `vagrant` which should have passwordless sudo permission

--- a/dist/profile/manifests/vagrant.pp
+++ b/dist/profile/manifests/vagrant.pp
@@ -2,6 +2,7 @@
 # Vagrant profile for capturing some of the spceifics we need for Vagrant boxes
 # to pvoision cleanly
 class profile::vagrant {
+  include apt # trigger an apt update
   include sudo
 
   # Vagrant defines a default user `vagrant` which should have passwordless sudo permission

--- a/vagrant-docker/Dockerfile
+++ b/vagrant-docker/Dockerfile
@@ -56,6 +56,17 @@ ADD https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub 
 RUN chmod 600 /home/vagrant/.ssh/authorized_keys \
   && chown -R vagrant:vagrant /home/vagrant/.ssh
 
+# Install the puppet agent
+# hadolint ignore=DL3008,DL3059
+RUN package_path=/tmp/puppetrelease.deb \
+  && curl --silent --show-error --location --output "${package_path}" "http://apt.puppetlabs.com/puppet6-release-$(grep UBUNTU_CODENAME /etc/os-release | cut -d= -f2).deb" \
+  && dpkg -i "${package_path}" \
+  && rm -f /tmp/puppetrelease.deb \
+  && apt-get update --quiet \
+  && apt-get install --no-install-recommends --yes --quiet puppet-agent \
+  && apt-get clean \
+  && rm -Rf /var/lib/apt/lists/*
+
 # /sys/fs/cgroup must be a volume to ensure cgroup hierarchy is not on the overlayfs (and should be mounted by user from the host cgroup)
 # /tmp and /run are temp. filesystem so at least a data volume outside the container
 # /var/lib/docker must be outside the overlay root filesystem


### PR DESCRIPTION
This is a non-functionnal PR which only optimize the vagrant local workflow:

- Puppet agent is now installed as part of the Docker image for faster provisionning (no need to reinstall when provisionning)
- The [Vagrant `puppet_apply` provisioner](https://www.vagrantup.com/docs/provisioning/puppet_apply) is used instead of a command line. Special gift for @smerle33 because it handles the logs level with the correct colors: Warnings, notcie and normal log lines are NOT printed in red :)