### PR TITLE
chore(gha) remove nodejs 12 warning for `updatecli` workflow

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -23,7 +23,7 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure AWS Credentials
         if: github.ref == 'refs/heads/production'
-        uses: aws-actions/configure-aws-credentials@v1.7.0
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
I missed one of the action causing the warning in jenkins-infra/jenkins-infra#2561 .

As per https://github.com/aws-actions/configure-aws-credentials/issues/489#issuecomment-1278145876, using the tag `v1-node16` until the `v2` is released.