### PR TITLE
fix(windows ACI agents): add double quotes around JENKINS_JAVA_OPTS

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -218,7 +218,8 @@ profile::jenkinscontroller::jcasc:
       remoteAdmin: Administrator
       osDiskSize: 128
       agentJavaBin: 'C:/tools/jdk-11/bin/java'
-      agentJavaOpts: '-XX:+PrintCommandLineFlags'
+      agentJavaOpts: >-
+        \"-XX:+PrintCommandLineFlags\"
     ubuntu:
       agentDir: "/home/jenkins"
       remoteAdmin: jenkins


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3274
