### PR TITLE
fix(rng) switch to the rng-tools5 package to ensure all ubuntu versions are covered

### DIFF
--- a/dist/profile/manifests/rngd.pp
+++ b/dist/profile/manifests/rngd.pp
@@ -1,8 +1,12 @@
 # Profile for managing rngd packet installation
 class profile::rngd {
-  ['rng-tools'].each | $package | {
-    package { $package:
-      ensure => present,
-    }
+  # This package exists on ubuntu 18.04, 20.04 and 22.04
+  package { 'rng-tools5':
+    ensure => present,
+  }
+
+  # This package is the "legacy" on ubuntu 18.04 and 20.04, but is renamed as 'rng-tools-debian' on 22.04+
+  package { 'rng-tools':
+    ensure => absent,
   }
 }


### PR DESCRIPTION
On Ubuntu 22.04, the package `rng-tools` was renamed to `rng-tools-debian` (and is marked as the "classic system").

The puppet agent on the Ubuntu 22.04 machines spams us because it keeps running the following (non failing) instruction:

```
Feb 22 17:20:05 private-vpn-jenkins-io puppet-agent[1038457]: (/Stage[main]/Profile::Rngd/Package[rng-tools]/ensure) created (corrective)
```

This PR switches to rng-tools5 which exists on all distributions, to fix this annoyance.