### PR TITLE
fix(docker) ensure that docker engine are cleaned up from dangling resources once a day

### DIFF
--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -44,4 +44,12 @@ class profile::docker {
     mode    => '0600',
     notify  => Service['docker'],
   }
+
+  cron { 'docker-system-prune':
+    # Override the content of the log file to avoid heavy files not rotated in 2-3 years.
+    command => "bash -c 'date && docker system prune --volumes --force' >/var/log/docker-system-prune.log 2>&1",
+    user    => 'root',
+    hour    => 2, # Once a day during UTC night
+    require => Class['docker'],
+  }
 }

--- a/spec/classes/profile/docker_spec.rb
+++ b/spec/classes/profile/docker_spec.rb
@@ -6,4 +6,5 @@ describe 'profile::docker' do
   it { expect(subject).to contain_firewall('010 allow inter-docker traffic').with_action('accept').with_iniface('docker0') }
   it { expect(subject).to contain_file('/etc/docker').with('ensure' => 'directory')}
   it { expect(subject).to contain_file('/etc/docker/daemon.json')}
+  it { expect(subject).to contain_cron('docker-system-prune').with('command' => "bash -c 'date && docker system prune --volumes --force' >/var/log/docker-system-prune.log 2>&1")}
 end


### PR DESCRIPTION
While working on #2054 , @smerle33 and I realized that there was no garbage collector for dangling docker resources.

This PR adds a crontab entry for the `root` user on each machine with the profile `docker`. This crontab run the `docker system prune` command and logs the output to ensure that dangling resources (unused and orphans docker resources such as images, layers, networks, volumes, etc.) are cleaned up.

The goal is to avoid filling VM disks.