### PR TITLE
Revert "fix(artifact-caching-proxy): mirror all HTTP maven repositories" (#2675

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>*,external:http:*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots</mirrorOf>
+                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2674

Not needed, the reason HTTP mirrors were not catched is because the content of the artifact caching proxy settings.xml files were not up to date on infra.ci.jenkins.io, fixed in https://github.com/jenkins-infra/kubernetes-management/pull/3651