### PR TITLE
feat(ci.jenkins.io): add ec2 agent to test Datadog

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -324,6 +324,15 @@ profile::jenkinscontroller::jcasc:
               - linux
             useAsMuchAsPosible: true
             spot: true
+          - description: "Ubuntu 20.04 LTS test"
+            maxInstances: 1
+            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            architecture: "amd64"
+            labels:
+              - ec2_test_datadog
+            useAsMuchAsPosible: false
+            spot: true
           - description: "Windows 2019"
             maxInstances: 10
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -332,7 +332,6 @@ profile::jenkinscontroller::jcasc:
             labels:
               - ec2_test_datadog
             useAsMuchAsPosible: false
-            spot: true
           - description: "Windows 2019"
             maxInstances: 10
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2980 first step to use datadog agent on amazon ec2 ephemeral