### PR TITLE
fix(ci.jenkins.io) remove duplicate agentJavaOpts from hieradata

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -94,8 +94,20 @@ jenkins:
         timeout: 60
         # Please note that envVars are specified differently than permanent or Kubernetes agents
         envVars:
+          <%- agentJavaOpts = agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] -%>
+          <%- jenkinsJavaOpts = "" -%>
+          <%- if agent['os'] == "windows" -%>
+            <%-# On Windows, due to https://github.com/jenkinsci/docker-inbound-agent/pull/227, each flag of the java opts string is wrapped with litteral double quote to avoid powershell interpolation  -%>
+            <%- agentJavaOpts.split(' ').each do |optFlag| -%>
+              <%- jenkinsJavaOpts += '\"' + optFlag + '\"' -%>
+            <%- end -%>
+          <%- else -%>
+            <%-# On Linux, we can pass the java opts string "as it" to the shell -%>
+            <%- jenkinsJavaOpts = agentJavaOpts -%>
+          <%- end -%>
           - key: "JENKINS_JAVA_OPTS"
-            value: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
+            value: >-
+              <%= jenkinsJavaOpts %>
           - key: "JENKINS_JAVA_BIN"
             value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
           - key: "ARTIFACT_CACHING_PROXY_PROVIDER"

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -432,8 +432,6 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
-            agentJavaOpts: >-
-              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-windows
           - name: maven-11-windows
@@ -442,8 +440,6 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
-            agentJavaOpts: >-
-              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-11-windows
           - name: maven-17-windows
@@ -452,8 +448,6 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
-            agentJavaOpts: >-
-              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-17-windows
           - name: maven-19-windows
@@ -462,8 +456,6 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
-            agentJavaOpts: >-
-              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-19-windows
   artifact_caching_proxy:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -343,8 +343,6 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
-            agentJavaOpts: >-
-              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-windows
           - name: maven-11-windows
@@ -353,8 +351,6 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
-            agentJavaOpts: >-
-              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-11-windows
           - name: maven-17-windows
@@ -363,8 +359,6 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
-            agentJavaOpts: >-
-              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-17-windows
           - name: maven-19-windows
@@ -373,8 +367,6 @@ profile::jenkinscontroller::jcasc:
             cpus: 4
             memory: 8
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
-            agentJavaOpts: >-
-              \"-XX:+PrintCommandLineFlags\"
             labels:
               - maven-19-windows
   artifact_caching_proxy:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -5,9 +5,6 @@ lookup_options:
       strategy: deep
       merge_hash_arrays: true
 
-## Vagrant uses Ubuntu 20.04: docker-ce package version is different than the default for 18.04 in common.yaml
-docker::version: "5:20.10.21~3-0~ubuntu-focal"
-
 profile::jenkinscontroller::ci_fqdn: 'cert.ci.jenkins.io'
 profile::jenkinscontroller::ci_resource_domain: 'assets.cert.ci.jenkins.io'
 profile::jenkinscontroller::proxy_port: 443

--- a/vagrant-docker/Dockerfile
+++ b/vagrant-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LANG="en_US.UTF-8"


### PR DESCRIPTION
This PR is a long term fix for https://github.com/jenkins-infra/helpdesk/issues/3283.

It fixes up #2521 by removing the duplicated `agentJavaOpts` directive. It also introduces a parsing on the case of Azure Container Instances agent template when a windows container immage is used. In this case, it parses the string and wrap each falg between double quote to ensure that powershell does not interpolate the flag itself.


NOTE: this PR also reverts the vagrant base image to Ubuntu 18.04 otherwise the `vagrant up jenkins:controller` command does not finish the provisionning (docker in docker error to be fixed but it is a "touchy" one).
Impact is: a lot of "PuppetFirewall" warning about unparseable iptable rules: no impact at all we can ignore (Docker Engine manages this).