### PR TITLE
feat: add `.enabled` agents parameter to disable them instead of deleting them (ex: DigitalOcean)

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -1,7 +1,7 @@
 <%- if @jcasc['cloud_agents'] && @jcasc['cloud_agents']['disabled'].to_s != "true" -%>
 jenkins:
   clouds:
-  <%- if @jcasc['cloud_agents']['azure-vm-agents'] && !@jcasc['cloud_agents']['azure-vm-agents'].empty? && @jcasc['cloud_agents']['azure-vm-agents']['enabled'] -%>
+  <%- if @jcasc['cloud_agents']['azure-vm-agents'] && !@jcasc['cloud_agents']['azure-vm-agents'].empty? && @jcasc['cloud_agents']['azure-vm-agents']['enabled'].to_s == "true" -%>
     <%- # Creating one cloud per template because there is no "maxVirtualMachinesLimit" directive applicable for a single template -%>
     <%- @jcasc['cloud_agents']['azure-vm-agents']['agent_definitions'].each do |agent| -%>
   - azureVM:
@@ -74,7 +74,7 @@ jenkins:
       <%- end -%>
     <%- end -%>
   <%- end -%>
-  <%- if @jcasc['cloud_agents']['azure-container-agents'] && !@jcasc['cloud_agents']['azure-container-agents'].empty? && @jcasc['cloud_agents']['azure-container-agents']['enabled'] -%>
+  <%- if @jcasc['cloud_agents']['azure-container-agents'] && !@jcasc['cloud_agents']['azure-container-agents'].empty? && @jcasc['cloud_agents']['azure-container-agents']['enabled'].to_s == "true" -%>
     <%- @jcasc['cloud_agents']['azure-container-agents'].each do |aci_cloud_name, aci_cloud_setup| -%>
   - aci:
       credentialsId: "<%= aci_cloud_setup['credentialsId'] %>"
@@ -103,7 +103,7 @@ jenkins:
       <%- end -%>
     <%- end -%>
   <%- end -%>
-  <%- if @jcasc['cloud_agents']['ec2'] && !@jcasc['cloud_agents']['ec2'].empty? && @jcasc['cloud_agents']['ec2']['enabled'] -%>
+  <%- if @jcasc['cloud_agents']['ec2'] && !@jcasc['cloud_agents']['ec2'].empty? && @jcasc['cloud_agents']['ec2']['enabled'].to_s == "true" -%>
     <%- @jcasc['cloud_agents']['ec2'].each do |ec2_cloud_name, ec2_cloud_setup| -%>
   - amazonEC2:
       cloudName: <%= ec2_cloud_name %>
@@ -178,7 +178,7 @@ jenkins:
   <%- end -%>
   <%- if @jcasc['cloud_agents']['kubernetes'] && !@jcasc['cloud_agents']['kubernetes'].empty? -%>
     <%- @jcasc['cloud_agents']['kubernetes'].each do |k8s_name, k8s_setup| -%>
-    <%- if k8s_setup['enabled'] -%>
+    <%- if k8s_setup['enabled'].to_s == "true" -%>
   - kubernetes:
       name: "<%= k8s_name %>"
       containerCap: <%= k8s_setup['max_capacity'] %>

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -1,7 +1,7 @@
 <%- if @jcasc['cloud_agents'] && @jcasc['cloud_agents']['disabled'].to_s != "true" -%>
 jenkins:
   clouds:
-  <%- if @jcasc['cloud_agents']['azure-vm-agents'] && !@jcasc['cloud_agents']['azure-vm-agents'].empty? -%>
+  <%- if @jcasc['cloud_agents']['azure-vm-agents'] && !@jcasc['cloud_agents']['azure-vm-agents'].empty? && @jcasc['cloud_agents']['azure-vm-agents']['enabled'] -%>
     <%- # Creating one cloud per template because there is no "maxVirtualMachinesLimit" directive applicable for a single template -%>
     <%- @jcasc['cloud_agents']['azure-vm-agents']['agent_definitions'].each do |agent| -%>
   - azureVM:
@@ -74,7 +74,7 @@ jenkins:
       <%- end -%>
     <%- end -%>
   <%- end -%>
-  <%- if @jcasc['cloud_agents']['azure-container-agents'] && !@jcasc['cloud_agents']['azure-container-agents'].empty? -%>
+  <%- if @jcasc['cloud_agents']['azure-container-agents'] && !@jcasc['cloud_agents']['azure-container-agents'].empty? && @jcasc['cloud_agents']['azure-container-agents']['enabled'] -%>
     <%- @jcasc['cloud_agents']['azure-container-agents'].each do |aci_cloud_name, aci_cloud_setup| -%>
   - aci:
       credentialsId: "<%= aci_cloud_setup['credentialsId'] %>"
@@ -101,7 +101,7 @@ jenkins:
       <%- end -%>
     <%- end -%>
   <%- end -%>
-  <%- if @jcasc['cloud_agents']['ec2'] && !@jcasc['cloud_agents']['ec2'].empty? -%>
+  <%- if @jcasc['cloud_agents']['ec2'] && !@jcasc['cloud_agents']['ec2'].empty? && @jcasc['cloud_agents']['ec2']['enabled'] -%>
     <%- @jcasc['cloud_agents']['ec2'].each do |ec2_cloud_name, ec2_cloud_setup| -%>
   - amazonEC2:
       cloudName: <%= ec2_cloud_name %>
@@ -171,6 +171,7 @@ jenkins:
   <%- end -%>
   <%- if @jcasc['cloud_agents']['kubernetes'] && !@jcasc['cloud_agents']['kubernetes'].empty? -%>
     <%- @jcasc['cloud_agents']['kubernetes'].each do |k8s_name, k8s_setup| -%>
+    <%- if k8s_setup['enabled'] -%>
   - kubernetes:
       name: "<%= k8s_name %>"
       containerCap: <%= k8s_setup['max_capacity'] %>
@@ -220,6 +221,7 @@ jenkins:
           slaveConnectTimeout: 100
           yamlMergeStrategy: "override"
       <%- end -%>
+    <%- end -%>
     <%- end -%>
   <%- end -%>
 <%- end -%>

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -122,6 +122,7 @@ profile::jenkinscontroller::jcasc:
   cloud_agents:
     kubernetes:
       cik8s:
+        enabled: true
         credentialsId: "cik8s-jenkins-agent-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIGTQYJKoZIhvcNAQcDoIIGPjCCBjoCAQAxggEhMIIBHQIBAD
@@ -212,7 +213,96 @@ profile::jenkinscontroller::jcasc:
             cpus: 1
             memory: 1
             imagePullSecrets: dockerhub-credential
+      doks:
+        enabled: false
+        provider: do
+        credentialsId: "doks-jenkins-agent-sa-token"
+        serverCertificate: >
+          ENC[PKCS7,MIIGrQYJKoZIhvcNAQcDoIIGnjCCBpoCAQAxggEhMIIBHQIBAD
+          AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAr6k+sP7eKtXnjfgLky6TfIcFJs
+          vgfo4wu82beaRViAIb+stBS52yhKiE0YXCH/LVbIQg8ZWWABGKlNlGM/Ow6G
+          miEGKOlmF9SWZF+XfTqqBC5xO/wjD0lfvDacmi/nUuHsfhpQxxibMlnVSJ+p
+          0hcHLlkUYErg3pJj+UPf3R8ETyUh37W+dzcHlc3VRv2IYoD6Rv0zUkOGGUOt
+          3WVCwDDzaUQP/LRm2YTrbCXL7PZCA5+BeLnd1NxexyU0uK9EdKudYY4w8GXV
+          oxu0QT6PClTdOPLa23mVmjfDNRXuOsJ7Y5RV+V+zV51Ut/Mb88bUNhrnBg5R
+          7mEjSLj2aZEFfXgzCCBW4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEJiWIA
+          mCfHYQfHn/Lp6aQXuAggVAoecyPSgMXtEL/JYKXc2ZTg3veMFcQzuY3iBqTd
+          liBnEN8V7/3P8E1w5rv7lgWUlzb8ccm87S7LTMho8OInEZ04TfwA92AU9MoL
+          BO5Zue9+ZLlTa+Kk6hYtf16bX4p5nqgOxGSZVDSWqUkSFDJaIxPJEUN9fntm
+          9qDcYLV7IaSSj1uoki/tkhdJukOdx0raoH4iXu3EWHPwH3aMy74hbbBNCrJc
+          w71/Y1E88xT1N9GzCPj/SkFReS3k8r5O2IQtqlg0DtcQkTvV0D6LCT6fgGgQ
+          EiqdrAgl6MF4o7VDtiBAyrJjLQrUpCPOihLm63Tzr4HbNhp2TiWTjs1sbrNv
+          m3qZJtDvNF+hHbEMflobZb5PYK0TkbPr6Lgc5LTLKTlpnvT3UkuG0gjxUI27
+          8OwO3Czgu3GKQL8qfKQf7AVHy0X5tztCjYbxgdieDia/35xxB7Yrhn5EZLSY
+          mrA18mFArgT/Niq8GB1jb0d0tGdbqEate78c8694Yl9qWjg+2rCx9dyG1JCo
+          uxiWYCPsQKf2xTMDf8Ib3k7VfEGy1cw/HhjDLqTyCAvRYRFPWGPuOLtHBqU4
+          Yfujtd0znDm6xTCX3wK3t/zmbpUA6EBI15XCEi4DzkQw6MYcn9mfCcydVAok
+          00muCSvu9DlSlmAH5JGDsfSnG7YAogVg4sEd7n1hX0Mdc0OTZxsf3gwQgyAK
+          6U84g1RYYu5add51ikIiY9MBYlUaUIE4ET43BrHxy/mj+9Y4n4WDoOS/h9OM
+          CkpvWRW/kYp5mUllCsyvG75HpfK8lbyO5+Xue1ZrqZWF2BgIkWtc6TIeSn9B
+          H1kRLw4DomKYobwuIrb5jugfR2ylv9YXs8Ao3YW/z2Wuits+0QLr9nzgc9s9
+          aLRdjazSIVC7lc89nPPkhc4ufEjyeBmNU3U1iUz9BE6c79zdA4SB7PBEpuPv
+          oKzylyJoQDOQ9hfD5fZC3Og6bblc5+z/5qDCWSbqqLhRuuJr/NgqNppOSKnx
+          dcc9yioyJnkjr5XbaH/bAPqqqALB6/6mWlrDC3jEkvyF7JaunfDy2O3P+9x8
+          Kxt+xDsfPuoA6fd3WDuzDlK1QSLhWNZ4JPgx9LbhewcVWL8SxwxpMbxoP325
+          QqMbKXIBz+WS7f55wWmmzSx+p/FdxBeSNeerFPpKpKNe9cM2wzyRJY7LffL3
+          IvB8FG0hHLFpYEFL1LPjTvdhTBfNpNUW6+nYVO4qvLdEZKOedBVUTfOaB9eK
+          8y/I1yGzr832E23r+KSnRCr1fpoer1mR5bPFU4Tz/pKaeaSQmov/vPq1WS/w
+          53bDmMcAbuNnnaLdacIPM3pomwB5/se0j/VwChAd6Tbdm4Q0tTUtFNYvnoQm
+          twVXrc0wlh3m+5l2SwHNb/2eEr2n5C6D3S9Nkc2bEr9P8vd2fWSk5k2xpYqZ
+          IhCgEYUVPaw6sC8LtNKcwVGxCx2mcOtPzLpaThm/sMUvu5sXN0BEfDtive/k
+          QWmWGg4VElPOQbcTAQkXDuqXdq47FncE6JVNgCcDm+/z3442kV06IYQgt0or
+          Tmi3+UPvTsznMvdfiUsxBbu36GQ2UpbzokBwRl+34qY9Jyk9SovHPsd+SV6Q
+          CCiuaCDLybTilrLGeMBcBkYJ0L6H193cM3n1mF++VtYZ85nFztuqdzub4acn
+          96xw/pJ0oAMBH7Tt2wUpZozZ+XVF4urj6oh3WkggSHH3vbo2ooPYfcTWkqh0
+          sDd6xAYpzxtCpXKnBDv1W5cMXyjdxMf2knvSO9UEVLhpT3FUtL5apoYAgbqo
+          jbvFaVW+RV5IW/]
+        max_capacity: 30 # Max 10 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each
+        url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAc6NOxZbHKCrW0RtsyuKr+nWLkQe5373QWJyENhn2potG95WHOAMXIvptK4TVmj5+AUz05uv7rnji01I+c8RYFpdu7J3dEczLsUdCY9QMTtFngz7Z/GpXAszorvEobocOQdVWzw4Rg7jncJuNI1JfiMIA9KcVYOISuyF6VEQajb/ACcyDBeYoLD7K3V6uTDIDrChCvW0FvmYDFPhxt0TheX6AxWI/9/1DzCYdz8yvOtxiSAdXOvZ87yM58OdyRotzjRCX+5E2VhxyyJdI+myfoU3DKP1H1tAuOIBdubq8OZJaZv2SQTC/BVLTIl0Wr43kKhE3kg2UOcMUypIuGcmzvDB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCLrMYKsCzYfbJk8jdLB+5WgFBuB88xQ38Pl6SjAdHgCJxgwm0Ty9pFtJ/5OubJ9UaKrZfQtI9HmGkzIr8wq5CWPjPQ3ZZ9r7TIJBWITnOnFQWiUODb+x79K1SXa5US343uKg==]
+        agent_definitions:
+          - name: jnlp-maven-8
+            labels:
+              - maven
+              - maven-8
+              - jdk8
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-11
+            labels:
+              - maven-11
+              - jdk11
+            cpus: 4
+            memory: 8
+            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-17
+            labels:
+              - maven-17
+              - jdk17
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-node
+            cpus: 2
+            memory: 4
+            labels:
+              - node
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-alpine
+            cpus: 1
+            memory: 2
+            labels:
+              - alpine
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp
+            labels:
+              - default
+            cpus: 1
+            memory: 1
+            imagePullSecrets: dockerhub-credential
     ec2:
+      enabled: true
       aws-us-east-2:
         region: us-east-2
         credentialsId: "aws-credentials-jenkins-ci"
@@ -261,6 +351,7 @@ profile::jenkinscontroller::jcasc:
             useAsMuchAsPosible: false
             spot: true
     azure-vm-agents:
+      enabled: true
       azureCredentialsId: "azure-credentials"
       resource_group: eastus-cijenkinsio
       agent_definitions:
@@ -353,6 +444,7 @@ profile::jenkinscontroller::jcasc:
           subnetName: "ci.j-agents-vm"
           spot: true
     azure-container-agents:
+      enabled: true
       aci-windows:
         credentialsId: "azure-credentials"
         resource_group: eastus-cijenkinsio


### PR DESCRIPTION
Revert https://github.com/jenkins-infra/jenkins-infra/pull/2343 by restoring DigitalOcean cluster agent definition, with `enabled` set to `false`
Also include https://github.com/jenkins-infra/jenkins-infra/pull/2351#issuecomment-1228525017