### PR TITLE
feat(artifact-caching-proxy): add an env var specifying the proxy provider to use for the agents

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -90,6 +90,8 @@ jenkins:
             value: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
           - key: "JENKINS_JAVA_BIN"
             value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
+          - key: "ARTIFACT_CACHING_PROXY_PROVIDER"
+            value: "azure"
       <%- end -%>
     <%- end -%>
   <%- end -%>
@@ -158,6 +160,11 @@ jenkins:
         type: <%= agent['instanceType'] %>
         tmpDir: "<%= @jcasc['agents_setup'][agent['os']]['tempDir'] %>"
         useEphemeralDevices: true
+        nodeProperties:
+        - envVars:
+            env:
+            - key: "ARTIFACT_CACHING_PROXY_PROVIDER"
+              value: "aws"
       <%- end -%>
     <%- end -%>
   <%- end -%>
@@ -189,6 +196,9 @@ jenkins:
               - envVar:
                   key: "JENKINS_JAVA_BIN"
                   value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup']['ubuntu']['agentJavaBin'] %>"
+              - envVar:
+                  key: "ARTIFACT_CACHING_PROXY_PROVIDER"
+                  value: "<%= k8s_setup['provider'] %>"
             livenessProbe:
               failureThreshold: 0
               initialDelaySeconds: 0

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -101,6 +101,8 @@ profile::jenkinscontroller::jcasc:
         javaPath: "/opt/jdk-11/bin/java"
       envVars:
         PATH+MAVEN: "/home/jenkins/tools/apache-maven-3.8.4/bin"
+        # For the permanent agents, we're using the artifact caching proxy on DigitalOcean (bandwith available)
+        ARTIFACT_CACHING_PROXY_PROVIDER: "do"
       toolLocation:
         - home: "/home/jenkins/tools/apache-maven-3.8.4"
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
@@ -116,12 +118,15 @@ profile::jenkinscontroller::jcasc:
         hostKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCYwX3Fu4fWEb9hPlan3FsiUsZoCsMD7CMqFNT/+Uh11HhvKU5ZFiF3sGNI7FrhNNbqBFd0HnS1t3zIkP3FFlKToSTrkcXPUyw+svFf5YbPbDxQUNE0kclTUsERzC3GNB5eXUlyNxCiGksqGtinXgknF2Z5cOO8osODP7ddRc6L3H4gvDi0/smz9QukZB2N0FqBJ3EZGbv0X9V3iwRu6Cu9lhcl/ue5fuIjKAgGzGQgWgCEg0k9xkK0OmxyJalI0eiqBRbdES/bXkkxp+4TQNOsxN/ZrZqxtlN7o9Fq9y+dp7xQFEoivSAjn6WQ6izjkMGKon7rcFJ4t4g6FJoQYv2Z"
       envVars:
         PATH+MAVEN: "/home/jenkins/tools/apache-maven-3.8.4/bin"
+        # For the permanent agents, we're using the artifact caching proxy on DigitalOcean (bandwith available)
+        ARTIFACT_CACHING_PROXY_PROVIDER: "do"
       toolLocation:
         - home: "/home/jenkins/tools/apache-maven-3.8.4"
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
   cloud_agents:
     kubernetes:
       cik8s:
+        provider: "aws"
         credentialsId: "cik8s-jenkins-agent-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIGTQYJKoZIhvcNAQcDoIIGPjCCBjoCAQAxggEhMIIBHQIBAD
@@ -213,6 +218,7 @@ profile::jenkinscontroller::jcasc:
             memory: 1
             imagePullSecrets: dockerhub-credential
       doks:
+        provider: "do"
         credentialsId: "doks-jenkins-agent-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIGrQYJKoZIhvcNAQcDoIIGnjCCBpoCAQAxggEhMIIBHQIBAD


### PR DESCRIPTION
New `ARTIFACT_CACHING_PROXY_PROVIDER` env var used in https://github.com/jenkins-infra/pipeline-library/pull/458

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2752
