### PR TITLE
fix(jenkinscontroller) get rid of 'discoverOtherRefsTrait' is obsolete,please use 'discoverOtherRefs' message

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/global-libraries.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/global-libraries.yaml.erb
@@ -20,7 +20,7 @@ unclassified:
                 traits:
                 - "gitBranchDiscovery"
     <%- if setup['allow-pull-requests'] -%>
-                - discoverOtherRefsTrait:
+                - discoverOtherRefs:
                     ref: "pull/*"
     <%- end -%>
                 - headWildcardFilter:


### PR DESCRIPTION
Our Puppet-managed controllers have the following warning in the admin messages:

<img width="600" alt="Capture d’écran 2023-01-17 à 10 48 52" src="https://user-images.githubusercontent.com/1522731/213412846-ff76590d-f7f0-4ee5-8ac3-91a1c765f623.png">

This PR applies the recommended JCasc syntax fix. Tested locally in Vagrant: the message disappear but the Global Library configuration is still the expected setup in the Administration UI:

<img width="566" alt="Capture d’écran 2023-01-19 à 11 01 26" src="https://user-images.githubusercontent.com/1522731/213413306-81d3a254-3aac-4f3e-9075-50b93f5d3300.png">

