### PR TITLE
fix(artifact-caching-proxy): add additional Maven repositories exceptions for `chimera-releases` & `chimera-snapshots`

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>*,!incrementals,!elementary-releases</mirrorOf>
+                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>


### PR DESCRIPTION
Follow-up of #2630 and cf @jglick comment in https://github.com/jenkinsci/stapler/pull/404#issuecomment-1238327013, adding additional exceptions.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3382 & https://github.com/jenkins-infra/helpdesk/issues/2752