### PR TITLE
feat(trusted.ci/cert.ci) specify static certificate until LE DNS is automated

### DIFF
--- a/dist/role/manifests/privateci.pp
+++ b/dist/role/manifests/privateci.pp
@@ -1,0 +1,14 @@
+#
+# A Jenkins Controller running in a private network
+class role::privateci {
+  include role::jenkins::controller
+
+  $ci_fqdn = lookup('profile::jenkinscontroller::ci_fqdn')
+
+  # Specify static SSL certs, expected to be managed by Let's Encrypt but manually (DNS)
+  # ref. https://github.com/jenkins-infra/helpdesk/issues/3328
+  Apache::Vhost <| title == $ci_fqdn |> {
+    ssl_key       => "/etc/letsencrypt/live/${ci_fqdn}/privkey.pem",
+    ssl_cert      => "/etc/letsencrypt/live/${ci_fqdn}/fullchain.pem",
+  }
+}

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -82,13 +82,13 @@ node 'azure.ci.jenkins.io' {
 node 'trusted-ci' {
   $hiera_role = 'trustedci'
   sshkeyman::hostkey { ['trusted.ci.jenkins.io', 'ci.trusted.jenkins.io']: }
-  include role::jenkins::controller
+  include role::privateci
 }
 
 # Jenkins controller for cert.ci.jenkins.io
 node 'cert-ci' {
   sshkeyman::hostkey { ['cert.ci.jenkins.io']: }
-  include role::jenkins::controller
+  include role::privateci
 }
 
 node 'trusted-agent-1' {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3328

Generating a certificate for these private instances (e.g. not available publicly for HTTP-01 challenge) is manual operation:

```console
# Install certbot CLI
$ apt update && apt install certbot
# Request a certificate for <FQDN>
certbot -d <FQDN> --manual --preferred-challenges dns certonly
```

then follow instruction and add the TXT record on Azure DNS Zone for FQDN's apex domain.