### PR TITLE
DO agent (test allinone): fix pod path try with the full path

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -210,8 +210,8 @@ jenkins:
                   key: "JAVA_HOME"
                   value: "<%= agent['javaHome'] %>"
               - envVar:
-                  key: "PATH.JAVA_HOME"
-                  value: "<%= agent['javaHome'] %>/bin"
+                  key: "PATH"
+                  value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:<%= agent['javaHome'] %>/bin"
             <%- end -%>
               - envVar:
                   key: "ARTIFACT_CACHING_PROXY_PROVIDER"


### PR DESCRIPTION
as the magic trick https://github.com/jenkinsci/jenkins/blob/01e637ec08fddc9a032837ebd838cccdefe4da83/core/src/main/java/hudson/EnvVars.java#L66-L71 is using a + and it's rejected here, I temporarily try with a full path variable (not incremental).

as per https://github.com/jenkins-infra/helpdesk/issues/2980