### PR TITLE
feat(ci.jenkins.io) enable ASDF for EC2 VMs and Kubernetes agents

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -123,7 +123,7 @@ jenkins:
           unixData:
             <%-# Windows VM agent are not supported yet: https://issues.jenkins.io/browse/JENKINS-69304 -%>
             <%- if agent['os'].to_s != 'windows' -%>
-            slaveCommandPrefix: "PATH=<%= scope.call_function('dirname', [agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup']['ubuntu']['agentJavaBin']]) %>:^${PATH}"
+            slaveCommandPrefix: "PATH=<%= scope.call_function('dirname', [agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup']['ubuntu']['agentJavaBin']]) %>:~/.asdf/shims:~/.asdf/bin:^${PATH}"
             <%- end -%>
             sshPort: "22"
         associatePublicIp: true
@@ -217,7 +217,7 @@ jenkins:
                   value: "<%= agent['javaHome'] %>"
               - envVar:
                   key: "PATH"
-                  value: "<%= agent['javaHome'] %>/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+                  value: "<%= agent['javaHome'] %>/bin:~/.asdf/shims:~/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             <%- end -%>
               - envVar:
                   key: "ARTIFACT_CACHING_PROXY_PROVIDER"
@@ -235,7 +235,7 @@ jenkins:
             resourceLimitMemory: "<%= agent['memory'] %>G"
             resourceRequestCpu: "<%= agent['cpus'] %>"
             resourceRequestMemory: "<%= agent['memory'] %>G"
-            workingDir: "/home/jenkins"
+            workingDir: "/home/jenkins/agent"
           label: "container kubernetes <%= k8s_name %> <%= agent['labels'] ? agent['labels'].join(' ') : '' %>"
           name: "<%= agent['name'] %>"
         <%- if agent['imagePullSecrets'] -%>

--- a/dist/profile/templates/jenkinscontroller/casc/jenkins.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/jenkins.yaml.erb
@@ -2,4 +2,7 @@
 jenkins:
   # No builds on controller
   numExecutors: 0
+unclassified:
+  shell:
+    shell: "/bin/bash"
 <%- end -%>


### PR DESCRIPTION
This PR enable ASDF on EC2 and Kubernetes agents (Linux only). It also fixes the `jnlp-webbuilder` agent which are failing as caught by @lemeurherve:

```
/home/jenkins/workspace/Tools_.github_PR-101/scripts@tmp/durable-e200b745/script.sh: 1: npm: not found
``` 

It introduces the following changes:

- Define the default pipeline `sh` shell to `/bin/bash` to allow using ASDF shims. As we removed Alpine Linux, all linux agent have bash in this path
- Add to the PATH the ASDF shims and dir