### PR TITLE
chore(ci.j.io) : path environment variable mixing case

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -210,7 +210,7 @@ jenkins:
                   key: "JAVA_HOME"
                   value: "<%= agent['javaHome'] %>"
               - envVar:
-                  key: "PATH"
+                  key: "Path"
                   value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:<%= agent['javaHome'] %>/bin"
             <%- end -%>
               - envVar:


### PR DESCRIPTION
not sure but worth a try : 
```
For a pod running on Linux, defaults to sh, which should be in $PATH; for a pod running on Windows, defaults to cmd, which should be in %Path%. Should not generally be overridden.
```

https://www.jenkins.io/doc/pipeline/steps/kubernetes/