### PR TITLE
Revert "feat(ci.j) switch all the linux container agents to doks while upgrading eks to kubernetes 1.23"

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -125,97 +125,97 @@ profile::jenkinscontroller::jcasc:
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
   cloud_agents:
     kubernetes:
-      # cik8s:
-      #   enabled: true
-      #   provider: "aws"
-      #   credentialsId: "cik8s-jenkins-agent-sa-token"
-      #   serverCertificate: >
-      #     ENC[PKCS7,MIIGTQYJKoZIhvcNAQcDoIIGPjCCBjoCAQAxggEhMIIBHQIBAD
-      #     AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAsVgJUVqR+e2bMF/ulLOaZXYdtX
-      #     JzjA4BG0hSLDbcu7xM1uX9vXvu8K2wP//z9S9l8iMLl93Ibb2zXeprQkmisy
-      #     5NuJHL3xVJ5fyogX4p0sTLmsKLlkG2r54dZORO/JK9th+Y1+SQgqSy+bdg8N
-      #     AuA30TvjND1Ak+v2lOEZAxS0DA4vl2aa7kCed4P6jZHdg+cQsktyzKcpGUkZ
-      #     xtHqQsXEJGeIAa77DEHFq66S17opL+OXKkAzAFecu2nqU6feHrlrShBtyDQy
-      #     syj+gLfoQYfiimqPM2CfY7qYFthdXHPR0v3aLMtyJ38OwK884zPBnYD73Brn
-      #     vE+Pncu0A5VmuZsjCCBQ4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEHQlnt
-      #     b2BqcvY7cxYApC20aAggTgLN8skv5xkfzfN07tyruH8Kwzk1tC9ifBNH5qY5
-      #     07wRRzXPCUX2w4FsmYTaOUBUIZ13fKI4yGXPqghG4oFLTC1eWQg1H61JEZqd
-      #     awAJlQ07NOM7BnFTPSFFE1TCCDeYWegPxWpiisngDddRymDBYmBISW4czK3l
-      #     Y/wOgQDqkgwFqHTtNHLfcYNoWw3MwL52jWnpbk9LM4iM9g4dFPRtCggjaeFS
-      #     /5CZLWFbGVixEN46a/ruJ6sFSpyy9r2kRPYulBuTy8oT81R5Et45VuUDcqdp
-      #     lahTQRrrlOCDaNvyS0vJt/V7KdD0XCwqvv2xV9j9ovMgE0zlYnNJMAlexjTA
-      #     G7f4Fl5fOtoL+EtkAW9q5PeftsRzO04TiJYsl/PgJ5pB/c2gOT6oBQV+jUol
-      #     VXRt+e4iA2ipIN1u7Pm6BKxjCoKUlS29OvFIMz+RK1F8FtooloBlEuziNMz0
-      #     Ufx+4v9vk53Vk4e1bMwLe/Ml7VtJgWskpS2cOxxEh/hitWJz5U0yS8ZXJxzk
-      #     c8Tev+NgdWtf/NgiYS0+XkiCaPq9LZ80pgRPMHanfKiluQQ5qoLOispGDPRy
-      #     FvaM00ascyCfhyP088HNC3/fVDqCoyL1n2lkchzFVwGf8orQU2y3KwsMBcje
-      #     6ONk1rrp2q4pRGpz4UpJhMTpSdlDyGQrLHYaBnUaXHt+wbxlGjR7o93hJv+9
-      #     XDQMWjxr1gaY4MkG/A+OgSWYR2hDXrRBf/N2CA7qJdsXhQjAJVPmTKDkO5OC
-      #     knAJuYwVdNWmPkyC8++khW28ceHmT+MRSb7OiU2poDod/czhRZ28d8nTlsNn
-      #     +xm0F15nWRBpL1Y0VHUXZF1Z0YCHuf4XYXFhGB7Vjq8URtNrru/IXvn/83aT
-      #     zZhgqEq8B5D1yoBtU7J53S3P6qxGNV3QTOHJqMB5XSXJgYd0xnxXC3p7z7U9
-      #     Rivp9YDUF0rEJiOL520lL33jjATSiG19fOrRM7vZCier+GhZuMb7bkrEJJ7t
-      #     8vYe4nALDrksZWt/XotVc86x8TgkLSs7HgRLy38WRJa5ITthX9Ue4nuRFDmB
-      #     2RVqItivthPkH//8qQYQsZ578oRgge99FD349gyx2sXnQskL6JaIyaPcFlXV
-      #     j4pqjvXiMDGQfuVFuGtb1EmLniVrzM9Auoc07ExD9sUMW3Od/y10hql7PksB
-      #     UwFgohFrV6gV0BgJOA/7n6RP/avmVQmSlItCzTxlWmvkq4AqJzfagtVq3IlE
-      #     qVr+9ENnd/WCAYmIcS5jPs/fzivfR4WVo6XMtusckVBKNYF7tvp09RuzgYX/
-      #     4qSPcd5QAJNtMBlTd5rVB4V6zr24Lj9GREySIwo9EThBOcaWsystGeEHHIw4
-      #     nYlIEYU7CHPXrbXIZbs9zLq7lYqagINWpJhHW1Px7c9jkkSVKOqfyBZ2uXQa
-      #     /bT0Z6Ud+l99vsC/RI8EDm9CgKgmpEatFNdScmepEp47I5jq5bNTKmX4fYxL
-      #     uDJXOx7CuXK9fR+XucRMqsER1yb0AcNmlV2RXbPBC2TxOhI5VrItT/jclz+e
-      #     BOSWYswPR4liVPS4jTNf7tQRx9u+X1YZsG74cOEfqwJEP3GmLh1x5s73yJyP
-      #     ymjCaTi1xPZDZAoXdk7G1q7Eop0txEeDt7ePD7XMEwmahONtcbxGQ2YmoM37
-      #     x8Z1xU]
-      #   max_capacity: 120 # Max 50 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each, minus the 30 of doks
-      #   url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAnPRdxpD9DpARlMqoylNtQBFWxBe3r2BBWM5kLNkttc26pxzUgbzfje/C+dOSmGn83S/mkimDFRVTjMft9/mIF5L9m2QbyXLKt630KBUPyFc1KZcfllrcaMtad+VZkv1cieLvb+iD1u4BhdFxsmG3SfaqFob9JWJdzRGCqAkvaIPg5Vdl5TzURbYTiHyrpNnrxP2vZOZQfbwq5cQmf1sf/k2aSinBm6g/BNt8cwxBex0tup16A9m7imOla5JxJiYtAEz6gY9HZBCHV301eB4SD2taX61aYPRpoh01K3qtYgDvb6LnaoUZEtsDNUkN/sRVwY/1HxcfisM4i7kcjk/3CTB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCK4mBTIaoCPJLfyQgJK4lfgFAyEO52eHBCPBz+ZDSvYhDxzKYo+ibl51dcJcp020b6jyJQwsNoD2Sq1Ahsz5Xs+t9DP/9PILukolb32tM9rK1kbz+Iry2hzixHUjE6idmJZA==]
-      #   agent_definitions:
-      #     - name: jnlp-maven-8
-      #       imageName: jnlp-maven-all-in-one
-      #       javaHome: /opt/jdk-8
-      #       labels:
-      #         - maven
-      #         - maven-8
-      #         - jdk8
-      #       cpus: 4
-      #       memory: 8
-      #       imagePullSecrets: dockerhub-credential
-      #     - name: jnlp-maven-11
-      #       imageName: jnlp-maven-all-in-one
-      #       javaHome: /opt/jdk-11
-      #       labels:
-      #         - maven-11
-      #         - jdk11
-      #       cpus: 4
-      #       memory: 8
-      #       imagePullSecrets: dockerhub-credential
-      #     - name: jnlp-maven-17
-      #       imageName: jnlp-maven-all-in-one
-      #       javaHome: /opt/jdk-17
-      #       labels:
-      #         - maven-17
-      #         - jdk17
-      #       cpus: 4
-      #       memory: 8
-      #       imagePullSecrets: dockerhub-credential
-      #     - name: jnlp-node
-      #       cpus: 2
-      #       memory: 4
-      #       labels:
-      #         - node
-      #       imagePullSecrets: dockerhub-credential
-      #     - name: jnlp-alpine
-      #       cpus: 1
-      #       memory: 2
-      #       labels:
-      #         - alpine
-      #       imagePullSecrets: dockerhub-credential
-      #     - name: jnlp
-      #       labels:
-      #         - default
-      #       cpus: 1
-      #       memory: 1
-      #       imagePullSecrets: dockerhub-credential
+      cik8s:
+        enabled: true
+        provider: "aws"
+        credentialsId: "cik8s-jenkins-agent-sa-token"
+        serverCertificate: >
+          ENC[PKCS7,MIIGTQYJKoZIhvcNAQcDoIIGPjCCBjoCAQAxggEhMIIBHQIBAD
+          AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAsVgJUVqR+e2bMF/ulLOaZXYdtX
+          JzjA4BG0hSLDbcu7xM1uX9vXvu8K2wP//z9S9l8iMLl93Ibb2zXeprQkmisy
+          5NuJHL3xVJ5fyogX4p0sTLmsKLlkG2r54dZORO/JK9th+Y1+SQgqSy+bdg8N
+          AuA30TvjND1Ak+v2lOEZAxS0DA4vl2aa7kCed4P6jZHdg+cQsktyzKcpGUkZ
+          xtHqQsXEJGeIAa77DEHFq66S17opL+OXKkAzAFecu2nqU6feHrlrShBtyDQy
+          syj+gLfoQYfiimqPM2CfY7qYFthdXHPR0v3aLMtyJ38OwK884zPBnYD73Brn
+          vE+Pncu0A5VmuZsjCCBQ4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEHQlnt
+          b2BqcvY7cxYApC20aAggTgLN8skv5xkfzfN07tyruH8Kwzk1tC9ifBNH5qY5
+          07wRRzXPCUX2w4FsmYTaOUBUIZ13fKI4yGXPqghG4oFLTC1eWQg1H61JEZqd
+          awAJlQ07NOM7BnFTPSFFE1TCCDeYWegPxWpiisngDddRymDBYmBISW4czK3l
+          Y/wOgQDqkgwFqHTtNHLfcYNoWw3MwL52jWnpbk9LM4iM9g4dFPRtCggjaeFS
+          /5CZLWFbGVixEN46a/ruJ6sFSpyy9r2kRPYulBuTy8oT81R5Et45VuUDcqdp
+          lahTQRrrlOCDaNvyS0vJt/V7KdD0XCwqvv2xV9j9ovMgE0zlYnNJMAlexjTA
+          G7f4Fl5fOtoL+EtkAW9q5PeftsRzO04TiJYsl/PgJ5pB/c2gOT6oBQV+jUol
+          VXRt+e4iA2ipIN1u7Pm6BKxjCoKUlS29OvFIMz+RK1F8FtooloBlEuziNMz0
+          Ufx+4v9vk53Vk4e1bMwLe/Ml7VtJgWskpS2cOxxEh/hitWJz5U0yS8ZXJxzk
+          c8Tev+NgdWtf/NgiYS0+XkiCaPq9LZ80pgRPMHanfKiluQQ5qoLOispGDPRy
+          FvaM00ascyCfhyP088HNC3/fVDqCoyL1n2lkchzFVwGf8orQU2y3KwsMBcje
+          6ONk1rrp2q4pRGpz4UpJhMTpSdlDyGQrLHYaBnUaXHt+wbxlGjR7o93hJv+9
+          XDQMWjxr1gaY4MkG/A+OgSWYR2hDXrRBf/N2CA7qJdsXhQjAJVPmTKDkO5OC
+          knAJuYwVdNWmPkyC8++khW28ceHmT+MRSb7OiU2poDod/czhRZ28d8nTlsNn
+          +xm0F15nWRBpL1Y0VHUXZF1Z0YCHuf4XYXFhGB7Vjq8URtNrru/IXvn/83aT
+          zZhgqEq8B5D1yoBtU7J53S3P6qxGNV3QTOHJqMB5XSXJgYd0xnxXC3p7z7U9
+          Rivp9YDUF0rEJiOL520lL33jjATSiG19fOrRM7vZCier+GhZuMb7bkrEJJ7t
+          8vYe4nALDrksZWt/XotVc86x8TgkLSs7HgRLy38WRJa5ITthX9Ue4nuRFDmB
+          2RVqItivthPkH//8qQYQsZ578oRgge99FD349gyx2sXnQskL6JaIyaPcFlXV
+          j4pqjvXiMDGQfuVFuGtb1EmLniVrzM9Auoc07ExD9sUMW3Od/y10hql7PksB
+          UwFgohFrV6gV0BgJOA/7n6RP/avmVQmSlItCzTxlWmvkq4AqJzfagtVq3IlE
+          qVr+9ENnd/WCAYmIcS5jPs/fzivfR4WVo6XMtusckVBKNYF7tvp09RuzgYX/
+          4qSPcd5QAJNtMBlTd5rVB4V6zr24Lj9GREySIwo9EThBOcaWsystGeEHHIw4
+          nYlIEYU7CHPXrbXIZbs9zLq7lYqagINWpJhHW1Px7c9jkkSVKOqfyBZ2uXQa
+          /bT0Z6Ud+l99vsC/RI8EDm9CgKgmpEatFNdScmepEp47I5jq5bNTKmX4fYxL
+          uDJXOx7CuXK9fR+XucRMqsER1yb0AcNmlV2RXbPBC2TxOhI5VrItT/jclz+e
+          BOSWYswPR4liVPS4jTNf7tQRx9u+X1YZsG74cOEfqwJEP3GmLh1x5s73yJyP
+          ymjCaTi1xPZDZAoXdk7G1q7Eop0txEeDt7ePD7XMEwmahONtcbxGQ2YmoM37
+          x8Z1xU]
+        max_capacity: 120 # Max 50 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each, minus the 30 of doks
+        url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAnPRdxpD9DpARlMqoylNtQBFWxBe3r2BBWM5kLNkttc26pxzUgbzfje/C+dOSmGn83S/mkimDFRVTjMft9/mIF5L9m2QbyXLKt630KBUPyFc1KZcfllrcaMtad+VZkv1cieLvb+iD1u4BhdFxsmG3SfaqFob9JWJdzRGCqAkvaIPg5Vdl5TzURbYTiHyrpNnrxP2vZOZQfbwq5cQmf1sf/k2aSinBm6g/BNt8cwxBex0tup16A9m7imOla5JxJiYtAEz6gY9HZBCHV301eB4SD2taX61aYPRpoh01K3qtYgDvb6LnaoUZEtsDNUkN/sRVwY/1HxcfisM4i7kcjk/3CTB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCK4mBTIaoCPJLfyQgJK4lfgFAyEO52eHBCPBz+ZDSvYhDxzKYo+ibl51dcJcp020b6jyJQwsNoD2Sq1Ahsz5Xs+t9DP/9PILukolb32tM9rK1kbz+Iry2hzixHUjE6idmJZA==]
+        agent_definitions:
+          - name: jnlp-maven-8
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-8
+            labels:
+              - maven
+              - maven-8
+              - jdk8
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-11
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-11
+            labels:
+              - maven-11
+              - jdk11
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-17
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-17
+            labels:
+              - maven-17
+              - jdk17
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-node
+            cpus: 2
+            memory: 4
+            labels:
+              - node
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-alpine
+            cpus: 1
+            memory: 2
+            labels:
+              - alpine
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp
+            labels:
+              - default
+            cpus: 1
+            memory: 1
+            imagePullSecrets: dockerhub-credential
       doks:
         enabled: true
         provider: do
@@ -260,8 +260,7 @@ profile::jenkinscontroller::jcasc:
           96xw/pJ0oAMBH7Tt2wUpZozZ+XVF4urj6oh3WkggSHH3vbo2ooPYfcTWkqh0
           sDd6xAYpzxtCpXKnBDv1W5cMXyjdxMf2knvSO9UEVLhpT3FUtL5apoYAgbqo
           jbvFaVW+RV5IW/]
-        # max_capacity: 30 # Max 10 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each
-        max_capacity: 150
+        max_capacity: 30 # Max 10 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each
         url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAc6NOxZbHKCrW0RtsyuKr+nWLkQe5373QWJyENhn2potG95WHOAMXIvptK4TVmj5+AUz05uv7rnji01I+c8RYFpdu7J3dEczLsUdCY9QMTtFngz7Z/GpXAszorvEobocOQdVWzw4Rg7jncJuNI1JfiMIA9KcVYOISuyF6VEQajb/ACcyDBeYoLD7K3V6uTDIDrChCvW0FvmYDFPhxt0TheX6AxWI/9/1DzCYdz8yvOtxiSAdXOvZ87yM58OdyRotzjRCX+5E2VhxyyJdI+myfoU3DKP1H1tAuOIBdubq8OZJaZv2SQTC/BVLTIl0Wr43kKhE3kg2UOcMUypIuGcmzvDB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCLrMYKsCzYfbJk8jdLB+5WgFBuB88xQ38Pl6SjAdHgCJxgwm0Ty9pFtJ/5OubJ9UaKrZfQtI9HmGkzIr8wq5CWPjPQ3ZZ9r7TIJBWITnOnFQWiUODb+x79K1SXa5US343uKg==]
         agent_definitions:
           - name: jnlp-maven-8


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2446

Related to https://github.com/jenkins-infra/helpdesk/issues/3053