### PR TITLE
fix(ci.jenkins.io - kubernetes agents - DOKS all-in-one) ordered path to get precedence for java path 

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -210,8 +210,8 @@ jenkins:
                   key: "JAVA_HOME"
                   value: "<%= agent['javaHome'] %>"
               - envVar:
-                  key: "Path"
-                  value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:<%= agent['javaHome'] %>/bin"
+                  key: "PATH"
+                  value: "<%= agent['javaHome'] %>/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             <%- end -%>
               - envVar:
                   key: "ARTIFACT_CACHING_PROXY_PROVIDER"


### PR DESCRIPTION
this should fix the path for the jdk to use