### PR TITLE
fix(ci.j.io agents): quotes java opts only for windows azure containers

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -95,7 +95,11 @@ jenkins:
         # Please note that envVars are specified differently than permanent or Kubernetes agents
         envVars:
           - key: "JENKINS_JAVA_OPTS"
+          <%- if !agent['agentJavaOpts'] && @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] && !@jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'].empty? && agent['os'].to_s == 'windows' -%>
+            value: "\"<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>\""
+          <%- else -%>
             value: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
+          <%- end -%>
           - key: "JENKINS_JAVA_BIN"
             value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
           - key: "ARTIFACT_CACHING_PROXY_PROVIDER"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -218,8 +218,7 @@ profile::jenkinscontroller::jcasc:
       remoteAdmin: Administrator
       osDiskSize: 128
       agentJavaBin: 'C:/tools/jdk-11/bin/java'
-      agentJavaOpts: >-
-        \"-XX:+PrintCommandLineFlags\"
+      agentJavaOpts: '-XX:+PrintCommandLineFlags'
     ubuntu:
       agentDir: "/home/jenkins"
       remoteAdmin: jenkins


### PR DESCRIPTION
Fix https://github.com/jenkins-infra/helpdesk/issues/3283 and following https://github.com/jenkins-infra/jenkins-infra/pull/2509
this make sure to escape with quotes only for windows azure containers and not the VMs