### PR TITLE
hotfix(jenkinscontroller) ensure that no azure VM agent uses ephemeral disk

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -19,7 +19,7 @@ jenkins:
         doNotUseMachineIfInitFails: true
         enableMSI: false
         enableUAMI: false
-        ephemeralOSDisk: <%= agent['useEphemeralOSDisk'].nil? ? true : agent['useEphemeralOSDisk'] %>
+        ephemeralOSDisk: false
       <%- if agent['initScript'] && !agent['initScript'].empty? -%>
         executeInitScriptAsRoot: true
         initScript: |

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -462,7 +462,6 @@ profile::jenkinscontroller::jcasc:
           maxInstances: 20
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
-          useEphemeralOSDisk: false
           usePrivateIP: true
           virtualNetworkName: "prod-jenkins-public-prod"
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
@@ -484,7 +483,6 @@ profile::jenkinscontroller::jcasc:
           maxInstances: 20
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
-          useEphemeralOSDisk: false
           usePrivateIP: true
           virtualNetworkName: "prod-jenkins-public-prod"
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -138,7 +138,6 @@ profile::jenkinscontroller::jcasc:
           maxInstances: 20
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
-          useEphemeralOSDisk: false
           usePrivateIP: true
           virtualNetworkName: "prod-jenkins-public-prod"
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -342,7 +342,6 @@ profile::jenkinscontroller::jcasc:
           maxInstances: 20
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
-          useEphemeralOSDisk: false
           usePrivateIP: true
           virtualNetworkName: "prod-jenkins-public-prod"
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
@@ -364,7 +363,6 @@ profile::jenkinscontroller::jcasc:
           maxInstances: 20
           useAsMuchAsPossible: false
           credentialsId: "jenkinsvmagents-userpass"
-          useEphemeralOSDisk: false
           usePrivateIP: true
           virtualNetworkName: "prod-jenkins-public-prod"
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"


### PR DESCRIPTION
Amends #2635 

We cannot use ephemeral disks as per https://learn.microsoft.com/en-us/azure/virtual-machines/dv3-dsv3-series#dsv3-series (we use D4S_v3 which only supports 32 Gb ephemeral disk while we need 150).