### PR TITLE
chore(updatecli) track the puppet-letsencrypt module version

### DIFF
--- a/updatecli/weekly.d/puppet-modules/letsencrypt.yaml
+++ b/updatecli/weekly.d/puppet-modules/letsencrypt.yaml
@@ -19,11 +19,11 @@ sources:
     name: Get the latest puppetlabs-letsencrypt module version
     spec:
       owner: voxpupuli
-      repository: puppetlabs-letsencrypt
+      repository: puppet-letsencrypt
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionfilter:
-        kind: semver
+        kind: latest # Avoid semver because https://github.com/voxpupuli/puppet-letsencrypt/releases/tag/v999.999.999 exists :'(
     transformers:
       - trimprefix: v
 
@@ -42,9 +42,9 @@ targets:
     spec:
       file: Puppetfile
       matchpattern: >
-        mod 'puppetlabs-letsencrypt'(.*)
+        mod 'puppet-letsencrypt'(.*)
       replacepattern: >
-        mod 'puppetlabs-letsencrypt', '{{ source "latestVersion" }}'
+        mod 'puppet-letsencrypt', '{{ source "latestVersion" }}'
     scmid: default
 
 actions:

--- a/updatecli/weekly.d/puppet-modules/letsencrypt.yaml
+++ b/updatecli/weekly.d/puppet-modules/letsencrypt.yaml
@@ -1,0 +1,58 @@
+---
+name: Bump the Let's Encrypt Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppetlabs-letsencrypt module version
+    spec:
+      owner: voxpupuli
+      repository: puppetlabs-letsencrypt
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppet-letsencrypt-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest puppetlabs-letsencrypt module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppetlabs-letsencrypt'(.*)
+      replacepattern: >
+        mod 'puppetlabs-letsencrypt', '{{ source "latestVersion" }}'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump the Let's Encrypt Puppet Module to {{ source "latestVersion" }}
+    spec:
+      labels:
+        - puppet-module
+        - dependencies


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/3091, @lemeurherve and I relaized that our puppet setups uses and oooooold version of the puppet-letsencrypt module.

1. We want to keep it up to date, like any other dpendency
2. https://github.com/jenkins-infra/helpdesk/issues/3091 was merged recently after our comment that we are interesting. Using the upcoming released version would help greatly to manage certificate in pure puppet