### PR TITLE
Revert "hotfix(ci.jenkins.io) only enable AWS and DO caching proxy, not AZURE"

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -111,9 +111,7 @@ jenkins:
           - key: "JENKINS_JAVA_BIN"
             value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
           - key: "ARTIFACT_CACHING_PROXY_PROVIDER"
-            value: "aws"
-            ## TODO: switch back to Azure once Azure ACP is working as expected
-            # value: "azure"
+            value: "azure"
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -96,8 +96,8 @@ profile::jenkinscontroller::jcasc:
       envVars:
         PATH+MAVEN: "/home/jenkins/tools/apache-maven-3.8.7/bin"
         JAVA_HOME: "/opt/jdk-11"
-        # For the permanent agents, we're using the closest artifact caching proxy available
-        ARTIFACT_CACHING_PROXY_PROVIDER: "aws"
+        # For the permanent agents, we're using the artifact caching proxy on DigitalOcean (bandwith available)
+        ARTIFACT_CACHING_PROXY_PROVIDER: "do"
       toolLocation:
         - home: "/home/jenkins/tools/apache-maven-3.8.7"
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
@@ -105,7 +105,7 @@ profile::jenkinscontroller::jcasc:
     kubernetes:
       cik8s:
         enabled: true
-        provider: "aws" # must be one of "aws","do", "azure"
+        provider: "aws"
         credentialsId: "cik8s-jenkins-agent-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIGTQYJKoZIhvcNAQcDoIIGPjCCBjoCAQAxggEhMIIBHQIBAD
@@ -202,7 +202,7 @@ profile::jenkinscontroller::jcasc:
             imagePullSecrets: dockerhub-credential
       doks:
         enabled: true
-        provider: do # must be one of "aws","do", "azure"
+        provider: do
         credentialsId: "doks-jenkins-agent-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIGrQYJKoZIhvcNAQcDoIIGnjCCBpoCAQAxggEhMIIBHQIBAD


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2616

Ref. https://github.com/jenkins-infra/helpdesk/issues/2752#issuecomment-1409006477


Now that Azure ACP has good performances, we can go back to nominal case