### PR TITLE
feat(ci.jenkins.io) remove jnlp-alpine and change jnlp-node to a jnlp-webbuilder template (with ruby and stuff)

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -202,7 +202,7 @@ jenkins:
       <%- k8s_setup['agent_definitions'].each do |agent| -%>
         - containers:
           - alwaysPullImage: false
-            image: "<%= agent['imageName'] && !agent['imageName'].empty? ?  @jcasc['agent_images']['container_images'][agent['imageName']] : @jcasc['agent_images']['container_images'][agent['name']] %>"
+            image: "<%= agent['imageName'] && !agent['imageName'].empty? ? @jcasc['agent_images']['container_images'][agent['imageName']] : @jcasc['agent_images']['container_images'][agent['name']] %>"
             # Please note that envVars are specified differently than permanent or ACI agents
             envVars:
               - envVar:

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -166,17 +166,13 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             imagePullSecrets: dockerhub-credential
-          - name: jnlp-node
+          - name: jnlp-webbuilder
             cpus: 2
             memory: 4
             labels:
               - node
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-alpine
-            cpus: 1
-            memory: 2
-            labels:
-              - alpine
+              - ruby
+              - webbuilder
             imagePullSecrets: dockerhub-credential
           - name: jnlp
             labels:
@@ -259,17 +255,13 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             imagePullSecrets: dockerhub-credential
-          - name: jnlp-node
+          - name: jnlp-webbuilder
             cpus: 2
             memory: 4
             labels:
               - node
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-alpine
-            cpus: 1
-            memory: 2
-            labels:
-              - alpine
+              - ruby
+              - webbuilder
             imagePullSecrets: dockerhub-credential
           - name: jnlp
             labels:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -226,8 +226,7 @@ profile::jenkinscontroller::jcasc:
       jnlp-maven-11-windows: jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver
       jnlp-ruby: jenkinsciinfra/inbound-agent-ruby@sha256:221f96baa1957742728eb6d2769a691aea5721fc11ed9b05da810c5debe92115
       jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-20.04@sha256:166b8cf505c4b55879a6d466c929f98c312cd9c2415389bfd55991e805852e6a
-      jnlp-node: 'jenkinsciinfra/inbound-agent-node@sha256:41d114feccaa6f6b0b24a7f01a3b1e06fe444f5435c6642a7fadcb0239e3fd9b'
-      jnlp-alpine: 'jenkins/inbound-agent@sha256:69877a2d1f2531f4618688541e67f13ea2a36df5259b215d62ce2a45e8927849'
+      jnlp-webbuilder: 'jenkinsciinfra/builder@sha256:0dfa634a05d8d6094ff64fb4e4578f5ee2d4c4a110061d358bb5189dbbbfbdff'
       # default template from the official inbound-agent image here to provide a default agent (`node()` pipeline step)
       jnlp: jenkins/inbound-agent@sha256:67319e589495d5beb11cfa17eeb6711b1a9155d8a2d2b6bade8c47f51bbee08f
   tools_default_versions:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -71,34 +71,34 @@ profile::jenkinscontroller::jcasc:
         max_capacity: 120 # Max 50 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each, minus the 30 of doks
         url: SuperSecretThatShouldBeEncryptedInProduction
         agent_definitions:
-          # - name: jnlp-maven-8
-          #   imageName: jnlp-maven-all-in-one
-          #   javaHome: /opt/jdk-8
-          #   labels:
-          #     - maven
-          #     - maven-8
-          #     - jdk8
-          #   cpus: 4
-          #   memory: 8
-          #   imagePullSecrets: dockerhub-credential
-          # - name: jnlp-maven-11
-          #   imageName: jnlp-maven-all-in-one
-          #   javaHome: /opt/jdk-11
-          #   labels:
-          #     - maven-11
-          #     - jdk11
-          #   cpus: 4
-          #   memory: 8
-          #   imagePullSecrets: dockerhub-credential
-          # - name: jnlp-maven-17
-          #   imageName: jnlp-maven-all-in-one
-          #   javaHome: /opt/jdk-17
-          #   labels:
-          #     - maven-17
-          #     - jdk17
-          #   cpus: 4
-          #   memory: 8
-          #   imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-8
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-8
+            labels:
+              - maven
+              - maven-8
+              - jdk8
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-11
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-11
+            labels:
+              - maven-11
+              - jdk11
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-17
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-17
+            labels:
+              - maven-17
+              - jdk17
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
           - name: jnlp-webbuilder
             cpus: 2
             memory: 4

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -71,45 +71,41 @@ profile::jenkinscontroller::jcasc:
         max_capacity: 120 # Max 50 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each, minus the 30 of doks
         url: SuperSecretThatShouldBeEncryptedInProduction
         agent_definitions:
-          - name: jnlp-maven-8
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-8
-            labels:
-              - maven
-              - maven-8
-              - jdk8
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-maven-11
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-11
-            labels:
-              - maven-11
-              - jdk11
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-maven-17
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-17
-            labels:
-              - maven-17
-              - jdk17
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-node
+          # - name: jnlp-maven-8
+          #   imageName: jnlp-maven-all-in-one
+          #   javaHome: /opt/jdk-8
+          #   labels:
+          #     - maven
+          #     - maven-8
+          #     - jdk8
+          #   cpus: 4
+          #   memory: 8
+          #   imagePullSecrets: dockerhub-credential
+          # - name: jnlp-maven-11
+          #   imageName: jnlp-maven-all-in-one
+          #   javaHome: /opt/jdk-11
+          #   labels:
+          #     - maven-11
+          #     - jdk11
+          #   cpus: 4
+          #   memory: 8
+          #   imagePullSecrets: dockerhub-credential
+          # - name: jnlp-maven-17
+          #   imageName: jnlp-maven-all-in-one
+          #   javaHome: /opt/jdk-17
+          #   labels:
+          #     - maven-17
+          #     - jdk17
+          #   cpus: 4
+          #   memory: 8
+          #   imagePullSecrets: dockerhub-credential
+          - name: jnlp-webbuilder
             cpus: 2
             memory: 4
             labels:
               - node
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-alpine
-            cpus: 1
-            memory: 2
-            labels:
-              - alpine
+              - webbuilder
+              - ruby
             imagePullSecrets: dockerhub-credential
           - name: jnlp
             labels:
@@ -153,17 +149,13 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             imagePullSecrets: dockerhub-credential
-          - name: jnlp-node
+          - name: jnlp-webbuilder
             cpus: 2
             memory: 4
             labels:
               - node
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-alpine
-            cpus: 1
-            memory: 2
-            labels:
-              - alpine
+              - webbuilder
+              - ruby
             imagePullSecrets: dockerhub-credential
           - name: jnlp
             labels:
@@ -325,26 +317,26 @@ profile::jenkinscontroller::jcasc:
             - <powershell>
             - (Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: keytokeepsecret' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml
             - </powershell>
-    azure-container-agents:
-      aci-windows:
-        credentialsId: "azure-credentials"
-        resource_group: eastus-cijenkinsio
-        agent_definitions:
-          - name: maven-8-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            labels:
-              - maven-windows
-          - name: maven-11-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
-            labels:
-              - maven-11-windows
+    # azure-container-agents:
+    #   aci-windows:
+    #     credentialsId: "azure-credentials"
+    #     resource_group: eastus-cijenkinsio
+    #     agent_definitions:
+    #       - name: maven-8-windows
+    #         os: windows
+    #         command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+    #         cpus: 4
+    #         memory: 8
+    #         labels:
+    #           - maven-windows
+    #       - name: maven-11-windows
+    #         os: windows
+    #         command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+    #         cpus: 4
+    #         memory: 8
+    #         agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+    #         labels:
+    #           - maven-11-windows
   artifact_caching_proxy:
     disabled: false
 # These are plugins we need in our ci environment

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -317,26 +317,26 @@ profile::jenkinscontroller::jcasc:
             - <powershell>
             - (Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: keytokeepsecret' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml
             - </powershell>
-    # azure-container-agents:
-    #   aci-windows:
-    #     credentialsId: "azure-credentials"
-    #     resource_group: eastus-cijenkinsio
-    #     agent_definitions:
-    #       - name: maven-8-windows
-    #         os: windows
-    #         command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-    #         cpus: 4
-    #         memory: 8
-    #         labels:
-    #           - maven-windows
-    #       - name: maven-11-windows
-    #         os: windows
-    #         command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-    #         cpus: 4
-    #         memory: 8
-    #         agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
-    #         labels:
-    #           - maven-11-windows
+    azure-container-agents:
+      aci-windows:
+        credentialsId: "azure-credentials"
+        resource_group: eastus-cijenkinsio
+        agent_definitions:
+          - name: maven-8-windows
+            os: windows
+            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+            cpus: 4
+            memory: 8
+            labels:
+              - maven-windows
+          - name: maven-11-windows
+            os: windows
+            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+            cpus: 4
+            memory: 8
+            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+            labels:
+              - maven-11-windows
   artifact_caching_proxy:
     disabled: false
 # These are plugins we need in our ci environment

--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -45,17 +45,11 @@ sources:
       image: "jenkinsciinfra/inbound-agent-maven"
       tag: "jdk17"
       architecture: amd64
-  getLatestInboundNodeContainerImage:
+  getLatestInboundWebBuilderContainerImage:
     kind: dockerdigest
     spec:
-      image: "jenkinsciinfra/inbound-agent-node"
+      image: "jenkinsciinfra/builder"
       tag: "latest"
-      architecture: amd64
-  getLatestInboundAlpineContainerImage:
-    kind: dockerdigest
-    spec:
-      image: "jenkins/inbound-agent"
-      tag: "alpine"
       architecture: amd64
   getLatestInboundJDK11ContainerImage:
     kind: dockerdigest
@@ -145,25 +139,15 @@ targets:
     transformers:
       - addprefix: "jenkinsciinfra/jenkins-agent-ubuntu-20.04@"
     scmid: default
-  setInboundNodeContainerImage:
-    sourceid: getLatestInboundNodeContainerImage
-    name: "Bump container agent image jenkinsciinfra/inbound-agent-node"
+  setInboundWebBuilderContainerImage:
+    sourceid: getLatestInboundWebBuilderContainerImage
+    name: "Bump container agent image jenkinsciinfra/builder"
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-node"
+      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-webbuilder"
     transformers:
-      - addprefix: "jenkinsciinfra/inbound-agent-node@"
-    scmid: default
-  setInboundAlpineContainerImage:
-    sourceid: getLatestInboundAlpineContainerImage
-    name: "Bump container agent image jenkins/inbound-agent (Alpine)"
-    kind: yaml
-    spec:
-      file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-alpine"
-    transformers:
-      - addprefix: "jenkins/inbound-agent@"
+      - addprefix: "jenkinsciinfra/builder@"
     scmid: default
   setInboundJDK11ContainerImage:
     sourceid: getLatestInboundJDK11ContainerImage


### PR DESCRIPTION
Retying https://github.com/jenkins-infra/jenkins-infra/pull/2458 which was reverted in https://github.com/jenkins-infra/jenkins-infra/pull/2461.

It is part of the work for https://github.com/jenkins-infra/helpdesk/issues/3157.

- The template `jnlp-alpine` (label `alpine`)  is removed because not needed.
- The template `jnlp-node` is renamed to `jnlp-webbuilder` and switched to the `jenkinsciinfra/build` (jenkins-infra/docker-builder) image which features ASDF, ruby, and more tools usefull for web development. This image should be changed to the same image as other in a near future but let's get started here.