### PR TITLE
chore(jdk19): add jdk19 tool installation

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
@@ -56,7 +56,7 @@ tool:
             }
             -%>
               # subdir is the top-level directory in the archive: depends on the how the JDK is packaged. Defaults to adoptium convention unless a customized version is specified
-              # Example of subdirs for adoptium 8: jdk8u345-b01, adoptium 11: jdk-11.0.16+8 and aoptium 17: jdk-17.0.4+8
+              # Example of subdirs for adoptium 8: jdk8u345-b01, adoptium 11: jdk-11.0.16+8, adoptium 17: jdk-17.0.4+8 and adoptium 19: jdk-19.0.1+10
               subdir: "<%= installer_setup['subdir'] ? installer_setup['subdir'] : ("jdk" + ($jdk_major_version.to_i == 8 ? '' : '-') + $jdk['version']) %>"
               url: "<%= scope.call_function('template', ["profile/jdk-adoptium-url.erb"]).chop() %>"
           <%- elsif installer_setup['type'] == 'command' -%>

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -73,6 +73,16 @@ profile::jenkinscontroller::jcasc:
             type: "zip"
             label: "s390x"
             cpu_arch: "s390x"
+      jdk19:
+        installers:
+          linux-arm64:
+            type: "zip"
+            label: "linux && arm64"
+            cpu_arch: "aarch64"
+          s390x:
+            type: "zip"
+            label: "s390x"
+            cpu_arch: "s390x"
   permanent_agents:
     s390x-agent:
       remoteFS: /home/jenkins/agent

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -235,6 +235,7 @@ profile::jenkinscontroller::jcasc:
     jdk8: "8u352-b08"
     jdk11: "11.0.17+8"
     jdk17: "17.0.5+8"
+    jdk19: "19.0.1+10"
     maven: "3.8.6"
   artifact_caching_proxy:
     providers:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -45,6 +45,16 @@ profile::jenkinscontroller::jcasc:
             type: "zip"
             label: "s390x"
             cpu_arch: "s390x"
+      jdk19:
+        installers:
+          linux-arm64:
+            type: "zip"
+            label: "linux && arm64"
+            cpu_arch: "aarch64"
+          s390x:
+            type: "zip"
+            label: "s390x"
+            cpu_arch: "s390x"
   permanent_agents:
     s390x-agent:
       remoteFS: /home/jenkins/agent


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3243
adding the jdk19 as a tool from within the controller for ci.jenkins.io as code within puppet.

a subsequent PR will deal with the updatecli to keep it on the latest jdk19