### PR TITLE
fix(artifact-caching-proxy): add exception for `elementary-releases` Maven repository

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>*,!incrementals</mirrorOf>
+                  <mirrorOf>*,!incrementals,!elementary-releases</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>


### PR DESCRIPTION
As the `com.karuslabs:elementary` dependency used in https://github.com/jenkinsci/stapler isn't published (yet) in Maven Central but to https://repo.karuslabs.com/repository/elementary-releases/, adding this repository as exception allows restoring the use of the Artifactory Caching Proxy for stapler's builds.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3382