### PR TITLE
fix(private-vpn): don't include 99-disable-network-config.cfg if there are only 2 network interfaces

### DIFF
--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -62,16 +62,18 @@ class profile::openvpn (
   }
 
   # Ensure cloud-init doesn't manage network to ensure the order of eth1 and eth2 if this last one is defined (ie 3 interfaces) (netplan config + netplan apply + systemd, in Ubuntu Bionic)
+  $content = ''
   if $networks.length > 2 {
-    file { '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg':
-      ensure  => 'file',
-      owner   => 'root',
-      group   => 'root',
-      require => [
-        File['/etc/cloud/cloud.cfg.d'],
-      ],
-      content => 'network: {config: disabled}',
-    }
+    $content = 'network: {config: disabled}'
+  }
+  file { '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg':
+    ensure  => 'file',
+    owner   => 'root',
+    group   => 'root',
+    require => [
+      File['/etc/cloud/cloud.cfg.d'],
+    ],
+    content => $content,
   }
 
   file { '/etc/netplan/':

--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -61,15 +61,17 @@ class profile::openvpn (
     ],
   }
 
-  # Ensure cloud-init doesn't manage network (netplan config + netplan apply + systemd, in Ubuntu Bionic)
-  file { '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg':
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    require => [
-      File['/etc/cloud/cloud.cfg.d'],
-    ],
-    content => 'network: {config: disabled}',
+  # Ensure cloud-init doesn't manage network to ensure the order of eth1 and eth2 if this last one is defined (ie 3 interfaces) (netplan config + netplan apply + systemd, in Ubuntu Bionic)
+  if $networks.length > 2 {
+    file { '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      require => [
+        File['/etc/cloud/cloud.cfg.d'],
+      ],
+      content => 'network: {config: disabled}',
+    }
   }
 
   file { '/etc/netplan/':

--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -62,18 +62,16 @@ class profile::openvpn (
   }
 
   # Ensure cloud-init doesn't manage network to ensure the order of eth1 and eth2 if this last one is defined (ie 3 interfaces) (netplan config + netplan apply + systemd, in Ubuntu Bionic)
-  $content = ''
   if $networks.length > 2 {
-    $content = 'network: {config: disabled}'
-  }
-  file { '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg':
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    require => [
-      File['/etc/cloud/cloud.cfg.d'],
-    ],
-    content => $content,
+    file { '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      require => [
+        File['/etc/cloud/cloud.cfg.d'],
+      ],
+      content => 'network: {config: disabled}',
+    }
   }
 
   file { '/etc/netplan/':

--- a/hieradata/rspec/profile_openvpn.yaml
+++ b/hieradata/rspec/profile_openvpn.yaml
@@ -14,7 +14,7 @@ profile::openvpn::networks:
     name: Another Network
     network_cidr: 192.168.200.0/24
     peered_network_cidrs:
-      - 10.0.0.0/16
+      - 11.0.0.0/16
 profile::openvpn::vpn_networks_cidr:
   - 127.0.10.0/24
   - 172.19.0.0/24

--- a/hieradata/rspec/profile_openvpn_two_interfaces.yaml
+++ b/hieradata/rspec/profile_openvpn_two_interfaces.yaml
@@ -10,11 +10,6 @@ profile::openvpn::networks:
     network_cidr: 192.168.100.0/24
     peered_network_cidrs:
       - 10.0.0.0/16
-  eth2:
-    name: Another Network
-    network_cidr: 192.168.200.0/24
-    peered_network_cidrs:
-      - 10.0.0.0/16
 profile::openvpn::vpn_networks_cidr:
   - 127.0.10.0/24
   - 172.19.0.0/24

--- a/hieradata/rspec/profile_openvpn_two_interfaces.yaml
+++ b/hieradata/rspec/profile_openvpn_two_interfaces.yaml
@@ -13,4 +13,4 @@ profile::openvpn::networks:
 profile::openvpn::vpn_networks_cidr:
   - 127.0.10.0/24
   - 172.19.0.0/24
-profile::openvpn::openvpn_network: default
+profile::openvpn::openvpn_network: private

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -2,6 +2,27 @@ require 'spec_helper'
 
 describe 'profile::openvpn' do
 
+  it { expect(subject).to contain_class 'stdlib' }
+  it { expect(subject).to contain_class 'profile::docker' }
+
+  it { expect(subject).to contain_package 'net-tools' }
+
+  it { expect(subject).to contain_firewall '107 accept incoming 443 connections' }
+
+  # Routing from VPN networks to eth0 network
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.0.0/24 on ports 80/443" } #.with('outiface' => 'eth0') }
+  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 192.168.0.0/24 on ports 80/443" }
+
+  # Routing from VPN networks to eth1 network
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.100.0/24 on ports 80/443" }
+  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 192.168.100.0/24 on ports 80/443" }
+
+  # Routing from VPN networks to eth1 peered networks
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 10.0.0.0/16 on ports 80/443" }
+  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 10.0.0.0/16 on ports 80/443" }
+  it { expect(subject).to contain_exec "addroute 10.0.0.0 through 192.168.100.1 (NIC eth1)" }
+
+  # Disable network config in cloud-init if there is more than two network interfaces
   context 'with 3 network interfaces' do
     let(:facts) do
       {
@@ -27,24 +48,4 @@ describe 'profile::openvpn' do
       :rspec_hieradata_fixture => 'profile_openvpn',
     }
   end
-
-  it { expect(subject).to contain_class 'stdlib' }
-  it { expect(subject).to contain_class 'profile::docker' }
-
-  it { expect(subject).to contain_package 'net-tools' }
-
-  it { expect(subject).to contain_firewall '107 accept incoming 443 connections' }
-
-  # Routing from VPN networks to eth0 network
-  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.0.0/24 on ports 80/443" } #.with('outiface' => 'eth0') }
-  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 192.168.0.0/24 on ports 80/443" }
-
-  # Routing from VPN networks to eth1 network
-  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.100.0/24 on ports 80/443" }
-  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 192.168.100.0/24 on ports 80/443" }
-
-  # Routing from VPN networks to eth1 peered networks
-  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 10.0.0.0/16 on ports 80/443" }
-  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 10.0.0.0/16 on ports 80/443" }
-  it { expect(subject).to contain_exec "addroute 10.0.0.0 through 192.168.100.1 (NIC eth1)" }
 end

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 describe 'profile::openvpn' do
 
+  let(:facts) do
+    {
+      :rspec_hieradata_fixture => 'profile_openvpn',
+    }
+  end
+
   it { expect(subject).to contain_class 'stdlib' }
   it { expect(subject).to contain_class 'profile::docker' }
 
@@ -41,11 +47,5 @@ describe 'profile::openvpn' do
     end
 
     it { expect(subject).not_to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
-  end
-  
-  let(:facts) do
-    {
-      :rspec_hieradata_fixture => 'profile_openvpn',
-    }
   end
 end

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe 'profile::openvpn' do
-
   let(:facts) do
     {
       :rspec_hieradata_fixture => 'profile_openvpn',

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -29,3 +29,34 @@ describe 'profile::openvpn' do
   it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 10.0.0.0/16 on ports 80/443" }
   it { expect(subject).to contain_exec "addroute 10.0.0.0 through 192.168.100.1 (NIC eth1)" }
 end
+
+
+describe 'profile::openvpn' do
+  let(:facts) do
+    {
+      :rspec_hieradata_fixture => 'profile_openvpn_two_interfaces',
+    }
+  end
+
+  it { expect(subject).to contain_class 'stdlib' }
+  it { expect(subject).to contain_class 'profile::docker' }
+
+  it { expect(subject).to contain_package 'net-tools' }
+
+  it { expect(subject).to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
+
+  it { expect(subject).to contain_firewall '107 accept incoming 443 connections' }
+
+  # Routing from VPN networks to eth0 network
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.0.0/24 on ports 80/443" } #.with('outiface' => 'eth0') }
+  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 192.168.0.0/24 on ports 80/443" }
+
+  # Routing from VPN networks to eth1 network
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.100.0/24 on ports 80/443" }
+  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 192.168.100.0/24 on ports 80/443" }
+
+  # Routing from VPN networks to eth1 peered networks
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 10.0.0.0/16 on ports 80/443" }
+  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 10.0.0.0/16 on ports 80/443" }
+  it { expect(subject).to contain_exec "addroute 10.0.0.0 through 192.168.100.1 (NIC eth1)" }
+end

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -38,25 +38,5 @@ describe 'profile::openvpn' do
     }
   end
 
-  it { expect(subject).to contain_class 'stdlib' }
-  it { expect(subject).to contain_class 'profile::docker' }
-
-  it { expect(subject).to contain_package 'net-tools' }
-
-  it { expect(subject).to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
-
-  it { expect(subject).to contain_firewall '107 accept incoming 443 connections' }
-
-  # Routing from VPN networks to eth0 network
-  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.0.0/24 on ports 80/443" } #.with('outiface' => 'eth0') }
-  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 192.168.0.0/24 on ports 80/443" }
-
-  # Routing from VPN networks to eth1 network
-  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.100.0/24 on ports 80/443" }
-  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 192.168.100.0/24 on ports 80/443" }
-
-  # Routing from VPN networks to eth1 peered networks
-  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 10.0.0.0/16 on ports 80/443" }
-  it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 10.0.0.0/16 on ports 80/443" }
-  it { expect(subject).to contain_exec "addroute 10.0.0.0 through 192.168.100.1 (NIC eth1)" }
+  it { expect(subject).to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' without_mode }
 end

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -1,6 +1,27 @@
 require 'spec_helper'
 
 describe 'profile::openvpn' do
+
+  context 'with 3 network interfaces' do
+    let(:facts) do
+      {
+        :rspec_hieradata_fixture => 'profile_openvpn',
+      }
+    end
+
+    it { expect(subject).to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
+  end
+
+  context 'with 2 network interfaces' do
+    let(:facts) do
+      {
+        :rspec_hieradata_fixture => 'profile_openvpn_two_interfaces',
+      }
+    end
+
+    it { expect(subject).not_to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
+  end
+  
   let(:facts) do
     {
       :rspec_hieradata_fixture => 'profile_openvpn',
@@ -11,8 +32,6 @@ describe 'profile::openvpn' do
   it { expect(subject).to contain_class 'profile::docker' }
 
   it { expect(subject).to contain_package 'net-tools' }
-
-  it { expect(subject).to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
 
   it { expect(subject).to contain_firewall '107 accept incoming 443 connections' }
 
@@ -28,15 +47,4 @@ describe 'profile::openvpn' do
   it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 10.0.0.0/16 on ports 80/443" }
   it { expect(subject).to contain_firewall "100 allow routing from 172.19.0.0/24 to 10.0.0.0/16 on ports 80/443" }
   it { expect(subject).to contain_exec "addroute 10.0.0.0 through 192.168.100.1 (NIC eth1)" }
-end
-
-
-describe 'profile::openvpn with 2 interfaces' do
-  let(:facts) do
-    {
-      :rspec_hieradata_fixture => 'profile_openvpn_two_interfaces',
-    }
-  end
-
-  it { expect(subject).not_to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
 end

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -38,5 +38,5 @@ describe 'profile::openvpn' do
     }
   end
 
-  it { expect(subject).to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' without_mode }
+  it { should_not contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
 end

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -31,12 +31,12 @@ describe 'profile::openvpn' do
 end
 
 
-describe 'profile::openvpn' do
+describe 'profile::openvpn with 2 interfaces' do
   let(:facts) do
     {
       :rspec_hieradata_fixture => 'profile_openvpn_two_interfaces',
     }
   end
 
-  it { should_not contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
+  it { expect(subject).not_to contain_file '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg' }
 end


### PR DESCRIPTION
Including this cloud-init config seems to break connectivity on Ubuntu Jammy VM like the private.vpn.jenkins.io one.