### PR TITLE
chore: retry .enabled (dummy addition first)

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -125,6 +125,7 @@ profile::jenkinscontroller::jcasc:
   cloud_agents:
     kubernetes:
       cik8s:
+        enabled: true
         provider: "aws"
         credentialsId: "cik8s-jenkins-agent-sa-token"
         serverCertificate: >


### PR DESCRIPTION
Checking if the absence of ruby agent isn't the culprit (cf #2355)