### PR TITLE
feat(datadog) ec2 vm with datadog cloud init

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -168,6 +168,12 @@ jenkins:
         type: <%= agent['instanceType'] %>
         tmpDir: "<%= @jcasc['agents_setup'][agent['os']]['tempDir'] %>"
         useEphemeralDevices: true
+        <%- if agent['userData'] && !agent['userData'].empty? -%>
+        userData: |
+          <%- agent['userData'].each do |line| -%>
+            <%= line %>
+          <%- end -%>
+        <%- end -%>
         nodeProperties:
         - envVars:
             env:

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -349,6 +349,17 @@ profile::jenkinscontroller::jcasc:
             labels:
               - ec2_test_datadog
             useAsMuchAsPosible: false
+            userData:
+              - #!/bin/bash
+              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+              - mkdir /var/log/datadog
+              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+              - chmod 640 /etc/datadog-agent/datadog.yaml
+              - chown dd-agent:dd-agent /var/log/datadog
+              - chmod 770 /var/log/datadog
+              - systemctl restart datadog-agent.service
+              - rm -f /etc/sudoers.d/90-cloud-init-users
           - description: "Windows 2019"
             maxInstances: 10
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2980
should provide the datadog api key for startup agent.