### PR TITLE
fix(ACI): correct quotes around JENKINS_JAVA_OPTS

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -432,6 +432,8 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaOpts: >-
+              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-windows
           - name: maven-11-windows
@@ -440,6 +442,8 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaOpts: >-
+              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-11-windows
           - name: maven-17-windows
@@ -448,6 +452,8 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaOpts: >-
+              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-17-windows
           - name: maven-19-windows
@@ -456,6 +462,8 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaOpts: >-
+              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-19-windows
   artifact_caching_proxy:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -218,8 +218,7 @@ profile::jenkinscontroller::jcasc:
       remoteAdmin: Administrator
       osDiskSize: 128
       agentJavaBin: 'C:/tools/jdk-11/bin/java'
-      agentJavaOpts: >-
-        \"-XX:+PrintCommandLineFlags\"
+      agentJavaOpts: '-XX:+PrintCommandLineFlags'
     ubuntu:
       agentDir: "/home/jenkins"
       remoteAdmin: jenkins

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -339,6 +339,9 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
+            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaOpts: >-
+              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-windows
           - name: maven-11-windows
@@ -346,7 +349,9 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaOpts: >-
+              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-11-windows
           - name: maven-17-windows
@@ -354,9 +359,21 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaOpts: >-
+              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-17-windows
+          - name: maven-19-windows
+            os: windows
+            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+            cpus: 4
+            memory: 8
+            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaOpts: >-
+              \"-XX:+PrintCommandLineFlags\"
+            labels:
+              - maven-19-windows
   artifact_caching_proxy:
     disabled: false
 # These are plugins we need in our ci environment

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -5,6 +5,9 @@ lookup_options:
       strategy: deep
       merge_hash_arrays: true
 
+## Vagrant uses Ubuntu 20.04: docker-ce package version is different than the default for 18.04 in common.yaml
+docker::version: "5:20.10.21~3-0~ubuntu-focal"
+
 profile::jenkinscontroller::ci_fqdn: 'cert.ci.jenkins.io'
 profile::jenkinscontroller::ci_resource_domain: 'assets.cert.ci.jenkins.io'
 profile::jenkinscontroller::proxy_port: 443


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3283 use quotes around parameter only for windows azure ACI 