### PR TITLE
feat(ci.jenkins.io): add a window agent ACI with jdk17

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -167,7 +167,7 @@ profile::jenkinscontroller::jcasc:
             memory: 8
             imagePullSecrets: dockerhub-credential
           - name: jnlp-webbuilder
-            agentJavaBin: /opt/java/openjdk/bin/java            
+            agentJavaBin: /opt/java/openjdk/bin/java
             cpus: 2
             memory: 4
             labels:
@@ -427,6 +427,14 @@ profile::jenkinscontroller::jcasc:
             agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
             labels:
               - maven-11-windows
+          - name: maven-17-windows
+            os: windows
+            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+            cpus: 4
+            memory: 8
+            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+            labels:
+              - maven-17-windows
   artifact_caching_proxy:
     disabled: false
 # These are plugins we need in our ci environment

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -225,6 +225,7 @@ profile::jenkinscontroller::jcasc:
     container_images:
       jnlp-maven-8-windows: jenkinsciinfra/inbound-agent-maven:jdk8-nanoserver
       jnlp-maven-11-windows: jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver
+      jnlp-maven-17-windows: jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver
       jnlp-ruby: jenkinsciinfra/inbound-agent-ruby@sha256:221f96baa1957742728eb6d2769a691aea5721fc11ed9b05da810c5debe92115
       jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-20.04@sha256:56f85c2dc7d93d49a3ede72c49f23275a88b6cd634ea421c0c40297f47b57438
       jnlp-webbuilder: 'jenkinsciinfra/builder@sha256:230919e6a856373c43ed01c4f967cab6274599f6457cd1ea49850ea759e67aa4'

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -339,6 +339,14 @@ profile::jenkinscontroller::jcasc:
             agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
             labels:
               - maven-11-windows
+          - name: maven-17-windows
+            os: windows
+            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+            cpus: 4
+            memory: 8
+            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+            labels:
+              - maven-17-windows
   artifact_caching_proxy:
     disabled: false
 # These are plugins we need in our ci environment


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2822
create a windows jdk 17 agent based on the docker image : https://hub.docker.com/layers/jenkinsciinfra/inbound-agent-maven/jdk17-nanoserver/images/sha256-53ec72a0a97adfb3b8f901d49f82c419cf9177516a2f488612135c186ea27170?context=explore