### PR TITLE
feat(ci agent): add a windows 2022 agent to test

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -62,7 +62,7 @@ jenkins:
         templateDesc: "Dynamically provisioned <%= agent['description'] %> machine"
         templateDisabled: false
         templateName: "<%= agent['name'] %>"
-        usageMode: "<%= agent['useAsMuchAsPosible'] == true ? 'NORMAL' : 'EXCLUSIVE' %>"
+        usageMode: "<%= agent['useAsMuchAsPossible'] == true ? 'NORMAL' : 'EXCLUSIVE' %>"
         virtualMachineSize: "<%= agent['instanceType'] %>"
       <%- if agent['usePrivateIP'] -%>
         usePrivateIP: true
@@ -156,7 +156,7 @@ jenkins:
         maxTotalUses: 1 # Throw away the VMs after a build
         minimumNumberOfInstances: 0
         minimumNumberOfSpareInstances: 0
-        mode: <%= agent['useAsMuchAsPosible'] == true ? 'NORMAL' : 'EXCLUSIVE' %>
+        mode: <%= agent['useAsMuchAsPossible'] == true ? 'NORMAL' : 'EXCLUSIVE' %>
         monitoring: false
         numExecutors: 1
         remoteAdmin: "<%= @jcasc['agents_setup'][agent['os'].to_s]['remoteAdmin'] %>"

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -129,7 +129,7 @@ jenkins:
       useInstanceProfileForCredentials: false
       templates:
       <%- ec2_cloud_setup['agent_definitions'].each do |agent| -%>
-      - ami: "<%= @jcasc['agent_images']['ec2_amis'][agent['os'].to_s + "-" + agent['architecture'].to_s] %>"
+      - ami: "<%= @jcasc['agent_images']['ec2_amis'][agent['os'].to_s + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"
         amiOwners: "200564066411"
         amiType:
           unixData:

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -44,7 +44,7 @@ jenkins:
         installMaven: false
         javaPath: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
         jvmOptions: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
-        labels: "<%= agent['os'] %> <%= agent['architecture'] %> azure vm <%= agent['labels'].join(' ') %>"
+        labels: "<%= agent['os'].to_s + "-" + agent['os_version'].to_s %> <%= agent['architecture'].to_s %> azure vm <%= agent['labels'].join(' ') %>"
         location: "<%= agent['location'] %>"
         noOfParallelJobs: 1
         osDiskSize: <%= agent['osDiskSize'] ? agent['osDiskSize'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskSize'] %>
@@ -151,7 +151,7 @@ jenkins:
         <%- end -%>
         instanceCapStr: "<%= agent['maxInstances'] %>"
         jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
-        labelString: "<%= agent['os'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['labels'].join(' ') %>"
+        labelString: "<%= agent['os'] + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['labels'].join(' ') %>"
         launchTimeoutStr: "1000"
         maxTotalUses: 1 # Throw away the VMs after a build
         minimumNumberOfInstances: 0

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -346,6 +346,20 @@ profile::jenkinscontroller::jcasc:
               - <powershell>
               - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAqyumVXNZAJylM6NiC/zKT+FKHqGnSwfUMWBupxumSJWL8GHEYFPB/Irr+sRiCPkRWW88bYg7Mp3Rv3qbxc0Aw/cU3XcQZB8RrAOsODBMjOJpHTvoB5aDtSYqygCjffPgwXK0DKguR2ADtsNkMcK7BOT02uaXgZOwo2S5UKkuDn6DsQBq9m1Ho8SwKw/E/+rwsUow+o5JVvPF9//8BIb53Y+wHYm2tOSe5dHFzBIP/+mJMHMpYiE5/q5LBELM9ZXhtBx2zeagEzbriDdlnDkMZk5AMWYz3+omDIX1MO2Fmg9Ak6O4dcNl4hhGJ5KtmPgLGzuhvfh018gi3NVhMBXv9zBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBltum5EYpT8EqN+vY0wudsgDBX++BA5bC+DpDxuqoANdKkUZdPyBo2cwxq8W4FfUtKE6ZReUIXxvARdR/Z2c5gYY4=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
               - </powershell>
+          - description: "Windows 2022"
+            maxInstances: 1
+            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
+            os: "windows-2022"
+            architecture: "amd64"
+            labels:
+              - windows-2022
+            useAsMuchAsPosible: false
+            spot: false
+            userData:
+              #this script is ran before the agent service startup so no need to restart it
+              - <powershell>
+              - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAqyumVXNZAJylM6NiC/zKT+FKHqGnSwfUMWBupxumSJWL8GHEYFPB/Irr+sRiCPkRWW88bYg7Mp3Rv3qbxc0Aw/cU3XcQZB8RrAOsODBMjOJpHTvoB5aDtSYqygCjffPgwXK0DKguR2ADtsNkMcK7BOT02uaXgZOwo2S5UKkuDn6DsQBq9m1Ho8SwKw/E/+rwsUow+o5JVvPF9//8BIb53Y+wHYm2tOSe5dHFzBIP/+mJMHMpYiE5/q5LBELM9ZXhtBx2zeagEzbriDdlnDkMZk5AMWYz3+omDIX1MO2Fmg9Ak6O4dcNl4hhGJ5KtmPgLGzuhvfh018gi3NVhMBXv9zBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBltum5EYpT8EqN+vY0wudsgDBX++BA5bC+DpDxuqoANdKkUZdPyBo2cwxq8W4FfUtKE6ZReUIXxvARdR/Z2c5gYY4=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+              - </powershell>
           - description: "High memory ubuntu 20.04 (ondemand)"
             maxInstances: 50
             instanceType: M54xlarge # 16 vCPUS / 64 Gb

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -315,7 +315,7 @@ profile::jenkinscontroller::jcasc:
               - docker
               - linux
               - linux-amd64
-            useAsMuchAsPosible: true
+            useAsMuchAsPossible: true
             spot: true
             userData: &BootstrapDatadogScript
               - "#!/bin/bash"
@@ -339,7 +339,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             labels:
               - docker-windows
-            useAsMuchAsPosible: true
+            useAsMuchAsPossible: true
             spot: true
             userData:
               #this script is ran before the agent service startup so no need to restart it
@@ -353,7 +353,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             labels:
               - windows-2022
-            useAsMuchAsPosible: false
+            useAsMuchAsPossible: false
             spot: false
             userData:
               #this script is ran before the agent service startup so no need to restart it
@@ -370,7 +370,7 @@ profile::jenkinscontroller::jcasc:
               - highram
               - docker-highmem
               - linux-amd64-big
-            useAsMuchAsPosible: false
+            useAsMuchAsPossible: false
             spot: false
             userData: *BootstrapDatadogScript
           - description: "ARM64 ubuntu 20.04"
@@ -381,7 +381,7 @@ profile::jenkinscontroller::jcasc:
             labels:
               - arm64docker
               - arm64linux
-            useAsMuchAsPosible: false
+            useAsMuchAsPossible: false
             spot: true
             userData: *BootstrapDatadogScript
     azure-vm-agents:
@@ -402,7 +402,7 @@ profile::jenkinscontroller::jcasc:
             - docker
             - linux-amd64
           maxInstances: 10
-          useAsMuchAsPosible: true
+          useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           virtualNetworkName: "prod-jenkins-public-prod"
@@ -424,7 +424,7 @@ profile::jenkinscontroller::jcasc:
             - docker-highmem
             - linux-amd64-big
           maxInstances: 20
-          useAsMuchAsPosible: false
+          useAsMuchAsPossible: false
           usePrivateIP: true
           credentialsId: "jenkinsvmagents-userpass"
           virtualNetworkName: "prod-jenkins-public-prod"
@@ -443,7 +443,7 @@ profile::jenkinscontroller::jcasc:
           labels:
             - docker-windows
           maxInstances: 20
-          useAsMuchAsPosible: true
+          useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           useEphemeralOSDisk: false
           usePrivateIP: true

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -309,6 +309,7 @@ profile::jenkinscontroller::jcasc:
             maxInstances: 20
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb
             os: "ubuntu"
+            os_version: "20.04"
             architecture: "amd64"
             labels:
               - java
@@ -336,9 +337,11 @@ profile::jenkinscontroller::jcasc:
             maxInstances: 10
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb
             os: "windows"
+            os_version: "2019"
             architecture: "amd64"
             labels:
               - docker-windows
+              - docker-windows-2019
             useAsMuchAsPossible: true
             spot: true
             userData:
@@ -433,6 +436,8 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - docker-windows
+            - docker-windows-2019
+            - windows
           maxInstances: 20
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -346,24 +346,11 @@ profile::jenkinscontroller::jcasc:
               - <powershell>
               - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAqyumVXNZAJylM6NiC/zKT+FKHqGnSwfUMWBupxumSJWL8GHEYFPB/Irr+sRiCPkRWW88bYg7Mp3Rv3qbxc0Aw/cU3XcQZB8RrAOsODBMjOJpHTvoB5aDtSYqygCjffPgwXK0DKguR2ADtsNkMcK7BOT02uaXgZOwo2S5UKkuDn6DsQBq9m1Ho8SwKw/E/+rwsUow+o5JVvPF9//8BIb53Y+wHYm2tOSe5dHFzBIP/+mJMHMpYiE5/q5LBELM9ZXhtBx2zeagEzbriDdlnDkMZk5AMWYz3+omDIX1MO2Fmg9Ak6O4dcNl4hhGJ5KtmPgLGzuhvfh018gi3NVhMBXv9zBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBltum5EYpT8EqN+vY0wudsgDBX++BA5bC+DpDxuqoANdKkUZdPyBo2cwxq8W4FfUtKE6ZReUIXxvARdR/Z2c5gYY4=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
               - </powershell>
-          - description: "Windows 2022"
-            maxInstances: 1
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "windows-2022"
-            architecture: "amd64"
-            labels:
-              - windows-2022
-            useAsMuchAsPossible: false
-            spot: false
-            userData:
-              #this script is ran before the agent service startup so no need to restart it
-              - <powershell>
-              - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAqyumVXNZAJylM6NiC/zKT+FKHqGnSwfUMWBupxumSJWL8GHEYFPB/Irr+sRiCPkRWW88bYg7Mp3Rv3qbxc0Aw/cU3XcQZB8RrAOsODBMjOJpHTvoB5aDtSYqygCjffPgwXK0DKguR2ADtsNkMcK7BOT02uaXgZOwo2S5UKkuDn6DsQBq9m1Ho8SwKw/E/+rwsUow+o5JVvPF9//8BIb53Y+wHYm2tOSe5dHFzBIP/+mJMHMpYiE5/q5LBELM9ZXhtBx2zeagEzbriDdlnDkMZk5AMWYz3+omDIX1MO2Fmg9Ak6O4dcNl4hhGJ5KtmPgLGzuhvfh018gi3NVhMBXv9zBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBltum5EYpT8EqN+vY0wudsgDBX++BA5bC+DpDxuqoANdKkUZdPyBo2cwxq8W4FfUtKE6ZReUIXxvARdR/Z2c5gYY4=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
-              - </powershell>
           - description: "High memory ubuntu 20.04 (ondemand)"
             maxInstances: 50
             instanceType: M54xlarge # 16 vCPUS / 64 Gb
             os: "ubuntu"
+            os_version: "20.04"
             architecture: "amd64"
             labels:
               - highmem
@@ -377,6 +364,7 @@ profile::jenkinscontroller::jcasc:
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
             os: "ubuntu"
+            os_version: "20.04"
             architecture: "arm64"
             labels:
               - arm64docker
@@ -392,6 +380,7 @@ profile::jenkinscontroller::jcasc:
           description: "Ubuntu 20.04 LTS"
           imageDefinition: jenkins-agent-ubuntu-20.04
           os: "ubuntu"
+          os_version: "20.04"
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXcLW9OnUwAhARiFS6P8vg8YrfYj9DHXTJmXqp+U/Ytjeova0bH/C8bhEbOykV4nJLMReHrrfEu5Jx+Eg+wjfq7LGD4bkAsp3covik/lkxAEDiMACIU3mWGlgeQ+0Tf4tpEHDOlWXNiA33T+3Knr1/v4H4vQOWC63tASAUUIPys2sesrv4RilEqKTd39oT9ugsQDVhftEHbp4eaqmI9zTXpU5hvy2fpJp5F2b5o7ohNvdRsovrsbN7XWJvMxvRbg/YMK/yq3zdowBzUFqXRcmiNC7T2iV0/lNjKKJOV1j4y0VDQoMomOZ5+zrozDq44FhwtAXRHJMyHr8lhtYZth0PTBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBVFqN/yr2UmCADos0nCHO7gCC7w2deUgakcUIXAZ7Y1M+Y3+dGENY/F2cNkceceJpQhw==]
           location: "East US 2"
           instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
@@ -414,6 +403,7 @@ profile::jenkinscontroller::jcasc:
           description: "Ubuntu 20.04 LTS Highmem"
           imageDefinition: jenkins-agent-ubuntu-20.04
           os: "ubuntu"
+          os_version: "20.04"
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAG/Diw4+KrBubbNNGJxe7yGXyJJUSSbhWIRXcLBYGPxo14g/jsZLqyoO7yW7mN36IUnByMnBhQemcp2gGXj7x4GXBwbrABRd4UhIJMfMoAaKjFktl2FQk1YRdgBFDmCd7+FeOSn4GsCG1w/IVSpN1ezlqBdVqiMuG3RSyEByVBHvLXBQLulGp/ZsKGoJkW2gFTLnjxSbpu3fB8Y2KtiZ6RT3IlfnGS5Yfhl9vBxTcxgzvRrjK2h6QjVFSz/r+unAhpPKZ8BPlFCQta7/HF1bzWE4G7fX+rYiNtTAH3aWdOlD/okMUlhzsByIzi74VFvHREFVOkD908Gds7kzMh3qptjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDg3jrltbTU6EQUsnrJ7+VRgCCtEzUFqD1vyGyzqY4dHdJpD1CrMKnVM/JW0AT+y6573g==]
           location: "East US 2"
           instanceType: Standard_D16s_v3 # 16 vCPUS / 64 Gb
@@ -436,6 +426,7 @@ profile::jenkinscontroller::jcasc:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019
           os: "windows"
+          os_version: "2019"
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAa3oGTsMY7PLE9o717wXQutJn5erhOYg2JV0KX1wR4JrAOBQ3d8DIdy7Uz60N/ANgEDZyrEgt2PYs51RYhtJV5OY5r7GxHecYj0fClGCkGVn+Zkz7SWLQlppK5QX3HaXFXwEXMvsn3CRZai8r2y6f0xxoVuEudih2eCxZ9ayq5CdOQYE3hXmGa6lXvpjpQTJpx1qwcyQRy/eieps4i3571pY8GYDQRkTdGKWrNpO7j59EgnEp64s+VRrSJuYHq+AqOPzA3DY8onnHCGg+uFFJ5W0ZtKDwj8hBHW8nKt7U0hURivHKbfr0S1mb9SDO5G5i/4OB6cIio6COS1pTsHbfSjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAKIIdotZJv1Gi79wx+4nFBgCCJXHclsURJelhh4ZScsLY7s1rrE+6qCUIDMOkDz7kaBw==]
           location: "East US 2"
           instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
@@ -444,6 +435,28 @@ profile::jenkinscontroller::jcasc:
             - docker-windows
           maxInstances: 20
           useAsMuchAsPossible: true
+          credentialsId: "jenkinsvmagents-userpass"
+          useEphemeralOSDisk: false
+          usePrivateIP: true
+          virtualNetworkName: "prod-jenkins-public-prod"
+          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+          subnetName: "ci.j-agents-vm"
+          spot: true
+          initScript:
+            - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAqyumVXNZAJylM6NiC/zKT+FKHqGnSwfUMWBupxumSJWL8GHEYFPB/Irr+sRiCPkRWW88bYg7Mp3Rv3qbxc0Aw/cU3XcQZB8RrAOsODBMjOJpHTvoB5aDtSYqygCjffPgwXK0DKguR2ADtsNkMcK7BOT02uaXgZOwo2S5UKkuDn6DsQBq9m1Ho8SwKw/E/+rwsUow+o5JVvPF9//8BIb53Y+wHYm2tOSe5dHFzBIP/+mJMHMpYiE5/q5LBELM9ZXhtBx2zeagEzbriDdlnDkMZk5AMWYz3+omDIX1MO2Fmg9Ak6O4dcNl4hhGJ5KtmPgLGzuhvfh018gi3NVhMBXv9zBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBltum5EYpT8EqN+vY0wudsgDBX++BA5bC+DpDxuqoANdKkUZdPyBo2cwxq8W4FfUtKE6ZReUIXxvARdR/Z2c5gYY4=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+        - name: "win-2022" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2022"
+          imageDefinition: jenkins-agent-windows-2022
+          os: "windows"
+          os_version: "2022"
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAa3oGTsMY7PLE9o717wXQutJn5erhOYg2JV0KX1wR4JrAOBQ3d8DIdy7Uz60N/ANgEDZyrEgt2PYs51RYhtJV5OY5r7GxHecYj0fClGCkGVn+Zkz7SWLQlppK5QX3HaXFXwEXMvsn3CRZai8r2y6f0xxoVuEudih2eCxZ9ayq5CdOQYE3hXmGa6lXvpjpQTJpx1qwcyQRy/eieps4i3571pY8GYDQRkTdGKWrNpO7j59EgnEp64s+VRrSJuYHq+AqOPzA3DY8onnHCGg+uFFJ5W0ZtKDwj8hBHW8nKt7U0hURivHKbfr0S1mb9SDO5G5i/4OB6cIio6COS1pTsHbfSjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAKIIdotZJv1Gi79wx+4nFBgCCJXHclsURJelhh4ZScsLY7s1rrE+6qCUIDMOkDz7kaBw==]
+          location: "East US 2"
+          instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
+          architecture: amd64
+          labels:
+            - docker-windows-2022
+          maxInstances: 1
+          useAsMuchAsPossible: false
           credentialsId: "jenkinsvmagents-userpass"
           useEphemeralOSDisk: false
           usePrivateIP: true

--- a/hieradata/clients/cert-ci.yaml
+++ b/hieradata/clients/cert-ci.yaml
@@ -86,7 +86,7 @@ profile::jenkinscontroller::jcasc:
             - linux
           idleTerminationMinutes: 5
           maxInstances: 7 # Quota of 56 vCPUs
-          useAsMuchAsPosible: true
+          useAsMuchAsPossible: true
           credentialsId: "azure-login"
           usePrivateIP: false
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
@@ -102,7 +102,7 @@ profile::jenkinscontroller::jcasc:
             - windows
           idleTerminationMinutes: 5
           maxInstances: 7 # Quota of 56 vCPUs
-          useAsMuchAsPosible: true
+          useAsMuchAsPossible: true
           credentialsId: "azure-login"
           usePrivateIP: false
 ## Ensure we override the default plugins to install defined from hieradata/common.yaml

--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -80,7 +80,7 @@ profile::jenkinscontroller::jcasc:
             - jdk11
           idleTerminationMinutes: 5
           maxInstances: 7 # Quota of 56 vCPUs
-          useAsMuchAsPosible: true
+          useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: false
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
@@ -96,7 +96,7 @@ profile::jenkinscontroller::jcasc:
             - docker-windows
           idleTerminationMinutes: 5
           maxInstances: 7 # Quota of 56 vCPUs
-          useAsMuchAsPosible: true
+          useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: false
 # These are plugins we need only in our trusted-ci environment

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -219,14 +219,6 @@ profile::jenkinscontroller::jcasc:
       osDiskSize: 128
       agentJavaBin: 'C:/tools/jdk-11/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
-    windows-2022:
-      agentDir: 'C:/Jenkins'
-      # Double Backslash is required (for EC2 plugin as we hackishly use the unix launched for Windows to use OpenSSH)
-      tempDir: 'C:\\\\Temp'
-      remoteAdmin: Administrator
-      osDiskSize: 128
-      agentJavaBin: 'C:/tools/jdk-11/bin/java'
-      agentJavaOpts: '-XX:+PrintCommandLineFlags'
     ubuntu:
       agentDir: "/home/jenkins"
       remoteAdmin: jenkins
@@ -237,9 +229,9 @@ profile::jenkinscontroller::jcasc:
       path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
   agent_images:
     ec2_amis:
-      ubuntu-amd64: "ami-0379f8a145c548384"
-      windows-amd64: "ami-0342fba4cd8bae2da"
-      ubuntu-arm64: "ami-07275ab5d2e1fe7f7"
+      ubuntu-20.04-amd64: "ami-0379f8a145c548384"
+      windows-2019-amd64: "ami-0342fba4cd8bae2da"
+      ubuntu-20.04-arm64: "ami-07275ab5d2e1fe7f7"
       windows-2022-amd64: "ami-0ccedc505fa0d89c5"
     azure_vms_gallery_image:
       version: 0.51.0

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -219,6 +219,14 @@ profile::jenkinscontroller::jcasc:
       osDiskSize: 128
       agentJavaBin: 'C:/tools/jdk-11/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
+    windows-2022:
+      agentDir: 'C:/Jenkins'
+      # Double Backslash is required (for EC2 plugin as we hackishly use the unix launched for Windows to use OpenSSH)
+      tempDir: 'C:\\\\Temp'
+      remoteAdmin: Administrator
+      osDiskSize: 128
+      agentJavaBin: 'C:/tools/jdk-11/bin/java'
+      agentJavaOpts: '-XX:+PrintCommandLineFlags'
     ubuntu:
       agentDir: "/home/jenkins"
       remoteAdmin: jenkins
@@ -232,6 +240,7 @@ profile::jenkinscontroller::jcasc:
       ubuntu-amd64: "ami-0379f8a145c548384"
       windows-amd64: "ami-0342fba4cd8bae2da"
       ubuntu-arm64: "ami-07275ab5d2e1fe7f7"
+      windows-2022-amd64: "ami-0ccedc505fa0d89c5"
     azure_vms_gallery_image:
       version: 0.51.0
       subscription_id: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAluBQmOHo1MWoOCMVOCcgVUs9gOzFVEZMT7RA3V33KeolyRKh0lm5Ta5+C9aKJe9myuVGaDQsd99XsW40d7NdygJcnBxUV+VTnnLphjplPtCX5JIS4ww/S8JGOpOIE2zejy5bL2CpnZhgSFh+aD1FLD91ozNS5lgNOq9hNKqo+mSfUnX5wrUFvlCaadTWp3yxG7l7VluxP1Wh4BlsRmphmbUmmgFo56CjDUVz9dMwxT/p/uE1S/SPuEirJOAPtPCl7x2NQWg+Qlv5j1tC5ASgh9beD3SjUVPd6VYM+K+u07aw8jOj/meARXgghtUPgqHqWC44JGHPzWkZ4dQFhe6jyzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDc6VPQnQTEmwF9aAh/uK9IgDDXAM9S6QNxRH8cFSOAESeqOlLFBKVAlJc3Mnby3Pc/6H21BsehZbQLUd+1MfcoPI0=]

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -18,34 +18,7 @@ profile::jenkinscontroller::jcasc:
     groovy:
       groovy: # Default version is named "groovy"
         version: "2.4.7"
-    jdk:
-      jdk8:
-        installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux && arm64"
-            cpu_arch: "aarch64"
       jdk11:
-        installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux && arm64"
-            cpu_arch: "aarch64"
-          s390x:
-            type: "zip"
-            label: "s390x"
-            cpu_arch: "s390x"
-      jdk17:
-        installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux && arm64"
-            cpu_arch: "aarch64"
-          s390x:
-            type: "zip"
-            label: "s390x"
-            cpu_arch: "s390x"
-      jdk19:
         installers:
           linux-arm64:
             type: "zip"
@@ -81,99 +54,15 @@ profile::jenkinscontroller::jcasc:
         max_capacity: 120 # Max 50 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each, minus the 30 of doks
         url: SuperSecretThatShouldBeEncryptedInProduction
         agent_definitions:
-          - name: jnlp-maven-8
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-8
-            labels:
-              - maven
-              - maven-8
-              - jdk8
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-maven-11
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-11
-            labels:
-              - maven-11
-              - jdk11
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-maven-17
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-17
-            labels:
-              - maven-17
-              - jdk17
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
           - name: jnlp-webbuilder
             agentJavaBin: java
+            javaHome: /opt/jdk-11
             cpus: 2
             memory: 4
             labels:
               - node
               - webbuilder
               - ruby
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp
-            labels:
-              - default
-            cpus: 1
-            memory: 1
-            imagePullSecrets: dockerhub-credential
-      doks:
-        enabled: true
-        provider: do
-        credentialsId: "doks-jenkins-agent-sa-token"
-        serverCertificate: SuperSecretThatShouldBeEncryptedInProduction
-        max_capacity: 30 # Max 10 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each
-        url: SuperSecretThatShouldBeEncryptedInProduction
-        agent_definitions:
-          - name: jnlp-maven-8
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-8
-            labels:
-              - maven
-              - maven-8
-              - jdk8
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-maven-11
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-11
-            labels:
-              - maven-11
-              - jdk11
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-maven-17
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-17
-            labels:
-              - maven-17
-              - jdk17
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-webbuilder
-            agentJavaBin: java
-            cpus: 2
-            memory: 4
-            labels:
-              - node
-              - webbuilder
-              - ruby
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp
-            labels:
-              - default
-            cpus: 1
-            memory: 1
             imagePullSecrets: dockerhub-credential
     ec2:
       aws-us-east-2:
@@ -181,50 +70,11 @@ profile::jenkinscontroller::jcasc:
         credentialsId: "aws-credentials-jenkins-ci"
         sshKeysCredentialsId: "ec2-agent-ssh-2021-06"
         agent_definitions:
-          - description: "Ubuntu 20.04 LTS"
-            maxInstances: 20
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            architecture: "amd64"
-            labels:
-              - java
-              - docker
-              - linux
-            useAsMuchAsPosible: true
-            spot: true
-          - description: "Windows 2019"
-            maxInstances: 10
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "windows"
-            architecture: "amd64"
-            labels:
-              - docker-windows
-            useAsMuchAsPosible: true
-            spot: true
-          - description: "Windows 2022"
-            maxInstances: 10
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "windows-2022"
-            architecture: "amd64"
-            labels:
-              - docker-windows-2022
-            useAsMuchAsPosible: true
-            spot: true
-          - description: "High memory ubuntu 20.04 (ondemand)"
-            maxInstances: 50
-            instanceType: M54xlarge # 16 vCPUS / 64 Gb
-            os: "ubuntu"
-            architecture: "amd64"
-            labels:
-              - highmem
-              - highram
-              - docker-highmem
-            useAsMuchAsPosible: false
-            spot: false
           - description: "Ubuntu 20.04 LTS datadog"
             maxInstances: 1
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb
             os: "ubuntu"
+            os_version: "20.04"
             architecture: "amd64"
             labels:
               - ec2_datadog
@@ -240,15 +90,15 @@ profile::jenkinscontroller::jcasc:
               - chmod 770 /var/log/datadog
               - systemctl restart datadog-agent.service
               - rm -f /etc/sudoers.d/90-cloud-init-users
-          - description: "ARM64 ubuntu 20.04"
+          - description: "Windows 2022"
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
-            os: "ubuntu"
+            os: "windows"
+            os_version: "2022"
             architecture: "arm64"
             labels:
-              - arm64docker
-              - arm64linux
-            useAsMuchAsPosible: false
+              - windows
+            useAsMuchAsPossible: false
             spot: true
             userData: *datadogInitUserData
     azure-vm-agents:
@@ -276,26 +126,6 @@ profile::jenkinscontroller::jcasc:
           subnetName: "ci.j-agents-vm"
           spot: true
           initScript: *datadogInitUserData
-        - name: "ubuntu-20-highmem"
-          description: "Ubuntu 20.04 LTS Highmem"
-          imageDefinition: jenkins-agent-ubuntu-20.04
-          os: "ubuntu"
-          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
-          location: "East US 2"
-          instanceType: Standard_D16s_v3 # 16 vCPUS / 64 Gb
-          architecture: amd64
-          labels:
-            - highmem
-            - highram
-            - docker-highmem
-          maxInstances: 20
-          useAsMuchAsPosible: false
-          usePrivateIP: true
-          credentialsId: "jenkinsvmagents-userpass"
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
-          spot: false
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019
@@ -315,25 +145,6 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-        - name: "win-2019-datadog-test" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2019 test datadog"
-          imageDefinition: jenkins-agent-windows-2019
-          os: "windows"
-          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
-          location: "East US 2"
-          instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
-          architecture: amd64
-          labels:
-            - docker-windows-test-datadog
-          maxInstances: 20
-          useAsMuchAsPosible: false
-          credentialsId: "jenkinsvmagents-userpass"
-          useEphemeralOSDisk: false
-          usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
-          spot: false
           initScript:
             - <powershell>
             - (Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: keytokeepsecret' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml
@@ -343,13 +154,6 @@ profile::jenkinscontroller::jcasc:
         credentialsId: "azure-credentials"
         resource_group: eastus-cijenkinsio
         agent_definitions:
-          - name: maven-8-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            labels:
-              - maven-windows
           - name: maven-11-windows
             os: windows
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
@@ -358,57 +162,26 @@ profile::jenkinscontroller::jcasc:
             agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
             labels:
               - maven-11-windows
-          - name: maven-17-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
-            labels:
-              - maven-17-windows
   artifact_caching_proxy:
     disabled: false
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
-  - ansicolor
   - azure-container-agents
   - azure-vm-agents
   - blueocean
-  - build-timeout
-  - buildtriggerbadge
   - cloudbees-folder
-  - code-coverage-api
   - config-file-provider
   - configuration-as-code
   - credentials
   - credentials-binding
-  - docker-workflow
   - ec2
-  - embeddable-build-status
-  - git-client
-  - git
-  - github
-  - github-checks
   - github-branch-source
-  - groovy
   - kubernetes
-  - jobConfigHistory
-  - junit-attachments
-  - junit-realtime-test-reporter
   - ldap
-  - lockable-resources
-  - mailer
   - matrix-auth
-  - parallel-test-executor
-  - pipeline-githubnotify-step
   - pipeline-graph-view
-  - pipeline-stage-view
-  - pipeline-utility-steps
   - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs
   - ssh-slaves # SSH Build Agent to implement "outbound agents"
-  - throttle-concurrents
-  - timestamper
   - toolenv
-  - warnings-ng
   - workflow-aggregator
   - workflow-multibranch

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -78,7 +78,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             labels:
               - ec2_datadog
-            useAsMuchAsPosible: false
+            useAsMuchAsPossible: false
             userData: &datadogInitUserData
               - "#!/bin/bash"
               - "sed 's/api_key:.*/api_key: tokeepsecret' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
@@ -118,7 +118,7 @@ profile::jenkinscontroller::jcasc:
             - linux
             - docker
           maxInstances: 10
-          useAsMuchAsPosible: true
+          useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           virtualNetworkName: "prod-jenkins-public-prod"
@@ -137,7 +137,7 @@ profile::jenkinscontroller::jcasc:
           labels:
             - docker-windows
           maxInstances: 20
-          useAsMuchAsPosible: true
+          useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           useEphemeralOSDisk: false
           usePrivateIP: true

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -201,6 +201,15 @@ profile::jenkinscontroller::jcasc:
               - docker-windows
             useAsMuchAsPosible: true
             spot: true
+          - description: "Windows 2022"
+            maxInstances: 10
+            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
+            os: "windows-2022"
+            architecture: "amd64"
+            labels:
+              - docker-windows-2022
+            useAsMuchAsPosible: true
+            spot: true
           - description: "High memory ubuntu 20.04 (ondemand)"
             maxInstances: 50
             instanceType: M54xlarge # 16 vCPUS / 64 Gb

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -201,7 +201,7 @@ profile::jenkinscontroller::jcasc:
               - docker
               - linux
               - linux-amd64
-            useAsMuchAsPosible: true
+            useAsMuchAsPossible: true
             spot: true
             userData: &BootstrapDatadogScript
               - "#!/bin/bash"
@@ -226,7 +226,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             labels:
               - docker-windows
-            useAsMuchAsPosible: true
+            useAsMuchAsPossible: true
             spot: true
             userData:
               #this script is ran before the agent service startup so no need to restart it
@@ -241,7 +241,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             labels:
               - windows-2022
-            useAsMuchAsPosible: false
+            useAsMuchAsPossible: false
             spot: false
             userData:
               #this script is ran before the agent service startup so no need to restart it
@@ -259,7 +259,7 @@ profile::jenkinscontroller::jcasc:
               - highram
               - docker-highmem
               - linux-amd64-big
-            useAsMuchAsPosible: false
+            useAsMuchAsPossible: false
             spot: false
             userData: *BootstrapDatadogScript
           - description: "ARM64 ubuntu 20.04"
@@ -271,7 +271,7 @@ profile::jenkinscontroller::jcasc:
             labels:
               - arm64docker
               - arm64linux
-            useAsMuchAsPosible: false
+            useAsMuchAsPossible: false
             spot: true
             userData: *BootstrapDatadogScript
     azure-vm-agents:
@@ -292,7 +292,7 @@ profile::jenkinscontroller::jcasc:
             - docker
             - linux-amd64
           maxInstances: 10
-          useAsMuchAsPosible: true
+          useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           virtualNetworkName: "prod-jenkins-public-prod"
@@ -314,7 +314,7 @@ profile::jenkinscontroller::jcasc:
             - docker-highmem
             - linux-amd64-big
           maxInstances: 20
-          useAsMuchAsPosible: false
+          useAsMuchAsPossible: false
           usePrivateIP: true
           credentialsId: "jenkinsvmagents-userpass"
           virtualNetworkName: "prod-jenkins-public-prod"
@@ -333,7 +333,7 @@ profile::jenkinscontroller::jcasc:
           labels:
             - docker-windows
           maxInstances: 20
-          useAsMuchAsPosible: true
+          useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           useEphemeralOSDisk: false
           usePrivateIP: true

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -233,21 +233,6 @@ profile::jenkinscontroller::jcasc:
               - <powershell>
               - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretThatShouldBeEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
               - </powershell>
-          - description: "Windows 2022"
-            maxInstances: 1
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "windows"
-            os_version: "2022"
-            architecture: "amd64"
-            labels:
-              - windows-2022
-            useAsMuchAsPossible: false
-            spot: false
-            userData:
-              #this script is ran before the agent service startup so no need to restart it
-              - <powershell>
-              - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretThatShouldBeEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
-              - </powershell>
           - description: "High memory ubuntu 20.04 (ondemand)"
             maxInstances: 50
             instanceType: M54xlarge # 16 vCPUS / 64 Gb
@@ -334,6 +319,28 @@ profile::jenkinscontroller::jcasc:
             - docker-windows
           maxInstances: 20
           useAsMuchAsPossible: true
+          credentialsId: "jenkinsvmagents-userpass"
+          useEphemeralOSDisk: false
+          usePrivateIP: true
+          virtualNetworkName: "prod-jenkins-public-prod"
+          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+          subnetName: "ci.j-agents-vm"
+          spot: true
+          initScript:
+            - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretThatShouldBeEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+        - name: "win-2022" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2022"
+          imageDefinition: jenkins-agent-windows-2022
+          os: "windows"
+          os_version: "2022"
+          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
+          location: "East US 2"
+          instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
+          architecture: amd64
+          labels:
+            - docker-windows-2022
+          maxInstances: 20
+          useAsMuchAsPossible: false
           credentialsId: "jenkinsvmagents-userpass"
           useEphemeralOSDisk: false
           usePrivateIP: true

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -194,6 +194,7 @@ profile::jenkinscontroller::jcasc:
             maxInstances: 20
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb
             os: "ubuntu"
+            os_version: "20.04"
             architecture: "amd64"
             labels:
               - java
@@ -205,6 +206,7 @@ profile::jenkinscontroller::jcasc:
             maxInstances: 10
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb
             os: "windows"
+            os_version: "2019"
             architecture: "amd64"
             labels:
               - docker-windows
@@ -213,7 +215,8 @@ profile::jenkinscontroller::jcasc:
           - description: "Windows 2022"
             maxInstances: 10
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "windows-2022"
+            os: "windows"
+            os_version: "2022"
             architecture: "amd64"
             labels:
               - docker-windows-2022
@@ -223,6 +226,7 @@ profile::jenkinscontroller::jcasc:
             maxInstances: 50
             instanceType: M54xlarge # 16 vCPUS / 64 Gb
             os: "ubuntu"
+            os_version: "20.04"
             architecture: "amd64"
             labels:
               - highmem
@@ -253,6 +257,7 @@ profile::jenkinscontroller::jcasc:
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
             os: "ubuntu"
+            os_version: "20.04"
             architecture: "arm64"
             labels:
               - arm64docker

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -210,6 +210,15 @@ profile::jenkinscontroller::jcasc:
               - docker-windows
             useAsMuchAsPosible: true
             spot: true
+          - description: "Windows 2022"
+            maxInstances: 10
+            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
+            os: "windows-2022"
+            architecture: "amd64"
+            labels:
+              - docker-windows-2022
+            useAsMuchAsPosible: true
+            spot: true
           - description: "High memory ubuntu 20.04 (ondemand)"
             maxInstances: 50
             instanceType: M54xlarge # 16 vCPUS / 64 Gb

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -200,8 +200,24 @@ profile::jenkinscontroller::jcasc:
               - java
               - docker
               - linux
+              - linux-amd64
             useAsMuchAsPosible: true
             spot: true
+            userData: &BootstrapDatadogScript
+              - "#!/bin/bash"
+              - "set -eux"
+              - echo "START CLOUDINIT"
+              - "sed 's/api_key:.*/api_key: SuperSecretThatShouldBeEncryptedInProduction/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+              - systemctl stop datadog-agent.service
+              - mkdir -p /var/log/datadog /etc/datadog-agent
+              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+              - chmod 640 /etc/datadog-agent/datadog.yaml
+              - chown dd-agent:dd-agent /var/log/datadog
+              - chmod 770 /var/log/datadog
+              - systemctl start datadog-agent.service
+              - rm -f /etc/sudoers.d/90-cloud-init-users
+              - echo "END CLOUDINIT"
           - description: "Windows 2019"
             maxInstances: 10
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb
@@ -212,16 +228,26 @@ profile::jenkinscontroller::jcasc:
               - docker-windows
             useAsMuchAsPosible: true
             spot: true
+            userData:
+              #this script is ran before the agent service startup so no need to restart it
+              - <powershell>
+              - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretThatShouldBeEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+              - </powershell>
           - description: "Windows 2022"
-            maxInstances: 10
+            maxInstances: 1
             instanceType: T3Xlarge # 4 vCPUs / 16 Gb
             os: "windows"
             os_version: "2022"
             architecture: "amd64"
             labels:
-              - docker-windows-2022
-            useAsMuchAsPosible: true
-            spot: true
+              - windows-2022
+            useAsMuchAsPosible: false
+            spot: false
+            userData:
+              #this script is ran before the agent service startup so no need to restart it
+              - <powershell>
+              - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretThatShouldBeEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+              - </powershell>
           - description: "High memory ubuntu 20.04 (ondemand)"
             maxInstances: 50
             instanceType: M54xlarge # 16 vCPUS / 64 Gb
@@ -232,27 +258,10 @@ profile::jenkinscontroller::jcasc:
               - highmem
               - highram
               - docker-highmem
+              - linux-amd64-big
             useAsMuchAsPosible: false
             spot: false
-          - description: "Ubuntu 20.04 LTS datadog"
-            maxInstances: 1
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            architecture: "amd64"
-            labels:
-              - ec2_datadog
-            useAsMuchAsPosible: false
-            userData: &datadogInitUserData
-              - "#!/bin/bash"
-              - "sed 's/api_key:.*/api_key: tokeepsecret' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-              - mkdir /var/log/datadog
-              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-              - chmod 640 /etc/datadog-agent/datadog.yaml
-              - chown dd-agent:dd-agent /var/log/datadog
-              - chmod 770 /var/log/datadog
-              - systemctl restart datadog-agent.service
-              - rm -f /etc/sudoers.d/90-cloud-init-users
+            userData: *BootstrapDatadogScript
           - description: "ARM64 ubuntu 20.04"
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
@@ -264,7 +273,7 @@ profile::jenkinscontroller::jcasc:
               - arm64linux
             useAsMuchAsPosible: false
             spot: true
-            userData: *datadogInitUserData
+            userData: *BootstrapDatadogScript
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
       resource_group: eastus-cijenkinsio
@@ -281,6 +290,7 @@ profile::jenkinscontroller::jcasc:
             - java
             - linux
             - docker
+            - linux-amd64
           maxInstances: 10
           useAsMuchAsPosible: true
           credentialsId: "jenkinsvmagents-userpass"
@@ -289,7 +299,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript: *datadogInitUserData
+          initScript: *BootstrapDatadogScript
         - name: "ubuntu-20-highmem"
           description: "Ubuntu 20.04 LTS Highmem"
           imageDefinition: jenkins-agent-ubuntu-20.04
@@ -302,6 +312,7 @@ profile::jenkinscontroller::jcasc:
             - highmem
             - highram
             - docker-highmem
+            - linux-amd64-big
           maxInstances: 20
           useAsMuchAsPosible: false
           usePrivateIP: true
@@ -310,6 +321,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: false
+          initScript: *BootstrapDatadogScript
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019
@@ -329,29 +341,8 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-        - name: "win-2019-datadog-test" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2019 test datadog"
-          imageDefinition: jenkins-agent-windows-2019
-          os: "windows"
-          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
-          location: "East US 2"
-          instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
-          architecture: amd64
-          labels:
-            - docker-windows-test-datadog
-          maxInstances: 20
-          useAsMuchAsPosible: false
-          credentialsId: "jenkinsvmagents-userpass"
-          useEphemeralOSDisk: false
-          usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
-          spot: false
           initScript:
-            - <powershell>
-            - (Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: keytokeepsecret' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml
-            - </powershell>
+            - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretThatShouldBeEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"

--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -95,7 +95,7 @@ sources:
           values: "prod"
         - name: "tag:version"
           values: '{{ source "packerImageVersion" }}'
-  getLatestWindowsAgentAMIAmd64:
+  getLatestWindows2019AgentAMIAmd64:
     kind: aws/ami
     dependson:
       - packerImageVersion
@@ -105,6 +105,20 @@ sources:
       filters:
         - name: "name"
           values: "jenkins-agent-windows-2019-amd64-*"
+        - name: "tag:build_type"
+          values: "prod"
+        - name: "tag:version"
+          values: '{{ source "packerImageVersion" }}'
+  getLatestWindows2022AgentAMIAmd64:
+    kind: aws/ami
+    dependson:
+      - packerImageVersion
+    spec:
+      region: us-east-2
+      sortby: creationDateDesc
+      filters:
+        - name: "name"
+          values: "jenkins-agent-windows-2022-amd64-*"
         - name: "tag:build_type"
           values: "prod"
         - name: "tag:version"
@@ -229,7 +243,7 @@ targets:
     sourceid: getLatestUbuntuAgentAMIAmd64
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.ec2_amis.ubuntu-amd64"
+      key: 'profile::jenkinscontroller::jcasc.agent_images.ec2_amis.ubuntu-20\.04-amd64'
     scmid: default
   setUbuntuAgentAMIArm64:
     name: "Bump AMI ID for Ubuntu ARM64 agents"
@@ -237,15 +251,23 @@ targets:
     sourceid: getLatestUbuntuAgentAMIArm64
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.ec2_amis.ubuntu-arm64"
+      key: 'profile::jenkinscontroller::jcasc.agent_images.ec2_amis.ubuntu-20\.04-arm64'
     scmid: default
-  setWindowsAgentAMIamd64:
-    name: "Bump AMI ID for Windows AMD64 agents"
+  setWindowsAgent2019AMIamd64:
+    name: "Bump AMI ID for Windows 2019 AMD64 agents"
     kind: yaml
-    sourceid: getLatestWindowsAgentAMIAmd64
+    sourceid: getLatestWindows2019AgentAMIAmd64
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.ec2_amis.windows-amd64"
+      key: "profile::jenkinscontroller::jcasc.agent_images.ec2_amis.windows-2019-amd64"
+    scmid: default
+  setWindows2022AgentAMIamd64:
+    name: "Bump AMI ID for Windows 2022 AMD64 agents"
+    kind: yaml
+    sourceid: getLatestWindows2022AgentAMIAmd64
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.ec2_amis.windows-2022-amd64"
     scmid: default
 
 actions:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2629

adding a specific windows 2022 agent on ci.jenkins.io to test it

adding  `os_version` for amazon ec2 and azure VM to specify the version of the os, for ubuntu (20.04/22.04) and windows (2019/2022)