### PR TITLE
cleanup(ci.jenkins.io) remove duplicated labels for VM agents

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -345,7 +345,6 @@ profile::jenkinscontroller::jcasc:
               - docker-windows
               - docker-windows-2019
               - windows
-              - windows-2019
             useAsMuchAsPossible: true
             spot: false
             userData:
@@ -361,7 +360,6 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             labels:
               - docker-windows-2022
-              - windows-2022
             useAsMuchAsPossible: true
             spot: false
             userData:
@@ -462,7 +460,6 @@ profile::jenkinscontroller::jcasc:
             - docker-windows
             - docker-windows-2019
             - windows
-            - windows-2019
           maxInstances: 20
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
@@ -485,7 +482,6 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - docker-windows-2022
-            - windows-2022
           maxInstances: 20
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"


### PR DESCRIPTION
fix https://github.com/jenkins-infra/jenkins-infra/pull/2578 duplicates label windows-2019 and windows-2022