### PR TITLE
feat(datadog): adding the datadog initialisation on linux agents

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -365,6 +365,17 @@ profile::jenkinscontroller::jcasc:
               - linux
             useAsMuchAsPosible: true
             spot: true
+            userData:
+              - "#!/bin/bash"
+              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+              - mkdir /var/log/datadog
+              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+              - chmod 640 /etc/datadog-agent/datadog.yaml
+              - chown dd-agent:dd-agent /var/log/datadog
+              - chmod 770 /var/log/datadog
+              - systemctl restart datadog-agent.service
+              - rm -f /etc/sudoers.d/90-cloud-init-users
           - description: "Ubuntu 20.04 LTS test"
             maxInstances: 1
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb
@@ -405,6 +416,17 @@ profile::jenkinscontroller::jcasc:
               - docker-highmem
             useAsMuchAsPosible: false
             spot: false
+            userData:
+              - "#!/bin/bash"
+              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+              - mkdir /var/log/datadog
+              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+              - chmod 640 /etc/datadog-agent/datadog.yaml
+              - chown dd-agent:dd-agent /var/log/datadog
+              - chmod 770 /var/log/datadog
+              - systemctl restart datadog-agent.service
+              - rm -f /etc/sudoers.d/90-cloud-init-users
           - description: "ARM64 ubuntu 20.04"
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
@@ -415,6 +437,17 @@ profile::jenkinscontroller::jcasc:
               - arm64linux
             useAsMuchAsPosible: false
             spot: true
+            userData:
+              - "#!/bin/bash"
+              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+              - mkdir /var/log/datadog
+              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+              - chmod 640 /etc/datadog-agent/datadog.yaml
+              - chown dd-agent:dd-agent /var/log/datadog
+              - chmod 770 /var/log/datadog
+              - systemctl restart datadog-agent.service
+              - rm -f /etc/sudoers.d/90-cloud-init-users
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
       resource_group: eastus-cijenkinsio
@@ -439,6 +472,16 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
+          initScript:
+            - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAiiTWRyFEQbPaJ8OHohWOhICF/mxCHioTCk7QhxEXZ+PD6hFmKvhZFjPb5qG52MKHA1hHZtC5NnXp+BSpmoE2TK9DLQstzZxA3xsuoBcLiz5o3J3HqV4Vz9SKNC2gUtCnBFN2IQLbKQvnHeHFzPyltzWIJ4+ZWtH5RymSqDpkxBEw8IeIwX8Ps9Ryhmip3DJrWmtogpAdhfwlTzHbwDJvQkl7GjMzdPAEEISy0rtI2nj+HSFgiG7iCfAVIy+DcEFcgFrEX3xmA+IeurOT3Q1ayt1KJCgtTtO27GcJDOydeFJIIZluwnx4OnkmvZPCYcXh1KGiDvm+8sw3eklMSeswZDBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCJDjHErg9iT8ltw26SaB8TgDD2TVMoUmvWfiwUEz0hJsTJUsW4cg2iavGCJk2x4+m4BhljtPM5W5dfMJjgGtRe0Nc=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+            - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+            - mkdir /var/log/datadog
+            - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+            - chmod 640 /etc/datadog-agent/datadog.yaml
+            - chown dd-agent:dd-agent /var/log/datadog
+            - chmod 770 /var/log/datadog
+            - systemctl restart datadog-agent.service
+            - rm -f /etc/sudoers.d/90-cloud-init-users
         - name: "ubuntu-20-test"
           description: "Ubuntu 20.04 LTS test"
           imageDefinition: jenkins-agent-ubuntu-20.04
@@ -487,6 +530,16 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: false
+          initScript:
+            - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAiiTWRyFEQbPaJ8OHohWOhICF/mxCHioTCk7QhxEXZ+PD6hFmKvhZFjPb5qG52MKHA1hHZtC5NnXp+BSpmoE2TK9DLQstzZxA3xsuoBcLiz5o3J3HqV4Vz9SKNC2gUtCnBFN2IQLbKQvnHeHFzPyltzWIJ4+ZWtH5RymSqDpkxBEw8IeIwX8Ps9Ryhmip3DJrWmtogpAdhfwlTzHbwDJvQkl7GjMzdPAEEISy0rtI2nj+HSFgiG7iCfAVIy+DcEFcgFrEX3xmA+IeurOT3Q1ayt1KJCgtTtO27GcJDOydeFJIIZluwnx4OnkmvZPCYcXh1KGiDvm+8sw3eklMSeswZDBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCJDjHErg9iT8ltw26SaB8TgDD2TVMoUmvWfiwUEz0hJsTJUsW4cg2iavGCJk2x4+m4BhljtPM5W5dfMJjgGtRe0Nc=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+            - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+            - mkdir /var/log/datadog
+            - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+            - chmod 640 /etc/datadog-agent/datadog.yaml
+            - chown dd-agent:dd-agent /var/log/datadog
+            - chmod 770 /var/log/datadog
+            - systemctl restart datadog-agent.service
+            - rm -f /etc/sudoers.d/90-cloud-init-users
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -376,15 +376,6 @@ profile::jenkinscontroller::jcasc:
               - chmod 770 /var/log/datadog
               - systemctl restart datadog-agent.service
               - rm -f /etc/sudoers.d/90-cloud-init-users
-          - description: "Ubuntu 20.04 LTS test"
-            maxInstances: 1
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            architecture: "amd64"
-            labels:
-              - ec2_test_datadog
-            useAsMuchAsPosible: false
-            userData: *userData
           - description: "Windows 2019"
             maxInstances: 10
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -365,7 +365,7 @@ profile::jenkinscontroller::jcasc:
               - linux
             useAsMuchAsPosible: true
             spot: true
-            userData: &datadogInitUserData
+            userData: &BootstrapDatadogScript
               - "#!/bin/bash"
               - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
               - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
@@ -397,7 +397,7 @@ profile::jenkinscontroller::jcasc:
               - docker-highmem
             useAsMuchAsPosible: false
             spot: false
-            userData: *datadogInitUserData
+            userData: *BootstrapDatadogScript
           - description: "ARM64 ubuntu 20.04"
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
@@ -408,7 +408,7 @@ profile::jenkinscontroller::jcasc:
               - arm64linux
             useAsMuchAsPosible: false
             spot: true
-            userData: *datadogInitUserData
+            userData: *BootstrapDatadogScript
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
       resource_group: eastus-cijenkinsio
@@ -433,7 +433,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript: *datadogInitUserData
+          initScript: *BootstrapDatadogScript
         - name: "ubuntu-20-test"
           description: "Ubuntu 20.04 LTS test"
           imageDefinition: jenkins-agent-ubuntu-20.04
@@ -452,7 +452,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript: *datadogInitUserData
+          initScript: *BootstrapDatadogScript
         - name: "ubuntu-20-highmem"
           description: "Ubuntu 20.04 LTS Highmem"
           imageDefinition: jenkins-agent-ubuntu-20.04
@@ -473,7 +473,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: false
-          initScript: *datadogInitUserData
+          initScript: *BootstrapDatadogScript
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -365,7 +365,7 @@ profile::jenkinscontroller::jcasc:
               - linux
             useAsMuchAsPosible: true
             spot: true
-            userData: &userData
+            userData: &datadogInitUserData
               - "#!/bin/bash"
               - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
               - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
@@ -397,7 +397,7 @@ profile::jenkinscontroller::jcasc:
               - docker-highmem
             useAsMuchAsPosible: false
             spot: false
-            userData: *userData
+            userData: *datadogInitUserData
           - description: "ARM64 ubuntu 20.04"
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
@@ -408,7 +408,7 @@ profile::jenkinscontroller::jcasc:
               - arm64linux
             useAsMuchAsPosible: false
             spot: true
-            userData: *userData
+            userData: *datadogInitUserData
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
       resource_group: eastus-cijenkinsio
@@ -433,16 +433,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript: &initScript
-            - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAiiTWRyFEQbPaJ8OHohWOhICF/mxCHioTCk7QhxEXZ+PD6hFmKvhZFjPb5qG52MKHA1hHZtC5NnXp+BSpmoE2TK9DLQstzZxA3xsuoBcLiz5o3J3HqV4Vz9SKNC2gUtCnBFN2IQLbKQvnHeHFzPyltzWIJ4+ZWtH5RymSqDpkxBEw8IeIwX8Ps9Ryhmip3DJrWmtogpAdhfwlTzHbwDJvQkl7GjMzdPAEEISy0rtI2nj+HSFgiG7iCfAVIy+DcEFcgFrEX3xmA+IeurOT3Q1ayt1KJCgtTtO27GcJDOydeFJIIZluwnx4OnkmvZPCYcXh1KGiDvm+8sw3eklMSeswZDBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCJDjHErg9iT8ltw26SaB8TgDD2TVMoUmvWfiwUEz0hJsTJUsW4cg2iavGCJk2x4+m4BhljtPM5W5dfMJjgGtRe0Nc=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-            - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-            - mkdir /var/log/datadog
-            - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-            - chmod 640 /etc/datadog-agent/datadog.yaml
-            - chown dd-agent:dd-agent /var/log/datadog
-            - chmod 770 /var/log/datadog
-            - systemctl restart datadog-agent.service
-            - rm -f /etc/sudoers.d/90-cloud-init-users
+          initScript: *datadogInitUserData
         - name: "ubuntu-20-test"
           description: "Ubuntu 20.04 LTS test"
           imageDefinition: jenkins-agent-ubuntu-20.04
@@ -461,7 +452,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript: *initScript
+          initScript: *datadogInitUserData
         - name: "ubuntu-20-highmem"
           description: "Ubuntu 20.04 LTS Highmem"
           imageDefinition: jenkins-agent-ubuntu-20.04
@@ -482,7 +473,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: false
-          initScript: *initScript
+          initScript: *datadogInitUserData
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -365,7 +365,7 @@ profile::jenkinscontroller::jcasc:
               - linux
             useAsMuchAsPosible: true
             spot: true
-            userData:
+            userData: &userData
               - "#!/bin/bash"
               - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
               - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
@@ -384,17 +384,7 @@ profile::jenkinscontroller::jcasc:
             labels:
               - ec2_test_datadog
             useAsMuchAsPosible: false
-            userData:
-              - "#!/bin/bash"
-              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-              - mkdir /var/log/datadog
-              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-              - chmod 640 /etc/datadog-agent/datadog.yaml
-              - chown dd-agent:dd-agent /var/log/datadog
-              - chmod 770 /var/log/datadog
-              - systemctl restart datadog-agent.service
-              - rm -f /etc/sudoers.d/90-cloud-init-users
+            userData: *userData
           - description: "Windows 2019"
             maxInstances: 10
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb
@@ -416,17 +406,7 @@ profile::jenkinscontroller::jcasc:
               - docker-highmem
             useAsMuchAsPosible: false
             spot: false
-            userData:
-              - "#!/bin/bash"
-              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-              - mkdir /var/log/datadog
-              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-              - chmod 640 /etc/datadog-agent/datadog.yaml
-              - chown dd-agent:dd-agent /var/log/datadog
-              - chmod 770 /var/log/datadog
-              - systemctl restart datadog-agent.service
-              - rm -f /etc/sudoers.d/90-cloud-init-users
+            userData: *userData
           - description: "ARM64 ubuntu 20.04"
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
@@ -437,17 +417,7 @@ profile::jenkinscontroller::jcasc:
               - arm64linux
             useAsMuchAsPosible: false
             spot: true
-            userData:
-              - "#!/bin/bash"
-              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-              - mkdir /var/log/datadog
-              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-              - chmod 640 /etc/datadog-agent/datadog.yaml
-              - chown dd-agent:dd-agent /var/log/datadog
-              - chmod 770 /var/log/datadog
-              - systemctl restart datadog-agent.service
-              - rm -f /etc/sudoers.d/90-cloud-init-users
+            userData: *userData
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
       resource_group: eastus-cijenkinsio
@@ -472,7 +442,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript:
+          initScript: &initScript
             - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAiiTWRyFEQbPaJ8OHohWOhICF/mxCHioTCk7QhxEXZ+PD6hFmKvhZFjPb5qG52MKHA1hHZtC5NnXp+BSpmoE2TK9DLQstzZxA3xsuoBcLiz5o3J3HqV4Vz9SKNC2gUtCnBFN2IQLbKQvnHeHFzPyltzWIJ4+ZWtH5RymSqDpkxBEw8IeIwX8Ps9Ryhmip3DJrWmtogpAdhfwlTzHbwDJvQkl7GjMzdPAEEISy0rtI2nj+HSFgiG7iCfAVIy+DcEFcgFrEX3xmA+IeurOT3Q1ayt1KJCgtTtO27GcJDOydeFJIIZluwnx4OnkmvZPCYcXh1KGiDvm+8sw3eklMSeswZDBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCJDjHErg9iT8ltw26SaB8TgDD2TVMoUmvWfiwUEz0hJsTJUsW4cg2iavGCJk2x4+m4BhljtPM5W5dfMJjgGtRe0Nc=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
             - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
             - mkdir /var/log/datadog
@@ -500,16 +470,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript:
-            - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAiiTWRyFEQbPaJ8OHohWOhICF/mxCHioTCk7QhxEXZ+PD6hFmKvhZFjPb5qG52MKHA1hHZtC5NnXp+BSpmoE2TK9DLQstzZxA3xsuoBcLiz5o3J3HqV4Vz9SKNC2gUtCnBFN2IQLbKQvnHeHFzPyltzWIJ4+ZWtH5RymSqDpkxBEw8IeIwX8Ps9Ryhmip3DJrWmtogpAdhfwlTzHbwDJvQkl7GjMzdPAEEISy0rtI2nj+HSFgiG7iCfAVIy+DcEFcgFrEX3xmA+IeurOT3Q1ayt1KJCgtTtO27GcJDOydeFJIIZluwnx4OnkmvZPCYcXh1KGiDvm+8sw3eklMSeswZDBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCJDjHErg9iT8ltw26SaB8TgDD2TVMoUmvWfiwUEz0hJsTJUsW4cg2iavGCJk2x4+m4BhljtPM5W5dfMJjgGtRe0Nc=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-            - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-            - mkdir /var/log/datadog
-            - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-            - chmod 640 /etc/datadog-agent/datadog.yaml
-            - chown dd-agent:dd-agent /var/log/datadog
-            - chmod 770 /var/log/datadog
-            - systemctl restart datadog-agent.service
-            - rm -f /etc/sudoers.d/90-cloud-init-users
+          initScript: *initScript
         - name: "ubuntu-20-highmem"
           description: "Ubuntu 20.04 LTS Highmem"
           imageDefinition: jenkins-agent-ubuntu-20.04
@@ -530,16 +491,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: false
-          initScript:
-            - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAiiTWRyFEQbPaJ8OHohWOhICF/mxCHioTCk7QhxEXZ+PD6hFmKvhZFjPb5qG52MKHA1hHZtC5NnXp+BSpmoE2TK9DLQstzZxA3xsuoBcLiz5o3J3HqV4Vz9SKNC2gUtCnBFN2IQLbKQvnHeHFzPyltzWIJ4+ZWtH5RymSqDpkxBEw8IeIwX8Ps9Ryhmip3DJrWmtogpAdhfwlTzHbwDJvQkl7GjMzdPAEEISy0rtI2nj+HSFgiG7iCfAVIy+DcEFcgFrEX3xmA+IeurOT3Q1ayt1KJCgtTtO27GcJDOydeFJIIZluwnx4OnkmvZPCYcXh1KGiDvm+8sw3eklMSeswZDBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCJDjHErg9iT8ltw26SaB8TgDD2TVMoUmvWfiwUEz0hJsTJUsW4cg2iavGCJk2x4+m4BhljtPM5W5dfMJjgGtRe0Nc=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-            - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-            - mkdir /var/log/datadog
-            - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-            - chmod 640 /etc/datadog-agent/datadog.yaml
-            - chown dd-agent:dd-agent /var/log/datadog
-            - chmod 770 /var/log/datadog
-            - systemctl restart datadog-agent.service
-            - rm -f /etc/sudoers.d/90-cloud-init-users
+          initScript: *initScript
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -246,6 +246,25 @@ profile::jenkinscontroller::jcasc:
               - docker-highmem
             useAsMuchAsPosible: false
             spot: false
+          - description: "Ubuntu 20.04 LTS datadog"
+            maxInstances: 1
+            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            architecture: "amd64"
+            labels:
+              - ec2_datadog
+            useAsMuchAsPosible: false
+            userData: &datadogInitUserData
+              - "#!/bin/bash"
+              - "sed 's/api_key:.*/api_key: tokeepsecret' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+              - mkdir /var/log/datadog
+              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+              - chmod 640 /etc/datadog-agent/datadog.yaml
+              - chown dd-agent:dd-agent /var/log/datadog
+              - chmod 770 /var/log/datadog
+              - systemctl restart datadog-agent.service
+              - rm -f /etc/sudoers.d/90-cloud-init-users
           - description: "ARM64 ubuntu 20.04"
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
@@ -256,25 +275,7 @@ profile::jenkinscontroller::jcasc:
               - arm64linux
             useAsMuchAsPosible: false
             spot: true
-          - description: "Ubuntu 20.04 LTS test"
-            maxInstances: 1
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            architecture: "amd64"
-            labels:
-              - ec2_test_datadog
-            useAsMuchAsPosible: false
-            userData:
-              - "#!/bin/bash"
-              - "sed 's/api_key:.*/api_key: ToKeepSecret/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-              - mkdir /var/log/datadog
-              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-              - chmod 640 /etc/datadog-agent/datadog.yaml
-              - chown dd-agent:dd-agent /var/log/datadog
-              - chmod 770 /var/log/datadog
-              - systemctl restart datadog-agent.service
-              - rm -f /etc/sudoers.d/90-cloud-init-users
+            userData: *datadogInitUserData
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
       resource_group: eastus-cijenkinsio
@@ -299,16 +300,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript:
-            - "sed 's/api_key:.*/api_key: supersecretapikey/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-            - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-            - mkdir /var/log/datadog
-            - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-            - chmod 640 /etc/datadog-agent/datadog.yaml
-            - chown dd-agent:dd-agent /var/log/datadog
-            - chmod 770 /var/log/datadog
-            - systemctl restart datadog-agent.service
-            - rm -f /etc/sudoers.d/90-cloud-init-users
+          initScript: *datadogInitUserData
         - name: "ubuntu-20-highmem"
           description: "Ubuntu 20.04 LTS Highmem"
           imageDefinition: jenkins-agent-ubuntu-20.04


### PR DESCRIPTION
as per : https://github.com/jenkins-infra/helpdesk/issues/2980
add the datadog configuration file via cloudinit to all the linux vm azure and amazon,