### PR TITLE
Fix(openvpn) fix private

### DIFF
--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -64,8 +64,10 @@ class profile::openvpn (
     ],
   }
 
-  # Ensure cloud-init doesn't manage network to ensure the order of eth1 and eth2 if this last one is defined (ie 3 interfaces) (netplan config + netplan apply + systemd, in Ubuntu Bionic)
+  # When the VM has more than 2 interfaces (1 external and 1 internal) then it's a more complex setup where network interfaces
+  # must be managed by us instead of the usual cloud-init netplan generated configuration to keep the interface order
   if $networks.length > 2 {
+    # Ensure cloud-init doesn't manage network at all
     file { '/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg':
       ensure  => 'file',
       owner   => 'root',
@@ -75,28 +77,28 @@ class profile::openvpn (
       ],
       content => 'network: {config: disabled}',
     }
+
+    # Ensure the required directory exists
+    file { '/etc/netplan/':
+      ensure  => 'directory',
+      owner   => 'root',
+      group   => 'root',
+      recurse => true,
+    }
+
+    # Set up network interfaces ourselves from hieradata values
+    file { '/etc/netplan/90-network-config.yaml':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      require => [
+        File['/etc/netplan/'],
+      ],
+      content => template("${module_name}/openvpn/90-network-config.yaml.erb"),
+    }
   }
 
-  file { '/etc/netplan/':
-    ensure  => 'directory',
-    owner   => 'root',
-    group   => 'root',
-    recurse => true,
-  }
-
-  # Define eth interfaces with the correct mac addresses
-  # We assume the parent folder already exists
-  file { '/etc/netplan/90-network-config.yaml':
-    ensure  => 'file',
-    owner   => 'root',
-    group   => 'root',
-    require => [
-      File['/etc/netplan/'],
-    ],
-    content => template("${module_name}/openvpn/90-network-config.yaml.erb"),
-  }
-
-  # The CLI '/sbin/route' included in net-tools is required to create custom routes for peered networks
+  # The CLI '/sbin/route' is provided by the net-tools package
   package { 'net-tools':
     ensure => present,
   }

--- a/hieradata/clients/private.vpn.jenkins.io.yaml
+++ b/hieradata/clients/private.vpn.jenkins.io.yaml
@@ -13,9 +13,9 @@ profile::openvpn::networks:
 profile::openvpn::vpn_network:
   name: private
   # Defined in https://github.com/jenkins-infra/azure-net/blob/main/vpn.tf
-  cidr: 10.248.0.0/28
+  cidr: 10.9.0.0/24
   # TODO: replace by a conversion from cidr
-  netmask: 255.255.255.240
+  netmask: 255.255.255.0
 profile::openvpn::auth_ldap_binddn: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAUnLHzSYfhy9wQ622F9qg27p80NMo+5M1I0XJUM3vQ6+XhcmG8OeFN0lksZJMD1p2tp8vZTAbq+BtdCfy9e9iaZudQvL2XHqlGFSrssz25FfpfKny5/QvKRZJqOW7K/7gfwnj+kIO7kVMFkO0XhcqRKsCjO2hBIaWBw/3BtIpE0MB/pPw/vLI3aERnj/YBRg6iHQUuBiYOZc5WJ6CJiVPiiCcfz1YhzvsdjeE/6PLCXSWVzR6fXJaIv8AeLOJ/T/KrulWZbQ2C3fE/hWYCznIEzmsHHnd/td8/gTOyetl8CbPeeVWnl3z4cjD3dhpRc80hDB912Wpp7p3U6QeM2qlszBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDTNSew0xsPvYG7UiPm3rC2gDBdODpfNj9Y+ihtpKsm67MmN88nbQZ2LPfg2ClMVFQOYtKs+3nQoT8LupqIDGMIRYo=]
 profile::openvpn::auth_ldap_password: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAHnkX82SuWKYuW/ROAxQX3fw+HrN/AQf3BpbeUdSwCe9+ljLni05W4ZypQkRNgEksUfD0bBgK2RA7PF+KYSnTpA5v+GkqjUn8iAZg9whEpQaK7wfidp8rSL+nlsJFNE8mPHLCoO+6xHMFmm6XCCsFnQ2qYNQAjWeecngdp3IIZi2Vs8NBYJbOEovsRgdksNu7gO516C9DBrWKaTOf7j9x28g22XFQ3kxefxq89QGquvwc3Lyl8iNInJNUQ8wmCk54+m2CvTKzbqnO53QgHbw2VUwN+6JnmN+HgxzSM9o+VO8x2S8o8dzS0v45fWwLM4sKuwUPeAxfVGpfb2J46ab3tzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAidRxKsLYgBugid4s3KGq+gCBhpSsRd85sDKxC3m6l5ys56qg96hfUV7BRqeygYAztiw==]
 # CA comes from https://github.com/jenkins-infra/docker-openvpn

--- a/hieradata/rspec/profile_openvpn_two_interfaces.yaml
+++ b/hieradata/rspec/profile_openvpn_two_interfaces.yaml
@@ -2,8 +2,6 @@
 profile::openvpn::networks:
   eth0:
     name: Public network
-    # route-metric: 100
-    # macaddress: 00:0d:3a:0e:4b:1c
     network_cidr: 192.168.0.0/24
   eth1:
     name: Private Network

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -14,9 +14,6 @@ describe 'profile::openvpn' do
 
   it { expect(subject).to contain_firewall '107 accept incoming 443 connections' }
 
-  # Routing from VPN networks to eth0 network
-  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.0.0/24 on ports 80/443" } #.with('outiface' => 'eth0') }
-
   # Routing from VPN networks to eth1 network
   it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.100.0/24 on ports 80/443" }
 


### PR DESCRIPTION
This PR fixes the private.vpn.jenkins.io new VM to allow accessing the new [privatek8s cluster](https://github.com/jenkins-infra/helpdesk/issues/2844) through the "private.vpn" service.

It introduces the following changes:

- fix the behavior of the openvpn profile to make sure that network interface setup is fully delegated to cloud init when using only 2 interfaces
- change the private.vpn network to 10.9.0.0/24 (new one) to ease routing diagnostics
- remove unneeded routes (to the eth0 -main- network) as not needed


⚠️ this PR fixes the "breaking reboot" of the VM (rebooting the private.vpn.jenkins.io VM before this change always ends up in the VM unreachable because of the cloudinit configuration competing with ours, leading to "offline" network interfaces