### PR TITLE
feat(ci.jenkins.io) more resources for the node/ruby builds

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -168,8 +168,8 @@ profile::jenkinscontroller::jcasc:
             imagePullSecrets: dockerhub-credential
           - name: jnlp-webbuilder
             agentJavaBin: /opt/java/openjdk/bin/java
-            cpus: 2
-            memory: 4
+            cpus: 4
+            memory: 8
             labels:
               - node
               - ruby
@@ -258,8 +258,8 @@ profile::jenkinscontroller::jcasc:
             imagePullSecrets: dockerhub-credential
           - name: jnlp-webbuilder
             agentJavaBin: /opt/java/openjdk/bin/java
-            cpus: 2
-            memory: 4
+            cpus: 4
+            memory: 8
             labels:
               - node
               - ruby


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/stories/pull/16.

As pointed out by @lemeurherve and @halkeye , the nodejs processes deserve more resources for build efficiency.

This PR changes the default resources allocation for nodejs/ruby pod templates to:
- 4 vCPUs (instead of 2)
- 8 Gb memory (instead of 4)