### PR TITLE
feat(ci.j) ensure that ACP mirrors ALL maven repositories

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>repo.jenkins-ci.org,central</mirrorOf>
+                  <mirrorOf>*,!incrementals</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2752

This updates the mirroring pattern for ACP, to ensure that every request made by maven to either, repositories or plugin repositories, is sent to ACP:

- Expecting improved build performance (less requests made to the internet, less variability due to Jfrog Qos)
- https://github.com/jenkins-infra/kubernetes-management/pull/3536 Ensures that we have HA on ACPs (2 replicas per cluster)
- More control of the artifacts: ACP always uses JFrog for everything.