### PR TITLE
feat: exclude pipeline library pull requests from cache

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/global-libraries.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/global-libraries.yaml.erb
@@ -10,6 +10,7 @@ unclassified:
     <%- if setup['cache-ttl'] -%>
         cachingConfiguration:
           refreshTimeMinutes: <%= setup['cache-ttl'] %>
+          excludedVersionsStr: "pull/"
     <%- end -%>
         retriever:
           modernSCM:


### PR DESCRIPTION
Same as infra.ci.jenkins.io: https://github.com/jenkins-infra/kubernetes-management/blob/main/config/ext_jenkins-infra.yaml#L414

Allow testing pipeline library pull requests without having to empty the corresponding cache at each modification.