### PR TITLE
hotfix(cert.ci) persist temporary settings - helpdesk-3395

### DIFF
--- a/hieradata/clients/cert-ci.yaml
+++ b/hieradata/clients/cert-ci.yaml
@@ -69,7 +69,7 @@ profile::jenkinscontroller::jcasc:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.6.zip"
   cloud_agents:
     azure-vm-agents:
-      azureCredentialsId: "azure-sponsorship-credentials"
+      azureCredentialsId: "azure-sp-agents-2023-02"
       resource_group: "certci-agents-2"
       agent_definitions:
         - name: "ubuntu"
@@ -83,7 +83,7 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - linux
-          maxInstances: 7 # Quota of 56 vCPUs
+          maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
           usePrivateIP: false
@@ -98,7 +98,7 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - windows
-          maxInstances: 7 # Quota of 56 vCPUs
+          maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
           usePrivateIP: false


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3395

This PR persists the following settings applied manually:

- Using the (temporary) credential valid only for february 2023
- Increase the max. limit of agents of each kind to 10