### PR TITLE
fix(ci.jenkins.io) use absolute path for ASDF PATH on agents

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -213,7 +213,7 @@ profile::jenkinscontroller::jcasc:
       osDiskSize: 90
       agentJavaBin: '/opt/jdk-11/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
-      path: '~/.asdf/shims:~/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
+      path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
   agent_images:
     ec2_amis:
       ubuntu-amd64: "ami-0acd241bffe75e661"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3222
