### PR TITLE
fix(letsencrypt) use pip package for certbot and its plugins

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -14,14 +14,13 @@ class profile::letsencrypt (
       provider => 'snap',
     }
   }
-  ['/snap/bin/certbot', '/usr/local/bin/certbot'].each | $snap_created_file | {
-    file { $snap_created_file:
-      ensure => 'absent',
-    }
+  file { '/snap/bin/certbot':
+    ensure => 'absent',
   }
 
   $python_base_version = '3.8'
   $python_weight       = regsubst($python_base_version, '\.','')
+  $certbot_version     = '1.32.0'
 
   ['python3', 'python3-pip', "python${python_base_version}"].each | $package_name | {
     package { $package_name:
@@ -40,13 +39,13 @@ class profile::letsencrypt (
 
   exec { 'Ensure pip is initialized for certbot':
     require => [Package["python${python_base_version}"],Package['python3-pip']],
-    command => "/usr/bin/python${python_base_version} -m pip install --upgrade pip setuptools",
-    unless  => "/usr/bin/python${python_base_version} -m pip list | /bin/grep --quiet setuptools",
+    command => "/usr/bin/python${python_base_version} -m pip install --upgrade pip setuptools setuptools_rust",
+    unless  => "/usr/bin/python${python_base_version} -m pip list | /bin/grep --quiet setuptools_rust",
   }
 
   exec { 'Install certbot 1.x':
     require => [Package["python${python_base_version}"],Package['python3-pip'], Exec['Ensure pip is initialized for certbot']],
-    command => "/usr/bin/python${python_base_version} -m pip install --upgrade certbot==1.32.0 acme==1.32.0 pyopenssl",
+    command => "/usr/bin/python${python_base_version} -m pip install --upgrade pyopenssl certbot==${certbot_version} acme==${certbot_version}",
     creates => '/usr/local/bin/certbot',
   }
 

--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -18,7 +18,14 @@ class profile::letsencrypt (
     ensure => 'absent',
   }
 
-  $python_base_version = '3.8'
+  case $facts['os']['distro']['codename'] {
+    'bionic', 'focal':  {
+      $python_base_version = '3.8'
+    }
+    default:  {
+      $python_base_version = '3.10'
+    }
+  }
   $python_weight       = regsubst($python_base_version, '\.','')
   $certbot_version     = '1.32.0'
 

--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -50,14 +50,14 @@ class profile::letsencrypt (
     unless  => "/usr/bin/python${python_base_version} -m pip list | /bin/grep --quiet setuptools_rust",
   }
 
-  exec { 'Install certbot 1.x':
+  exec { 'Install certbot':
     require => [Package["python${python_base_version}"],Package['python3-pip'], Exec['Ensure pip is initialized for certbot']],
     command => "/usr/bin/python${python_base_version} -m pip install --upgrade pyopenssl certbot==${certbot_version} acme==${certbot_version}",
     creates => '/usr/local/bin/certbot',
   }
 
   exec { 'Install certbot-dns-azure plugin':
-    require => Exec['Install certbot 1.x'],
+    require => Exec['Install certbot'],
     command => "/usr/bin/python${python_base_version} -m pip install --upgrade certbot-dns-azure",
     unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet dns-azure',
   }

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -9,7 +9,13 @@ lookup_options:
       strategy: deep
       merge_hash_arrays: true
 
-profile::jenkinscontroller::letsencrypt: false
+profile::jenkinscontroller::letsencrypt: true
+profile::letsencrypt::dns_azure:
+  sp_client_id: "<application_id>" # application_id
+  sp_client_secret: "<application_password>" # application_password.
+  tenant_id: "<subscription id>" # subscription id
+  zones:
+    trusted.ci.jenkins.io: "/subscriptions/xxx/dnszone/yyyy"
 profile::jenkinscontroller::ci_fqdn: 'localhost'
 profile::jenkinscontroller::ci_resource_domain: 'assets.localhost'
 profile::jenkinscontroller::proxy_port: 443

--- a/spec/classes/profile/letsencrypt_spec.rb
+++ b/spec/classes/profile/letsencrypt_spec.rb
@@ -3,24 +3,19 @@ require 'spec_helper'
 describe 'profile::letsencrypt' do
   context 'default setup uses HTTP-01 with staging' do
     it {
-      expect(subject).to contain_class 'snap'
-      expect(subject).to contain_package('certbot').with({
-        :provider => 'snap',
-        :install_options => ['classic'],
+      expect(subject).to contain_package('python3.8')
+      expect(subject).to contain_package('python3-pip')
+      expect(subject).to contain_exec('Install certbot-dns-azure plugin').with({
+        :command => '/usr/bin/python3.8 -m pip install --upgrade certbot-dns-azure',
+        :unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet dns-azure',
       })
-      expect(subject).to contain_file('/usr/bin/certbot').with({
-        :ensure => 'link',
-        :source  => '/snap/bin/certbot',
-        })
+
       expect(subject).to contain_class('letsencrypt').with_config({
         'email'                => 'tyler@monkeypox.org',
         'server'               => 'https://acme-staging-v02.api.letsencrypt.org/directory',
         'authenticator'        => 'apache',
         'preferred-challenges' => 'http',
       }).with_package_ensure('absent').with_configure_epel(false)
-      expect(subject).to contain_package('certbot-dns-azure').with({
-        :ensure  => 'absent',
-      })
       expect(subject).to contain_file('/etc/letsencrypt/azure.ini').with({
         :ensure  => 'absent',
       })
@@ -44,28 +39,13 @@ describe 'profile::letsencrypt' do
     end
 
     it {
-      expect(subject).to contain_class 'snap'
-      expect(subject).to contain_package('certbot').with({
-        :provider => 'snap',
-        :install_options => ['classic'],
+      expect(subject).to contain_package('python3.8')
+      expect(subject).to contain_package('python3-pip')
+      expect(subject).to contain_exec('Install certbot-dns-azure plugin').with({
+        :command => '/usr/bin/python3.8 -m pip install --upgrade certbot-dns-azure',
+        :unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet dns-azure',
       })
-      expect(subject).to contain_package('certbot-dns-azure').with({
-        :provider => 'snap',
-      })
-      expect(subject).to contain_snap_conf('trust plugin with root dns-azure').with({
-        :ensure => 'present',
-        :conf   => 'trust-plugin-with-root',
-        :value  => 'ok',
-        :snap   => 'certbot',
-      })
-      expect(subject).to contain_file('/usr/bin/certbot').with({
-        :ensure => 'link',
-        :source  => '/snap/bin/certbot',
-      })
-      expect(subject).to contain_exec('Connect certbot with certbot-dns-azure plugin').with({
-        :command => '/usr/bin/snap connect certbot:plugin certbot-dns-azure',
-        :unless  => '/snap/bin/certbot plugins --text | /bin/grep "dns-azure" 2>/dev/null',
-      })
+
       expect(subject).to contain_file('/etc/letsencrypt/azure.ini').with({
         :ensure  => 'file',
         :owner   => 'root',


### PR DESCRIPTION
This PR is related to https://github.com/jenkins-infra/helpdesk/issues/3399.

It fixes the certbot installation by using the Python pip package instead of snap, which is the only way to use the dns azure plugin for certbot which requires certbot 1.x as for today (see the issue above for details).

- Python 3.8 is required in order to properly install `certbot` (to ensure the certbot requirement of pyopenssl >= 40.x )
- Since Python 3.6 is the "default" installed version on Ubuntu 18.04, this script ensures that python 3.8 is installed and defined as the "alternative" for both `python` and `python3`.
  - For Ubuntu 20.04, Python 3.8 is the system default ✅ 
  - For Ubuntu 22.04: Python 3.10 is used ✅ 
- Pip is "prepared" in the context of python 3.8 to ensure that  `certbot` installation deos not fail:
  - Upgraded to the last version available when executed 
  - Add requirements for proper pyopenssl installation: `setuptools` and setuptools_rust`
- `certbot` is installed in version 1.32.0: it's the latest available version for the 1.x line in PyPip:  https://pypi.org/project/certbot/#history
- The plugin `certbot-dns-azure` is always installed (less conditional code + we can switch between HTTP-01 and DNS-01 without surprise)


In order to avoid any problem once this PR merged, the following preventive actions were taken:

- Backed-up any letsencrypt folder with certificates: if anything goes wrong on a machine, we can rollback the "current" certificate and keep going

```shell
for machine in ci.jenkins.io cert.ci.jenkins.io archives.jenkins.io edamame.jenkins.io lettuce.jenkins.io census.jenkins.io usage.jenkins.io trusted.ci.jenkins.io trusted-agent-1 vpn.jenkins.io private.vpn.jenkins.io bounce puppet.jenkins.io; do echo "=== Machine: ${machine}";ssh "${machine}" sudo cp -r /etc/letsencrypt /root/bkp-letsencrypt-20230224-01;done 
```

- Disabled the Puppet agent on each machine (to control, machine per machine, the new execution flow):

```shell
for machine in ci.jenkins.io cert.ci.jenkins.io archives.jenkins.io edamame.jenkins.io lettuce.jenkins.io census.jenkins.io usage.jenkins.io trusted.ci.jenkins.io trusted-agent-1 vpn.jenkins.io private.vpn.jenkins.io bounce puppet.jenkins.io; do echo "=== Machine: ${machine}";ssh "${machine}" sudo "systemctl stop puppet && puppet agent --disable";done
```