### PR TITLE
Update plugins of cert.ci

### DIFF
--- a/hieradata/clients/cert-ci.yaml
+++ b/hieradata/clients/cert-ci.yaml
@@ -129,8 +129,6 @@ profile::jenkinscontroller::plugins:
   # Utility
   - compact-columns
 
-  # Unused detached (disabled)
-  - bouncycastle-api
-  - command-launcher
-  - jdk-tool
-  - sshd
+  # (Likely unused) detached
+  - sshd # split after 2.281
+  - javax-mail-api # split after 2.330


### PR DESCRIPTION
`ace-editor` is gone thanks to https://github.com/jenkinsci/workflow-cps-plugin/releases/tag/3611.v201b_d9f9eb_f7, which increases the minimal core dependency of plugins on this instance to 2.263.1, followed by a handful of 2.277.x, so remove obsolete detached plugins.

Lazy branch, please delete on merge.

Once merged, I'll be able uninstall `jdk-tool`, `command-launcher`.