### PR TITLE
chore(updatecli): add jdk19 to the tracking version

### DIFF
--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -25,6 +25,10 @@ function get_jdk_download_url() {
       ## JDK17 URLs have an underscore ('_') instead of a plus ('+') in their archive names
       echo "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${jdk_version}/OpenJDK17U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
+    19*)
+      ## JDK19 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${jdk_version}/OpenJDK19U-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      return 0;;
     *)
       echo "ERROR: unsupported JDK version (${jdk_version}).";
       exit 1;;
@@ -38,6 +42,8 @@ case "${1}" in
   11.*)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
   17.*+*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
+  19.*+*)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
   *)
     echo "ERROR: unsupported JDK version (${1}).";

--- a/updatecli/weekly.d/jenkinscontroller-tools-jdk19.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-jdk19.yaml
@@ -1,0 +1,54 @@
+---
+name: Bump JDK19 version (Jenkins tools) on all controllers
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getLatestJDK19Version:
+    kind: githubrelease
+    name: Get the latest Adoptium JDK19 version
+    spec:
+      owner: "adoptium"
+      repository: "temurin19-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-19.0.1+10(https://github.com/adoptium/temurin19-binaries/releases/tag/jdk-19.0.1%2B10) is OK
+        pattern: "^jdk-19.(\\d*).(\\d*).(\\d*)+(\\d*)$"
+    transformers:
+      - trimprefix: "jdk-"
+
+conditions:
+  checkIfReleaseIsAvailable:
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+
+targets:
+  setJDK19Version:
+    name: "Bump JDK19 version on tools"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.tools_default_versions.jdk19"
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    title: Bump JDK19 version (Jenkins tools) on all controllers to {{ source "getLatestJDK19Version" }}
+    spec:
+      labels:
+        - dependencies


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3243 step 2 add a updatecli manifest to keep track for jdk 19