### PR TITLE
hotfix(jenkinscontroller) force locale to C.UTF-8 for linux kubernetes containers

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -222,6 +222,12 @@ jenkins:
               - envVar:
                   key: "ARTIFACT_CACHING_PROXY_PROVIDER"
                   value: "<%= k8s_setup['provider'] %>"
+              - envVar:
+                  key: "LC_ALL"
+                  value: "C.UTF-8"
+              - envVar:
+                  key: "LANG"
+                  value: "C.UTF-8"
             livenessProbe:
               failureThreshold: 0
               initialDelaySeconds: 0


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3130
