### PR TITLE
feat(ci.jenkins.io, trusted.ci.jenkins.io,cert.ci.jenkins.io) Update Azure VM agents default configuration

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -48,6 +48,7 @@ jenkins:
         location: "<%= agent['location'] %>"
         noOfParallelJobs: 1
         osDiskSize: <%= agent['osDiskSize'] ? agent['osDiskSize'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskSize'] %>
+        osDiskStorageAccountType: <%= agent['osDiskStorageAccountType'] ? agent['osDiskStorageAccountType'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskStorageAccountType'] %>
         osType: "<%= agent['os'].to_s == "windows" ? 'Windows' : 'Linux' %>"
         preInstallSsh: false
       <%- if agent['idleTerminationMinutes'] -%>

--- a/hieradata/clients/cert-ci.yaml
+++ b/hieradata/clients/cert-ci.yaml
@@ -83,7 +83,6 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - linux
-          idleTerminationMinutes: 5
           maxInstances: 7 # Quota of 56 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
@@ -99,7 +98,6 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - windows
-          idleTerminationMinutes: 5
           maxInstances: 7 # Quota of 56 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-login"

--- a/hieradata/clients/trusted-ci.yaml
+++ b/hieradata/clients/trusted-ci.yaml
@@ -87,7 +87,6 @@ profile::jenkinscontroller::jcasc:
             - docker
             - maven-11
             - jdk11
-          idleTerminationMinutes: 5
           maxInstances: 7 # Quota of 56 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
@@ -103,7 +102,6 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - docker-windows
-          idleTerminationMinutes: 5
           maxInstances: 7 # Quota of 56 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -216,14 +216,16 @@ profile::jenkinscontroller::jcasc:
       # Double Backslash is required (for EC2 plugin as we hackishly use the unix launched for Windows to use OpenSSH)
       tempDir: 'C:\\\\Temp'
       remoteAdmin: Administrator
-      osDiskSize: 128
+      osDiskSize: 150
+      osDiskStorageAccountType: 'Premium_LRS'
       agentJavaBin: 'C:/tools/jdk-11/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
     ubuntu:
       agentDir: "/home/jenkins"
       remoteAdmin: jenkins
       tempDir: "/tmp"
-      osDiskSize: 90
+      osDiskSize: 150
+      osDiskStorageAccountType: 'Premium_LRS'
       agentJavaBin: '/opt/jdk-11/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
       path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'


### PR DESCRIPTION
This PR introduces the following configuration changes:

- All Azure VM agents are now using 150 Gb of disk (instead of 127 for Windows and 90 for Linux): related to https://github.com/jenkins-infra/helpdesk/issues/3359
- All Azure VM agents are now ephemeral to avoid any kind of data to be passed between jobs, and disk to be filled: related to https://github.com/jenkins-infra/helpdesk/issues/3359
- All Azure VM agents are now using Premium SSD (instead of HDD): related to https://github.com/jenkins-infra/helpdesk/issues/3117. The additional cost is acceptable, given that our bill decreased from ~10k€ monthly 1 year ago to ~8k€ monthly (and it's almost nothing compared to the VM minute/hours costs)