### PR TITLE
hotfix(ci.jenkins.io) typo in ACI java opts when escaping flags on windows containers

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -99,7 +99,7 @@ jenkins:
           <%- if agent['os'] == "windows" -%>
             <%-# On Windows, due to https://github.com/jenkinsci/docker-inbound-agent/pull/227, each flag of the java opts string is wrapped with litteral double quote to avoid powershell interpolation  -%>
             <%- agentJavaOpts.split(' ').each do |optFlag| -%>
-              <%- jenkinsJavaOpts += '\"' + optFlag + '\"' -%>
+              <%- jenkinsJavaOpts += '"' + optFlag + '"' -%>
             <%- end -%>
           <%- else -%>
             <%-# On Linux, we can pass the java opts string "as it" to the shell -%>


### PR DESCRIPTION
Fixup of #2527 

Before:

```
JENKINS_JAVA_OPTS \"-XX:+PrintCommandLineFlags\"
```

After:

```
JENKINS_JAVA_OPTS="-XX:+PrintCommandLineFlags"
```