### PR TITLE
Revert "Bump agent templates version on all controllers" (`0.60.0` -> `0.59.0`)

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -216,7 +216,7 @@ profile::jenkinscontroller::jcasc:
             # Double Backslash is required (for EC2 plugin as we hackishly use the unix launched for Windows to use OpenSSH)
             tempDir: 'C:\\\\Temp'
             remoteAdmin: Administrator
-            osDiskSize: "150"
+            osDiskSize: 150
             osDiskStorageAccountType: 'Premium_LRS'
             agentJavaBin: 'C:/tools/jdk-11/bin/java'
             agentJavaOpts: '-XX:+PrintCommandLineFlags'
@@ -231,13 +231,13 @@ profile::jenkinscontroller::jcasc:
             path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
     agent_images:
         ec2_amis:
-            ubuntu-20.04-amd64: "ami-0f333d074376481c9"
-            windows-2019-amd64: "ami-0c9fbd6ecfa4c46b8"
-            ubuntu-20.04-arm64: "ami-0d92c0581a9347752"
+            ubuntu-20.04-amd64: "ami-0d354788823e8d3d0"
+            windows-2019-amd64: "ami-04a1975f2651fa5c7"
+            ubuntu-20.04-arm64: "ami-0bcb5a1e1f558ab8c"
             # Empty until https://github.com/jenkins-infra/packer-images/pull/442 is merged
-            windows-2022-amd64: "ami-091e002aee1a14610"
+            windows-2022-amd64: "ami-0633c374ee50742e0"
         azure_vms_gallery_image:
-            version: 0.60.0
+            version: 0.59.0
             subscription_id: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAluBQmOHo1MWoOCMVOCcgVUs9gOzFVEZMT7RA3V33KeolyRKh0lm5Ta5+C9aKJe9myuVGaDQsd99XsW40d7NdygJcnBxUV+VTnnLphjplPtCX5JIS4ww/S8JGOpOIE2zejy5bL2CpnZhgSFh+aD1FLD91ozNS5lgNOq9hNKqo+mSfUnX5wrUFvlCaadTWp3yxG7l7VluxP1Wh4BlsRmphmbUmmgFo56CjDUVz9dMwxT/p/uE1S/SPuEirJOAPtPCl7x2NQWg+Qlv5j1tC5ASgh9beD3SjUVPd6VYM+K+u07aw8jOj/meARXgghtUPgqHqWC44JGHPzWkZ4dQFhe6jyzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDc6VPQnQTEmwF9aAh/uK9IgDDXAM9S6QNxRH8cFSOAESeqOlLFBKVAlJc3Mnby3Pc/6H21BsehZbQLUd+1MfcoPI0=]
         container_images:
             jnlp-maven-8-windows: jenkinsciinfra/inbound-agent-maven:jdk8-nanoserver@sha256:f61b83beede59e4afaa861ffde7dac4d8a4fc85ae86366c403c3da02819ad571
@@ -245,8 +245,8 @@ profile::jenkinscontroller::jcasc:
             jnlp-maven-17-windows: jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver@sha256:f53eb74b28cdf0c59ef619d90feff282b0752dec741ec7282706c557eea91c9f
             jnlp-maven-19-windows: jenkinsciinfra/inbound-agent-maven:jdk19-nanoserver@sha256:86d18406c645a0b220201307ad6f463b5e49977d7cb7d7b3f6575c2145035aa9
             jnlp-ruby: jenkinsciinfra/inbound-agent-ruby@sha256:221f96baa1957742728eb6d2769a691aea5721fc11ed9b05da810c5debe92115
-            jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-20.04@sha256:e2daa3fe2b61006d656c224eecce68aae42d17e64446b83bd5ae3739d6d88b07
-            jnlp-webbuilder: 'jenkinsciinfra/builder@sha256:f3b470c1061558c9c7e22a4370b9c909042bb099bcf4d9006bf005517891048b'
+            jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-20.04@sha256:3e5bafdde8059ae0b1a29a0f47a2e084bf247ad648ef0aa884e9bf3a85555d5e
+            jnlp-webbuilder: 'jenkinsciinfra/builder@sha256:4fda01a6c34e56c864abce3f2f4fd4d53dfe15e39e28e95687bf2ce62b2157a5'
             # default template from the official inbound-agent image here to provide a default agent (`node()` pipeline step)
             jnlp: jenkins/inbound-agent@sha256:c1be7443b2e2d577a1a7a4631c23df305756f8b5207ee2b4fe4b1d15c26b252c
     tools_default_versions:


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2645

While checking https://github.com/jenkins-infra/helpdesk/issues/3400, it appeared that the tag 0.60.0 had an issue: the Linux container image for AMD64 is not published (error).