### PR TITLE
hotfix(letsencrypt) ensure that pip list uses modern formatting for idempotency

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -19,7 +19,7 @@ class profile::letsencrypt (
   }
 
   case $facts['os']['distro']['codename'] {
-    'bionic', 'focal':  {
+    'bionic', 'focal': {
       $python_base_version = '3.8'
     }
     default:  {
@@ -47,7 +47,7 @@ class profile::letsencrypt (
   exec { 'Ensure pip is initialized for certbot':
     require => [Package["python${python_base_version}"],Package['python3-pip']],
     command => "/usr/bin/python${python_base_version} -m pip install --upgrade pip setuptools setuptools_rust",
-    unless  => "/usr/bin/python${python_base_version} -m pip list | /bin/grep --quiet setuptools_rust",
+    unless  => "/usr/bin/python${python_base_version} -m pip list --format=columns | /bin/grep --quiet setuptools_rust",
   }
 
   exec { 'Install certbot':


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/jenkins-infra/pull/2659

This PR ensures the `pip list` command does not error when piped to a non interactive process.
It adds the flag `--format=columns` to solve this issue.

