### PR TITLE
chore(ci.jenkins.io): disable cik8s before updating it to Kubernetes 1.24

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -104,7 +104,7 @@ profile::jenkinscontroller::jcasc:
   cloud_agents:
     kubernetes:
       cik8s:
-        enabled: true
+        enabled: false
         provider: "aws"
         credentialsId: "cik8s-jenkins-agent-sa-token"
         serverCertificate: >


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3387