### PR TITLE
feat(windows datadog): adding a windows initscript as initscript OR userData 

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -352,7 +352,7 @@ profile::jenkinscontroller::jcasc:
             os: "windows"
             architecture: "amd64"
             labels:
-              - docker-windows-datadog-test
+              - docker-windows-test-datadog-ec2
             useAsMuchAsPosible: false
             spot: true
             userData: *BootstrapDatadogScriptWindows
@@ -453,7 +453,7 @@ profile::jenkinscontroller::jcasc:
           instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
           architecture: amd64
           labels:
-            - docker-windows-test-datadog
+            - docker-windows-test-datadog-azure
           maxInstances: 20
           useAsMuchAsPosible: false
           credentialsId: "jenkinsvmagents-userpass"

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -355,7 +355,7 @@ profile::jenkinscontroller::jcasc:
               - docker-windows-datadog-test
             useAsMuchAsPosible: false
             spot: true
-            #initScript: *BootstrapDatadogScriptWindows #wait until manual testing
+            userData: *BootstrapDatadogScriptWindows
           - description: "High memory ubuntu 20.04 (ondemand)"
             maxInstances: 50
             instanceType: M54xlarge # 16 vCPUS / 64 Gb
@@ -465,7 +465,9 @@ profile::jenkinscontroller::jcasc:
           spot: true
           initScript: &BootstrapDatadogScriptWindows
             #this script is ran before the agent service startup so no need to restart it
-            - (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAqyumVXNZAJylM6NiC/zKT+FKHqGnSwfUMWBupxumSJWL8GHEYFPB/Irr+sRiCPkRWW88bYg7Mp3Rv3qbxc0Aw/cU3XcQZB8RrAOsODBMjOJpHTvoB5aDtSYqygCjffPgwXK0DKguR2ADtsNkMcK7BOT02uaXgZOwo2S5UKkuDn6DsQBq9m1Ho8SwKw/E/+rwsUow+o5JVvPF9//8BIb53Y+wHYm2tOSe5dHFzBIP/+mJMHMpYiE5/q5LBELM9ZXhtBx2zeagEzbriDdlnDkMZk5AMWYz3+omDIX1MO2Fmg9Ak6O4dcNl4hhGJ5KtmPgLGzuhvfh018gi3NVhMBXv9zBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBltum5EYpT8EqN+vY0wudsgDBX++BA5bC+DpDxuqoANdKkUZdPyBo2cwxq8W4FfUtKE6ZReUIXxvARdR/Z2c5gYY4=]' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+            - <powershell>
+            - (Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAqyumVXNZAJylM6NiC/zKT+FKHqGnSwfUMWBupxumSJWL8GHEYFPB/Irr+sRiCPkRWW88bYg7Mp3Rv3qbxc0Aw/cU3XcQZB8RrAOsODBMjOJpHTvoB5aDtSYqygCjffPgwXK0DKguR2ADtsNkMcK7BOT02uaXgZOwo2S5UKkuDn6DsQBq9m1Ho8SwKw/E/+rwsUow+o5JVvPF9//8BIb53Y+wHYm2tOSe5dHFzBIP/+mJMHMpYiE5/q5LBELM9ZXhtBx2zeagEzbriDdlnDkMZk5AMWYz3+omDIX1MO2Fmg9Ak6O4dcNl4hhGJ5KtmPgLGzuhvfh018gi3NVhMBXv9zBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBltum5EYpT8EqN+vY0wudsgDBX++BA5bC+DpDxuqoANdKkUZdPyBo2cwxq8W4FfUtKE6ZReUIXxvARdR/Z2c5gYY4=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml
+            - </powershell>
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -352,7 +352,9 @@ profile::jenkinscontroller::jcasc:
           subnetName: "ci.j-agents-vm"
           spot: false
           initScript: &BootstrapDatadogScriptWindowsVagrant
-            - (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: keytokeepsecret' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+            - <powershell>
+            - (Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: keytokeepsecret' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml
+            - </powershell>
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3149 
this should provide 2 windows agents one on azure, and one on aws/ec2 that should launch the datadog agent at startup through cloudinit