### PR TITLE
Revert "feat(ci.jenkins.io) remove jnlp-alpine pod template + switch the jnlp-node to a new image"

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -166,13 +166,17 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             imagePullSecrets: dockerhub-credential
-          - name: jnlp-webbuilder
+          - name: jnlp-node
             cpus: 2
             memory: 4
             labels:
               - node
-              - ruby
-              - webbuilder
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-alpine
+            cpus: 1
+            memory: 2
+            labels:
+              - alpine
             imagePullSecrets: dockerhub-credential
           - name: jnlp
             labels:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -226,7 +226,8 @@ profile::jenkinscontroller::jcasc:
       jnlp-maven-11-windows: jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver
       jnlp-ruby: jenkinsciinfra/inbound-agent-ruby@sha256:221f96baa1957742728eb6d2769a691aea5721fc11ed9b05da810c5debe92115
       jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-20.04@sha256:cec36d389def1132b441d3bff0cdf8ffd07f6d53b13c54bd67d59b4101445626
-      jnlp-webbuilder: 'jenkinsciinfra/builder@sha256:0dfa634a05d8d6094ff64fb4e4578f5ee2d4c4a110061d358bb5189dbbbfbdff'
+      jnlp-node: 'jenkinsciinfra/inbound-agent-node@sha256:a5680cf7cb49f30d5c9a9afbddd7b40c60a0cbc8d802c2a210aa1f6e36c130f5'
+      jnlp-alpine: 'jenkins/inbound-agent@sha256:69877a2d1f2531f4618688541e67f13ea2a36df5259b215d62ce2a45e8927849'
       # default template from the official inbound-agent image here to provide a default agent (`node()` pipeline step)
       jnlp: jenkins/inbound-agent@sha256:67319e589495d5beb11cfa17eeb6711b1a9155d8a2d2b6bade8c47f51bbee08f
   tools_default_versions:

--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -45,11 +45,17 @@ sources:
       image: "jenkinsciinfra/inbound-agent-maven"
       tag: "jdk17"
       architecture: amd64
-  getLatestInboundWebBuilderContainerImage:
+  getLatestInboundNodeContainerImage:
     kind: dockerdigest
     spec:
-      image: "jenkinsciinfra/builder"
+      image: "jenkinsciinfra/inbound-agent-node"
       tag: "latest"
+      architecture: amd64
+  getLatestInboundAlpineContainerImage:
+    kind: dockerdigest
+    spec:
+      image: "jenkins/inbound-agent"
+      tag: "alpine"
       architecture: amd64
   getLatestInboundJDK11ContainerImage:
     kind: dockerdigest
@@ -139,15 +145,25 @@ targets:
     transformers:
       - addprefix: "jenkinsciinfra/jenkins-agent-ubuntu-20.04@"
     scmid: default
-  setInboundWebBuilderContainerImage:
-    sourceid: getLatestInboundWebBuilderContainerImage
-    name: "Bump container agent image jenkinsciinfra/builder"
+  setInboundNodeContainerImage:
+    sourceid: getLatestInboundNodeContainerImage
+    name: "Bump container agent image jenkinsciinfra/inbound-agent-node"
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-webbuilder"
+      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-node"
     transformers:
-      - addprefix: "jenkinsciinfra/builder@"
+      - addprefix: "jenkinsciinfra/inbound-agent-node@"
+    scmid: default
+  setInboundAlpineContainerImage:
+    sourceid: getLatestInboundAlpineContainerImage
+    name: "Bump container agent image jenkins/inbound-agent (Alpine)"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-alpine"
+    transformers:
+      - addprefix: "jenkins/inbound-agent@"
     scmid: default
   setInboundJDK11ContainerImage:
     sourceid: getLatestInboundJDK11ContainerImage


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2458

Error in the puppet diff:

```
-            image: "jenkinsciinfra/inbound-agent-node@sha256:8e00d7461fa7abc27b41493a1efd6330ae183dbfd7fa6cdd11faa8eaa989b083"
+            image: ""
```

so I'm reverting to avoid taking any risk