### PR TITLE
chore(github action): bump v1-node16 sha version

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -23,7 +23,7 @@ jobs:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure AWS Credentials
         if: github.ref == 'refs/heads/production'
-        uses: aws-actions/configure-aws-credentials@5f641521a3878b25d04da89cfd0c9ba02229efc6 # v1-node16
+        uses: aws-actions/configure-aws-credentials@023daa7fe5f7f817faa31fc0fc4a8d0fb6224ed0 # v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
comparing changes : https://github.com/aws-actions/configure-aws-credentials/compare/5f641521a3878b25d04da89cfd0c9ba02229efc6...023daa7fe5f7f817faa31fc0fc4a8d0fb6224ed0

try to resolve the error : 
```
ERROR: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```