### PR TITLE
fix(trusted.ci) use the correct SSH host key fingerprint for trusted-agent-1

### DIFF
--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -52,7 +52,7 @@ profile::jenkinscontroller::jcasc:
         credentialsId: "0e73a07a-5f72-4a90-bcce-5dcfcd10aea8"
         maxNumRetries: 0
         retryWaitTime: 0
-        hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDz7R0AF0ftz0C0ZTcmTho83gXsf093aU88/lJS52l69"
+        hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII6p0lupt11K5Htbzw+yYs2GMiQsVF63jSW7/eGqjWSh"
       envVars:
         PATH+MAVEN: "/home/jenkins/tools/apache-maven-3.8.4/bin"
       toolLocation:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -69,7 +69,7 @@ profile::jenkinscontroller::jcasc:
         credentialsId: "ppc64le-ed25519-2021-12-03"
         launchTimeoutSeconds: 713
         retryWaitTime: 175
-        hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDz7R0AF0ftz0C0ZTcmTho83gXsf093aU88/lJS52l69"
+        hostKey: "ssh-ed25519 whatever"
         javaPath: "/opt/jdk-11/bin/java"
       envVars:
         PATH+MAVEN: "/home/jenkins/tools/apache-maven-3.8.4/bin"


### PR DESCRIPTION
Related to jenkins-infra/helpdesk#3104.

This PR fixes a regression introduced by the refactoring in https://github.com/jenkins-infra/jenkins-infra/pull/2333 where the SSH fingerprint for the permanent agent `trusted-agent-1` for the controller trusted.ci.jenkins.io was accidentally set to the same as the s390x permanent agent of ci.jenkins.io (copy and paste + PEBKAC).

The impact was trusted.ci.jenkins.io not able to start an agent process because it was refusing the SSH conenction due to a mismatch of ssh key fingerprint, which is a good indicator :)

This PR correct the problem by using the correct fingerprint retrieve from a manual command on the trusted.ci.jenkins.io (and tested manually).