### PR TITLE
fix(artifact-caching-proxy): mirror all HTTP maven repositories

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots</mirrorOf>
+                  <mirrorOf>*,external:http:*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>


### PR DESCRIPTION
Fix the *"Blocked mirror for repositories: [maven.jenkins-ci.org (http://repo.jenkins-ci.org/public/, default, releases+snapshots)]"* error noticed in https://github.com/jenkins-infra/backend-extension-indexer/pull/48

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752