### PR TITLE
fix(datadog) fine-tune disk metric collect to avoid tons of errors related to docker overlay of netns

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -154,7 +154,7 @@ datadog_agent::integrations:
           - overlay
           - shm
           - nsfs # netns
-        include_all_devices: true
+        include_all_devices: false
 profile::buildagent::ssh_keys:
   "/home/jenkins/.ssh/id_rsa":
     privkey: |

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -142,6 +142,19 @@ datadog_agent::api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQ
 datadog_agent::process_enabled: true
 datadog_agent::logs_enabled: true
 datadog_agent::container_collect_all: true
+datadog_agent::integrations:
+  disk:
+    init_config: {}
+    instances:
+      - use_mount: false
+        # Disable filesystem checks Ref. https://github.com/DataDog/dd-agent/issues/2932 and https://github.com/jenkins-infra/helpdesk/issues/1746
+        file_system_exclude:
+          - tmpfs
+          - none
+          - overlay
+          - shm
+          - nsfs # netns
+        include_all_devices: true
 profile::buildagent::ssh_keys:
   "/home/jenkins/.ssh/id_rsa":
     privkey: |


### PR DESCRIPTION
Close https://github.com/jenkins-infra/helpdesk/issues/1746

I was spammed by these errors on a personnal machine and found https://github.com/DataDog/dd-agent/issues/2932.

Fine-tuning the "disk" integration of the datadog agent seems to work pretty well