### PR TITLE
fix(inbound-agent-maven): provide new version with AgentJavaBin to the correct jdk11

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -431,6 +431,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
+            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
             labels:
               - maven-windows
           - name: maven-11-windows
@@ -438,7 +439,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
             labels:
               - maven-11-windows
           - name: maven-17-windows
@@ -446,7 +447,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
             labels:
               - maven-17-windows
           - name: maven-19-windows

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -237,10 +237,10 @@ profile::jenkinscontroller::jcasc:
       version: 0.50.0
       subscription_id: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAluBQmOHo1MWoOCMVOCcgVUs9gOzFVEZMT7RA3V33KeolyRKh0lm5Ta5+C9aKJe9myuVGaDQsd99XsW40d7NdygJcnBxUV+VTnnLphjplPtCX5JIS4ww/S8JGOpOIE2zejy5bL2CpnZhgSFh+aD1FLD91ozNS5lgNOq9hNKqo+mSfUnX5wrUFvlCaadTWp3yxG7l7VluxP1Wh4BlsRmphmbUmmgFo56CjDUVz9dMwxT/p/uE1S/SPuEirJOAPtPCl7x2NQWg+Qlv5j1tC5ASgh9beD3SjUVPd6VYM+K+u07aw8jOj/meARXgghtUPgqHqWC44JGHPzWkZ4dQFhe6jyzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDc6VPQnQTEmwF9aAh/uK9IgDDXAM9S6QNxRH8cFSOAESeqOlLFBKVAlJc3Mnby3Pc/6H21BsehZbQLUd+1MfcoPI0=]
     container_images:
-      jnlp-maven-8-windows: jenkinsciinfra/inbound-agent-maven:jdk8-nanoserver@sha256:4f4f542a1a408694d38771a8665ef01cdd8600e0a177ecffc8108aa2932fb89f
-      jnlp-maven-11-windows: jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver@sha256:58d48b7bfd6b49b9f9bb64fb400a1d141fcec5e2618660283938a9acaade2de1
-      jnlp-maven-17-windows: jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver@sha256:0f4b2b580680826cff3766d7f1928ab1c6f87da3aec54c1a753bedac907b1dcc
-      jnlp-maven-19-windows: jenkinsciinfra/inbound-agent-maven:jdk19-nanoserver@sha256:b1f001800382e0f685c50dbd8f3ed30d71e641068c41875014aa4937745f529a
+      jnlp-maven-8-windows: jenkinsciinfra/inbound-agent-maven:jdk8-nanoserver@sha256:d19080132b5b744a016945cc623049ae7ab685bdb76cbad781c8ba50b9aaf19c
+      jnlp-maven-11-windows: jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver@sha256:af17c242ca75a837913a35c5fa8824cf8236ae36bf640fdbfd89e825e14f4fdc
+      jnlp-maven-17-windows: jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver@sha256:b7a49e03de2eaf415dd9fa296564681f7b74cabe7871894cc32bffa5b236e386
+      jnlp-maven-19-windows: jenkinsciinfra/inbound-agent-maven:jdk19-nanoserver@sha256:a42f3b96dfd4085bb1a9f288bf55862633dbdce0deee4b5f63a70724225a8b4f
       jnlp-ruby: jenkinsciinfra/inbound-agent-ruby@sha256:221f96baa1957742728eb6d2769a691aea5721fc11ed9b05da810c5debe92115
       jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-20.04@sha256:0b7b41beceb21d9bc45eab578e03241f079bfc957ea93ebd749932953d46e201
       jnlp-webbuilder: 'jenkinsciinfra/builder@sha256:c65478b0b383d0eabc007eef7ee50dba751b5cc6914ff19738ea84c7782e2f47'

--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -45,6 +45,30 @@ sources:
       image: "jenkinsciinfra/inbound-agent-maven"
       tag: "jdk17"
       architecture: amd64
+  getLatestInboundMaven8WindowsContainerImage:
+    kind: dockerdigest
+    spec:
+      image: "jenkinsciinfra/inbound-agent-maven"
+      tag: "jdk8-nanoserver"
+      architecture: amd64
+  getLatestInboundMaven11WindowsContainerImage:
+    kind: dockerdigest
+    spec:
+      image: "jenkinsciinfra/inbound-agent-maven"
+      tag: "jdk11-nanoserver"
+      architecture: amd64
+  getLatestInboundMaven17WindowsContainerImage:
+    kind: dockerdigest
+    spec:
+      image: "jenkinsciinfra/inbound-agent-maven"
+      tag: "jdk17-nanoserver"
+      architecture: amd64
+  getLatestInboundMaven19WindowsContainerImage:
+    kind: dockerdigest
+    spec:
+      image: "jenkinsciinfra/inbound-agent-maven"
+      tag: "jdk19-nanoserver"
+      architecture: amd64
   getLatestInboundWebBuilderContainerImage:
     kind: dockerdigest
     spec:
@@ -156,6 +180,46 @@ targets:
     spec:
       file: hieradata/common.yaml
       key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp"
+    transformers:
+      - addprefix: "jenkins/inbound-agent@"
+    scmid: default
+  setInboundJDK8WindowsContainerImage:
+    sourceid: getLatestInboundMaven8WindowsContainerImage
+    name: "Bump container agent image jenkinsciinfra/inbound-agent-maven (jdk8-nanoserver)"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-8-windows"
+    transformers:
+      - addprefix: "jenkins/inbound-agent@"
+    scmid: default
+  setInboundJDK11WindowsContainerImage:
+    sourceid: getLatestInboundMaven11WindowsContainerImage
+    name: "Bump container agent image jenkinsciinfra/inbound-agent-maven (jdk11-nanoserver)"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-11-windows"
+    transformers:
+      - addprefix: "jenkins/inbound-agent@"
+    scmid: default
+  setInboundJDK17WindowsContainerImage:
+    sourceid: getLatestInboundMaven17WindowsContainerImage
+    name: "Bump container agent image jenkinsciinfra/inbound-agent-maven (jdk17-nanoserver)"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-17-windows"
+    transformers:
+      - addprefix: "jenkins/inbound-agent@"
+    scmid: default
+  setInboundJDK19WindowsContainerImage:
+    sourceid: getLatestInboundMaven19WindowsContainerImage
+    name: "Bump container agent image jenkinsciinfra/inbound-agent-maven (jdk19-nanoserver)"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-19-windows"
     transformers:
       - addprefix: "jenkins/inbound-agent@"
     scmid: default


### PR DESCRIPTION
Update the sha to provide the last version of the agent using the correct AgentJavaBin path to jdk 11.

with the corresponding updatecli manifest for the sha256 of all 4 images jdk8, 11, 17 and 19 (windows nanoserver)