### PR TITLE
hotfix(ci.jenkins.io) only enable AWS and DO caching proxy, not AZURE

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -111,7 +111,9 @@ jenkins:
           - key: "JENKINS_JAVA_BIN"
             value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
           - key: "ARTIFACT_CACHING_PROXY_PROVIDER"
-            value: "azure"
+            value: "aws"
+            ## TODO: switch back to Azure once Azure ACP is working as expected
+            # value: "azure"
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -96,8 +96,8 @@ profile::jenkinscontroller::jcasc:
       envVars:
         PATH+MAVEN: "/home/jenkins/tools/apache-maven-3.8.7/bin"
         JAVA_HOME: "/opt/jdk-11"
-        # For the permanent agents, we're using the artifact caching proxy on DigitalOcean (bandwith available)
-        ARTIFACT_CACHING_PROXY_PROVIDER: "do"
+        # For the permanent agents, we're using the closest artifact caching proxy available
+        ARTIFACT_CACHING_PROXY_PROVIDER: "aws"
       toolLocation:
         - home: "/home/jenkins/tools/apache-maven-3.8.7"
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
@@ -105,7 +105,7 @@ profile::jenkinscontroller::jcasc:
     kubernetes:
       cik8s:
         enabled: true
-        provider: "aws"
+        provider: "aws" # must be one of "aws","do", "azure"
         credentialsId: "cik8s-jenkins-agent-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIGTQYJKoZIhvcNAQcDoIIGPjCCBjoCAQAxggEhMIIBHQIBAD
@@ -202,7 +202,7 @@ profile::jenkinscontroller::jcasc:
             imagePullSecrets: dockerhub-credential
       doks:
         enabled: true
-        provider: do
+        provider: do # must be one of "aws","do", "azure"
         credentialsId: "doks-jenkins-agent-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIGrQYJKoZIhvcNAQcDoIIGnjCCBpoCAQAxggEhMIIBHQIBAD


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2752 (but also https://github.com/jenkins-infra/helpdesk/issues/3302 and https://github.com/jenkins-infra/helpdesk/issues/3221), this PR re-enable the caching proxy on ci.jenkins.io.

The first set of tests we ran on ci.jenkins.io with manual replays on the jenkinsci/jenkins-infra-test-plugin shows that:

- Digital Ocean and AWS caching proxies performs very well once cache is loaded (build are faster than when using jfrog in full cache mode, and +20% slower during the first cache warming).
- Azure caching proxy works well but really slowly (6 to 10x slower)
- Using the AWS cachin proxy whith Azure VMs is the same order of magnitude than using JFrog (US East cost for AWS, Azure and Jfrog) while using the Digital Ocean (located in a paris datacenter along with `doks`  cluster) is slower


=> So AWS is used for AWS agents (cluster cik8s) and for Azure VMs, while DO is used for `doks` agents, until we fix the Azure proxy.