### PR TITLE
fix(ci.jenkins.io) recycle Windows Azure VM once jobs finishes

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -426,7 +426,6 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - docker-windows
-          idleTerminationMinutes: 30 # Quick deallocation as Linux is billed per minute
           maxInstances: 20
           useAsMuchAsPosible: true
           credentialsId: "jenkinsvmagents-userpass"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -324,7 +324,6 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - docker-windows
-          idleTerminationMinutes: 30 # Quick deallocation as Linux is billed per minute
           maxInstances: 20
           useAsMuchAsPosible: true
           credentialsId: "jenkinsvmagents-userpass"


### PR DESCRIPTION
The Windows VM images are failing quite often when building the Docker images , because of full disks:

- https://github.com/jenkinsci/docker-inbound-agent/runs/8599670331
- https://github.com/jenkinsci/docker-inbound-agent/pull/278#issuecomment-1255183611


The goal of this PR is to make sure that the Windows Azure VM agents are recycled immediately after a job.

Please note it is already the case with the EC2 Windows machines.