### PR TITLE
fix(jenkinscontroller) correct default subdir to fit adoptium archives naming + allow to override through hieradata for edge cases

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
@@ -55,7 +55,9 @@ tool:
               'os' => installer_setup['os'] ? installer_setup['os'] : 'linux',
             }
             -%>
-              subdir: "<%= name %>-<%= $jdk['version'] %>"
+              # subdir is the top-level directory in the archive: depends on the how the JDK is packaged. Defaults to adoptium convention unless a customized version is specified
+              # Example of subdirs for adoptium 8: jdk8-8u345-b01, adoptium 11: jdk11-11.0.16+8 and aoptium 17: jdk-17.0.4+8
+              subdir: "<%= installer_setup['subdir'] ? installer_setup['subdir'] : ("jdk" + ($jdk_major_version.to_i < 17 ? $jdk_major_version : '') + "-" + $jdk['version']) %>"
               url: "<%= scope.call_function('template', ["profile/jdk-adoptium-url.erb"]).chop() %>"
           <%- elsif installer_setup['type'] == 'command' -%>
               command: "<%= installer_setup['command'] %>"


### PR DESCRIPTION
This PR amends #2333 to correct the automatic configuration of the `subdir` of the JDK tools to use the correct adoptium conventions (which are ... exotic).

It also adds the ability to customize the value of "subdir" per JDK tool installer in hieradata.

Once merged (and deployed), this PR shoyld fix the failures for builds of [jenkins-infra/update_center2 on ci.jenkins.io](https://github.com/jenkins-infra/update-center2/pull/642#issuecomment-1219361972); but also the crawler on trusted.ci.jenkins.io, and many more that we have not seen yet.