### PR TITLE
chore(labels): add linux-amd64 to small vm to match infra (pipeline merge)

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -286,6 +286,7 @@ profile::jenkinscontroller::jcasc:
               - java
               - docker
               - linux
+              - linux-amd64
             useAsMuchAsPosible: true
             spot: true
             userData: &BootstrapDatadogScript
@@ -357,6 +358,7 @@ profile::jenkinscontroller::jcasc:
             - java
             - linux
             - docker
+            - linux-amd64
           maxInstances: 10
           useAsMuchAsPosible: true
           credentialsId: "jenkinsvmagents-userpass"
@@ -378,6 +380,7 @@ profile::jenkinscontroller::jcasc:
             - highmem
             - highram
             - docker-highmem
+            - linux-amd64-big
           maxInstances: 20
           useAsMuchAsPosible: false
           usePrivateIP: true


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3087 in order to merge the pipelines we need to use the same label on both controllers.