### PR TITLE
hotfix(ci.jenkins.io) fixup on #2464 to use the default java

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -167,6 +167,7 @@ profile::jenkinscontroller::jcasc:
             memory: 8
             imagePullSecrets: dockerhub-credential
           - name: jnlp-webbuilder
+            javaHome: java
             cpus: 2
             memory: 4
             labels:
@@ -256,6 +257,7 @@ profile::jenkinscontroller::jcasc:
             memory: 8
             imagePullSecrets: dockerhub-credential
           - name: jnlp-webbuilder
+            javaHome: java
             cpus: 2
             memory: 4
             labels:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -100,6 +100,7 @@ profile::jenkinscontroller::jcasc:
             memory: 8
             imagePullSecrets: dockerhub-credential
           - name: jnlp-webbuilder
+            javaHome: java
             cpus: 2
             memory: 4
             labels:
@@ -150,6 +151,7 @@ profile::jenkinscontroller::jcasc:
             memory: 8
             imagePullSecrets: dockerhub-credential
           - name: jnlp-webbuilder
+            javaHome: java
             cpus: 2
             memory: 4
             labels:


### PR DESCRIPTION
Fixes the pod failing to start with

```
$ kubectl -n jenkins-agents logs jnlp-webbuilder-82w5c
/usr/local/bin/jenkins-agent: 131: exec: /opt/jdk-11/bin/java: not found
```

(had to enable pod retention for this)