### PR TITLE
feat(openvpn) refactor to allow hieradata network setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 *.sw*
 .vagrant*
 .ruby-*
-spec/fixtures/
+spec/fixtures/manifests
+spec/fixtures/modules
 .bundle
 modules
 modules/

--- a/Puppetfile
+++ b/Puppetfile
@@ -25,7 +25,7 @@ mod 'puppetlabs-cron_core', '1.1.0'
 mod 'saz-sudo', '5.0.0'
 
 # Needed for managing firewall rules
-mod 'puppetlabs-firewall', '3.0.1'
+mod 'puppetlabs-firewall', '4.0.0'
 
 # Needed for managing .yaml files from within Puppet
 mod 'reidmv-yamlfile'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,9 @@ Vagrant.configure("2") do |config|
         d.has_ssh = true
     end
 
+    # Add a secondary NIC (simulation of a "private" network for roles such as openvpn)
+    config.vm.network "private_network", ip: "192.168.0.10", netmask: 24, docker_network__internal: true, docker_network__gateway: "192.168.0.1"
+
     config.vm.network "forwarded_port", guest: 80, host: 80
     config.vm.network "forwarded_port", guest: 443, host: 443
     config.vm.network "forwarded_port", guest: 8080, host: 8080

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
         d.has_ssh = true
     end
 
-    # Add a secondary NIC (simulation of a "private" network for roles such as openvpn)
+    # Add a secondary NIC ("private" network simulation for roles such as openvpn)
     config.vm.network "private_network", ip: "192.168.0.10", netmask: 24, docker_network__internal: true, docker_network__gateway: "192.168.0.1"
 
     config.vm.network "forwarded_port", guest: 80, host: 80

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
                 puppet.working_directory = "/vagrant"
                 puppet.manifests_path = "manifests"
                 puppet.manifest_file = "site.pp"
-                puppet.options = "--hiera_config=/vagrant/spec/fixtures/hiera.yaml --execute 'require profile::vagrant\n include role::#{veggie}'"
+                puppet.options = "--hiera_config=/vagrant/vagrant-docker/hiera.yaml --execute 'require profile::vagrant\n include role::#{veggie}'"
             end
         end
     end

--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -89,7 +89,7 @@ class profile::openvpn (
     content => template("${module_name}/openvpn/90-network-config.yaml.erb"),
   }
 
-  # The CLI '/sbin/route' is required to create custom routes for peered networks
+  # The CLI '/sbin/route' included in net-tools is required to create custom routes for peered networks
   package { 'net-tools':
     ensure => present,
   }

--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -89,11 +89,19 @@ class profile::openvpn (
     content => template("${module_name}/openvpn/90-network-config.yaml.erb"),
   }
 
+  # The CLI '/sbin/route' is required to create custom routes for peered networks
+  package { 'net-tools':
+    ensure => present,
+  }
+
   ## Custom routes for peered networks
   exec { 'addroute-10.240.0.0':
     command => 'ip route add 10.240.0.0/14 via 10.0.2.1 dev eth1',
     unless  => 'route | grep 10.240.0.0',
     path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+    require => [
+      Package['net-tools'],
+    ],
   }
 
   firewall { '107 accept incoming 443 connections':

--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -42,11 +42,21 @@ class profile::openvpn (
     require          => [Docker::Image[$image]],
   }
 
+  file { '/etc/cloud':
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'root',
+    recurse => true,
+  }
+
   file { '/etc/cloud/cloud.cfg.d':
     ensure  => 'directory',
     owner   => 'root',
     group   => 'root',
     recurse => true,
+    require => [
+      File['/etc/cloud'],
+    ],
   }
 
   # Ensure cloud-init doesn't manage network (netplan config + netplan apply + systemd, in Ubuntu Bionic)

--- a/hieradata/clients/vpn.jenkins.io.yaml
+++ b/hieradata/clients/vpn.jenkins.io.yaml
@@ -1,14 +1,26 @@
 ---
 profile::openvpn::networks:
   eth0:
+    name: Subnet 'dmz' of network 'prod-jenkins-public-prod'
     route-metric: 100
     macaddress: 00:0d:3a:0e:4b:1c
+    network_cidr: 10.0.99.0/24
   eth1:
+    name: Subnet 'data-tier' of network 'prod-jenkins-public-prod'
     route-metric: 200
     macaddress: 00:0d:3a:0e:4f:89
+    network_cidr: 10.0.2.0/24
+    peered_network_cidrs:
+      # Network 'prod-jenkins-private-prod-vnet' through peering
+      - 10.240.0.0/14
   eth2:
+    name: Subnet 'app-tier' of network 'prod-jenkins-public-prod'
     route-metric: 300
     macaddress: 00:0d:3a:0e:4e:7e
+    network_cidr: 10.0.1.0/24
+profile::openvpn::vpn_networks_cidr:
+  - 10.8.0.0/24 # Normal VPN
+  - 10.8.1.0/24 # Admin network (legacy: only used for KK openvpn client config) - https://github.com/jenkins-infra/docker-openvpn/blob/583f84af3fb7f0a60bfb0b100e56e1b905d713f2/config.yaml#L12-L19
 profile::openvpn::auth_ldap_binddn: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAUnLHzSYfhy9wQ622F9qg27p80NMo+5M1I0XJUM3vQ6+XhcmG8OeFN0lksZJMD1p2tp8vZTAbq+BtdCfy9e9iaZudQvL2XHqlGFSrssz25FfpfKny5/QvKRZJqOW7K/7gfwnj+kIO7kVMFkO0XhcqRKsCjO2hBIaWBw/3BtIpE0MB/pPw/vLI3aERnj/YBRg6iHQUuBiYOZc5WJ6CJiVPiiCcfz1YhzvsdjeE/6PLCXSWVzR6fXJaIv8AeLOJ/T/KrulWZbQ2C3fE/hWYCznIEzmsHHnd/td8/gTOyetl8CbPeeVWnl3z4cjD3dhpRc80hDB912Wpp7p3U6QeM2qlszBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDTNSew0xsPvYG7UiPm3rC2gDBdODpfNj9Y+ihtpKsm67MmN88nbQZ2LPfg2ClMVFQOYtKs+3nQoT8LupqIDGMIRYo=]
 profile::openvpn::auth_ldap_password: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAHnkX82SuWKYuW/ROAxQX3fw+HrN/AQf3BpbeUdSwCe9+ljLni05W4ZypQkRNgEksUfD0bBgK2RA7PF+KYSnTpA5v+GkqjUn8iAZg9whEpQaK7wfidp8rSL+nlsJFNE8mPHLCoO+6xHMFmm6XCCsFnQ2qYNQAjWeecngdp3IIZi2Vs8NBYJbOEovsRgdksNu7gO516C9DBrWKaTOf7j9x28g22XFQ3kxefxq89QGquvwc3Lyl8iNInJNUQ8wmCk54+m2CvTKzbqnO53QgHbw2VUwN+6JnmN+HgxzSM9o+VO8x2S8o8dzS0v45fWwLM4sKuwUPeAxfVGpfb2J46ab3tzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAidRxKsLYgBugid4s3KGq+gCBhpSsRd85sDKxC3m6l5ys56qg96hfUV7BRqeygYAztiw==]
 # CA comes from https://github.com/jenkins-infra/docker-openvpn

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -1,0 +1,405 @@
+---
+lookup_options:
+  "^profile::jenkinscontroller::jcasc$":
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+
+profile::jenkinscontroller::ci_fqdn: 'cert.ci.jenkins.io'
+profile::jenkinscontroller::ci_resource_domain: 'assets.cert.ci.jenkins.io'
+profile::jenkinscontroller::proxy_port: 443
+profile::jenkinscontroller::letsencrypt: false
+profile::jenkinscontroller::groovy_init_enabled: false
+profile::jenkinscontroller::memory_limit: '14g'
+profile::jenkinscontroller::jcasc:
+  enabled: true
+  reload_token: SuperSecretThatShouldBeEncryptedInProduction
+  tools:
+    groovy:
+      groovy: # Default version is named "groovy"
+        version: "2.4.7"
+    jdk:
+      jdk8:
+        installers:
+          linux-arm64:
+            type: "zip"
+            label: "linux && arm64"
+            cpu_arch: "aarch64"
+      jdk11:
+        installers:
+          linux-arm64:
+            type: "zip"
+            label: "linux && arm64"
+            cpu_arch: "aarch64"
+          s390x:
+            type: "zip"
+            label: "s390x"
+            cpu_arch: "s390x"
+      jdk17:
+        installers:
+          linux-arm64:
+            type: "zip"
+            label: "linux && arm64"
+            cpu_arch: "aarch64"
+          s390x:
+            type: "zip"
+            label: "s390x"
+            cpu_arch: "s390x"
+      jdk19:
+        installers:
+          linux-arm64:
+            type: "zip"
+            label: "linux && arm64"
+            cpu_arch: "aarch64"
+          s390x:
+            type: "zip"
+            label: "s390x"
+            cpu_arch: "s390x"
+  permanent_agents:
+    s390x-agent:
+      remoteFS: /home/jenkins/agent
+      labels:
+        - s390x
+        - s390xdocker
+      mode: EXCLUSIVE
+      ssh:
+        host: "148.100.113.105"
+        credentialsId: "jenkins-s390x"
+        hostKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCYwX3Fu4fWEb9hPlan3FsiUsZoCsMD7CMqFNT/+Uh11HhvKU5ZFiF3sGNI7FrhNNbqBFd0HnS1t3zIkP3FFlKToSTrkcXPUyw+svFf5YbPbDxQUNE0kclTUsERzC3GNB5eXUlyNxCiGksqGtinXgknF2Z5cOO8osODP7ddRc6L3H4gvDi0/smz9QukZB2N0FqBJ3EZGbv0X9V3iwRu6Cu9lhcl/ue5fuIjKAgGzGQgWgCEg0k9xkK0OmxyJalI0eiqBRbdES/bXkkxp+4TQNOsxN/ZrZqxtlN7o9Fq9y+dp7xQFEoivSAjn6WQ6izjkMGKon7rcFJ4t4g6FJoQYv2Z"
+      envVars:
+        PATH+MAVEN: "/home/jenkins/tools/apache-maven-3.8.4/bin"
+      toolLocation:
+        - home: "/home/jenkins/tools/apache-maven-3.8.4"
+          key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
+  cloud_agents:
+    kubernetes:
+      cik8s:
+        enabled: true
+        provider: "aws"
+        credentialsId: "cik8s-jenkins-agent-sa-token"
+        serverCertificate: SuperSecretThatShouldBeEncryptedInProduction
+        max_capacity: 120 # Max 50 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each, minus the 30 of doks
+        url: SuperSecretThatShouldBeEncryptedInProduction
+        agent_definitions:
+          - name: jnlp-maven-8
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-8
+            labels:
+              - maven
+              - maven-8
+              - jdk8
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-11
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-11
+            labels:
+              - maven-11
+              - jdk11
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-17
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-17
+            labels:
+              - maven-17
+              - jdk17
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-webbuilder
+            agentJavaBin: java
+            cpus: 2
+            memory: 4
+            labels:
+              - node
+              - webbuilder
+              - ruby
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp
+            labels:
+              - default
+            cpus: 1
+            memory: 1
+            imagePullSecrets: dockerhub-credential
+      doks:
+        enabled: true
+        provider: do
+        credentialsId: "doks-jenkins-agent-sa-token"
+        serverCertificate: SuperSecretThatShouldBeEncryptedInProduction
+        max_capacity: 30 # Max 10 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each
+        url: SuperSecretThatShouldBeEncryptedInProduction
+        agent_definitions:
+          - name: jnlp-maven-8
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-8
+            labels:
+              - maven
+              - maven-8
+              - jdk8
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-11
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-11
+            labels:
+              - maven-11
+              - jdk11
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-17
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-17
+            labels:
+              - maven-17
+              - jdk17
+            cpus: 4
+            memory: 8
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp-webbuilder
+            agentJavaBin: java
+            cpus: 2
+            memory: 4
+            labels:
+              - node
+              - webbuilder
+              - ruby
+            imagePullSecrets: dockerhub-credential
+          - name: jnlp
+            labels:
+              - default
+            cpus: 1
+            memory: 1
+            imagePullSecrets: dockerhub-credential
+    ec2:
+      aws-us-east-2:
+        region: us-east-2
+        credentialsId: "aws-credentials-jenkins-ci"
+        sshKeysCredentialsId: "ec2-agent-ssh-2021-06"
+        agent_definitions:
+          - description: "Ubuntu 20.04 LTS"
+            maxInstances: 20
+            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            architecture: "amd64"
+            labels:
+              - java
+              - docker
+              - linux
+            useAsMuchAsPosible: true
+            spot: true
+          - description: "Windows 2019"
+            maxInstances: 10
+            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
+            os: "windows"
+            architecture: "amd64"
+            labels:
+              - docker-windows
+            useAsMuchAsPosible: true
+            spot: true
+          - description: "High memory ubuntu 20.04 (ondemand)"
+            maxInstances: 50
+            instanceType: M54xlarge # 16 vCPUS / 64 Gb
+            os: "ubuntu"
+            architecture: "amd64"
+            labels:
+              - highmem
+              - highram
+              - docker-highmem
+            useAsMuchAsPosible: false
+            spot: false
+          - description: "Ubuntu 20.04 LTS datadog"
+            maxInstances: 1
+            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            architecture: "amd64"
+            labels:
+              - ec2_datadog
+            useAsMuchAsPosible: false
+            userData: &datadogInitUserData
+              - "#!/bin/bash"
+              - "sed 's/api_key:.*/api_key: tokeepsecret' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+              - mkdir /var/log/datadog
+              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+              - chmod 640 /etc/datadog-agent/datadog.yaml
+              - chown dd-agent:dd-agent /var/log/datadog
+              - chmod 770 /var/log/datadog
+              - systemctl restart datadog-agent.service
+              - rm -f /etc/sudoers.d/90-cloud-init-users
+          - description: "ARM64 ubuntu 20.04"
+            maxInstances: 5
+            instanceType: A1Xlarge # 4 vCPUs / 8 Gb
+            os: "ubuntu"
+            architecture: "arm64"
+            labels:
+              - arm64docker
+              - arm64linux
+            useAsMuchAsPosible: false
+            spot: true
+            userData: *datadogInitUserData
+    azure-vm-agents:
+      azureCredentialsId: "azure-credentials"
+      resource_group: eastus-cijenkinsio
+      agent_definitions:
+        - name: "ubuntu-20"
+          description: "Ubuntu 20.04 LTS"
+          imageDefinition: jenkins-agent-ubuntu-20.04
+          os: "ubuntu"
+          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
+          location: "East US 2"
+          instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
+          architecture: amd64
+          labels:
+            - java
+            - linux
+            - docker
+          maxInstances: 10
+          useAsMuchAsPosible: true
+          credentialsId: "jenkinsvmagents-userpass"
+          usePrivateIP: true
+          virtualNetworkName: "prod-jenkins-public-prod"
+          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+          subnetName: "ci.j-agents-vm"
+          spot: true
+          initScript: *datadogInitUserData
+        - name: "ubuntu-20-highmem"
+          description: "Ubuntu 20.04 LTS Highmem"
+          imageDefinition: jenkins-agent-ubuntu-20.04
+          os: "ubuntu"
+          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
+          location: "East US 2"
+          instanceType: Standard_D16s_v3 # 16 vCPUS / 64 Gb
+          architecture: amd64
+          labels:
+            - highmem
+            - highram
+            - docker-highmem
+          maxInstances: 20
+          useAsMuchAsPosible: false
+          usePrivateIP: true
+          credentialsId: "jenkinsvmagents-userpass"
+          virtualNetworkName: "prod-jenkins-public-prod"
+          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+          subnetName: "ci.j-agents-vm"
+          spot: false
+        - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2019"
+          imageDefinition: jenkins-agent-windows-2019
+          os: "windows"
+          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
+          location: "East US 2"
+          instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
+          architecture: amd64
+          labels:
+            - docker-windows
+          maxInstances: 20
+          useAsMuchAsPosible: true
+          credentialsId: "jenkinsvmagents-userpass"
+          useEphemeralOSDisk: false
+          usePrivateIP: true
+          virtualNetworkName: "prod-jenkins-public-prod"
+          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+          subnetName: "ci.j-agents-vm"
+          spot: true
+        - name: "win-2019-datadog-test" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2019 test datadog"
+          imageDefinition: jenkins-agent-windows-2019
+          os: "windows"
+          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
+          location: "East US 2"
+          instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
+          architecture: amd64
+          labels:
+            - docker-windows-test-datadog
+          maxInstances: 20
+          useAsMuchAsPosible: false
+          credentialsId: "jenkinsvmagents-userpass"
+          useEphemeralOSDisk: false
+          usePrivateIP: true
+          virtualNetworkName: "prod-jenkins-public-prod"
+          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+          subnetName: "ci.j-agents-vm"
+          spot: false
+          initScript:
+            - <powershell>
+            - (Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: keytokeepsecret' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml
+            - </powershell>
+    azure-container-agents:
+      aci-windows:
+        credentialsId: "azure-credentials"
+        resource_group: eastus-cijenkinsio
+        agent_definitions:
+          - name: maven-8-windows
+            os: windows
+            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+            cpus: 4
+            memory: 8
+            labels:
+              - maven-windows
+          - name: maven-11-windows
+            os: windows
+            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+            cpus: 4
+            memory: 8
+            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+            labels:
+              - maven-11-windows
+          - name: maven-17-windows
+            os: windows
+            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+            cpus: 4
+            memory: 8
+            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+            labels:
+              - maven-17-windows
+  artifact_caching_proxy:
+    disabled: false
+# These are plugins we need in our ci environment
+profile::jenkinscontroller::plugins:
+  - ansicolor
+  - azure-container-agents
+  - azure-vm-agents
+  - blueocean
+  - build-timeout
+  - buildtriggerbadge
+  - cloudbees-folder
+  - code-coverage-api
+  - config-file-provider
+  - configuration-as-code
+  - credentials
+  - credentials-binding
+  - docker-workflow
+  - ec2
+  - embeddable-build-status
+  - git-client
+  - git
+  - github
+  - github-checks
+  - github-branch-source
+  - groovy
+  - kubernetes
+  - jobConfigHistory
+  - junit-attachments
+  - junit-realtime-test-reporter
+  - ldap
+  - lockable-resources
+  - mailer
+  - matrix-auth
+  - parallel-test-executor
+  - pipeline-githubnotify-step
+  - pipeline-graph-view
+  - pipeline-stage-view
+  - pipeline-utility-steps
+  - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs
+  - ssh-slaves # SSH Build Agent to implement "outbound agents"
+  - throttle-concurrents
+  - timestamper
+  - toolenv
+  - warnings-ng
+  - workflow-aggregator
+  - workflow-multibranch

--- a/hieradata/rspec/profile_openvpn.yaml
+++ b/hieradata/rspec/profile_openvpn.yaml
@@ -1,0 +1,15 @@
+---
+profile::openvpn::networks:
+  eth0:
+    name: Public network
+    # route-metric: 100
+    # macaddress: 00:0d:3a:0e:4b:1c
+    network_cidr: 192.168.0.0/24
+  eth1:
+    name: Private Network
+    network_cidr: 192.168.100.0/24
+    peered_network_cidrs:
+      - 10.0.0.0/16
+profile::openvpn::vpn_networks_cidr:
+  - 127.0.10.0/24
+  - 172.19.0.0/24

--- a/hieradata/vagrant/roles/openvpn.yaml
+++ b/hieradata/vagrant/roles/openvpn.yaml
@@ -1,14 +1,20 @@
 ---
 profile::openvpn::networks:
   eth0:
+    name: Subnet 'dmz' of network 'prod-jenkins-public-prod'
     route-metric: 100
     macaddress: 00:0d:3a:0e:4b:1c
+    network_cidr: 172.17.0.0/24
   eth1:
+    name: Subnet 'data-tier' of network 'prod-jenkins-public-prod'
     route-metric: 200
     macaddress: 00:0d:3a:0e:4f:89
-  eth2:
-    route-metric: 300
-    macaddress: 00:0d:3a:0e:4e:7e
+    network_cidr: 192.168.0.10/24
+    peered_network_cidrs:
+      - 10.1.0.0/16
+profile::openvpn::vpn_networks_cidr:
+  - 10.8.0.0/24
+  - 10.8.1.0/24
 
 profile::openvpn::auth_ldap_password: 's3cr3t'
 profile::openvpn::auth_ldap_url: 'ldaps://ldap'

--- a/spec/classes/profile/jenkinscontroller_spec.rb
+++ b/spec/classes/profile/jenkinscontroller_spec.rb
@@ -7,6 +7,11 @@ describe 'profile::jenkinscontroller' do
       :ci_fqdn => fqdn,
     }
   end
+  let(:facts) do
+    {
+      :rspec_hieradata_fixture => 'profile_jenkinscontroller',
+    }
+  end
 
   context 'Jenkins configuration' do
     it { is_expected.to contain_user('jenkins').with(

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'profile::openvpn' do
+  let(:facts) do
+    {
+      :rspec_hieradata_fixture => 'profile_openvpn',
+    }
+  end
+
+  it { expect(subject).to contain_class 'stdlib' }
+  it { expect(subject).to contain_class 'profile::docker' }
+
+  it { expect(subject).to contain_package 'net-tools' }
+
+  it { expect(subject).to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
+
+  it { expect(subject).to contain_firewall '107 accept incoming 443 connections' }
+
+  # Routing from VPN networks to eth0 network
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.0.0/24 on ports 80/443" } #.with('outiface' => 'eth0') }
+  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 192.168.0.0/24 on ports 80/443" }
+
+  # Routing from VPN networks to eth1 network
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.100.0/24 on ports 80/443" }
+  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 192.168.100.0/24 on ports 80/443" }
+
+  # Routing from VPN networks to eth1 peered networks
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 10.0.0.0/16 on ports 80/443" }
+  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 10.0.0.0/16 on ports 80/443" }
+  it { expect(subject).to contain_exec "addroute 10.0.0.0 through 192.168.100.1 (NIC eth1)" }
+end

--- a/updatecli/weekly.d/puppet-modules/firewall.yaml
+++ b/updatecli/weekly.d/puppet-modules/firewall.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump the Firewall Puppet Module
+name: Bump the puppetlabs-firewall module
 
 scms:
   default:
@@ -32,12 +32,11 @@ conditions:
     kind: shell
     disablesourceinput: true
     spec:
-    # https://forge.puppet.com/v3/files/puppetlabs-firewall-4.0.0.tar.gz
       command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppetlabs-firewall-{{ source "latestVersion" }}.tar.gz
 
 targets:
   puppetfile:
-    name: "Update Puppetfile with the latest Firewall module version"
+    name: "Update Puppetfile with the latest puppetlabs-firewall module version"
     kind: file
     sourceid: latestVersion
     spec:
@@ -52,8 +51,9 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    title: Bump the Firewall Puppet Module to {{ source "latestVersion" }}
+    title: Bump `puppetlabs-firewall` module to {{ source "latestVersion" }}
     spec:
       labels:
         - puppet-module
+        - puppetlabs-firewall
         - dependencies

--- a/updatecli/weekly.d/puppet-modules/firewall.yaml
+++ b/updatecli/weekly.d/puppet-modules/firewall.yaml
@@ -1,0 +1,59 @@
+---
+name: Bump the Firewall Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppetlabs-firewall module version
+    spec:
+      owner: puppetlabs
+      repository: puppetlabs-firewall
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+    # https://forge.puppet.com/v3/files/puppetlabs-firewall-4.0.0.tar.gz
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppetlabs-firewall-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest Firewall module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppetlabs-firewall'(.*)
+      replacepattern: >
+        mod 'puppetlabs-firewall', '{{ source "latestVersion" }}'
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    title: Bump the Firewall Puppet Module to {{ source "latestVersion" }}
+    spec:
+      labels:
+        - puppet-module
+        - dependencies

--- a/vagrant-docker/Dockerfile
+++ b/vagrant-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG="en_US.UTF-8"
@@ -13,6 +13,7 @@ RUN apt-get update \
   build-essential \
   curl \
   iproute2 \
+  iptables \
   locales \
   lvm2 \
   openssh-server \

--- a/vagrant-docker/hiera.yaml
+++ b/vagrant-docker/hiera.yaml
@@ -2,13 +2,15 @@
 version: 5
 defaults:
   # Relative path to the current file
-  datadir: ../../hieradata
+  datadir: ../hieradata
   data_hash: yaml_data
 hierarchy:
   - name: "YAML Hierarchy Levels"
     paths:
-      # Rspec custom
-      - "rspec/%{rspec_hieradata_fixture}.yaml"
+      # Vagrant-specific hierarchy
+      - "vagrant/clients/%{veggie}.yaml"
+      - "vagrant/roles/%{hiera_role}.yaml"
+      - "vagrant/common.yaml"
       # Same hierarchy as production (dist/profile/files/hiera.yaml is the reference)
       - "clients/%{clientcert}.yaml"
       - "roles/%{hiera_role}.yaml"


### PR DESCRIPTION
This PR refactors the OpenVPN profile to allow specifying the network configurations (routes, etc.) through hieradata, setting the ground for multiple VPN machines.

It also introduces the following changes that were required to test and validate the reafctoring:

- Add a second NIC to the container (require using Ubuntu 20.04 instead of 18.04 but EOL is near so it's OK)
- Split hieradata configs between rspec and vagrant to ensure we can properly unit tests
- Track the puppet firewall module with updatecli and bump it to 4.0.0 (to support latest iptables versions)