### PR TITLE
fixup of #2662

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -46,8 +46,8 @@ class profile::letsencrypt (
 
   exec { 'Ensure pip is initialized for certbot':
     require => [Package["python${python_base_version}"],Package['python3-pip']],
-    command => "/usr/bin/python${python_base_version} -m pip install --upgrade pip setuptools setuptools_rust",
-    unless  => "/usr/bin/python${python_base_version} -m pip list --format=columns | /bin/grep --quiet setuptools_rust",
+    command => "/usr/bin/python${python_base_version} -m pip install --upgrade pip setuptools setuptools-rust",
+    unless  => "/usr/bin/python${python_base_version} -m pip list --format=json | /bin/grep --quiet setuptools-rust",
   }
 
   exec { 'Install certbot':


### PR DESCRIPTION
- Tested in production
- `pip list` complains. Instead of an ugly `pip list | strings | grep`, using the `json` looks better has it is explicit for "processing" (I mean reading JSON is failing the turing test :trollface: )