### PR TITLE
fix(letsencrypt,pkg) ensure that createrepo is usable

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -44,15 +44,6 @@ class profile::letsencrypt (
     }
   }
 
-  ['python3', 'python'].each | $alternative_name | {
-    exec { "Define python${python_system_version} as the default system ${alternative_name}":
-      require => Package['python3'],
-      # Last argument is the weight. Bigger weight wins
-      command => "/usr/bin/update-alternatives --install /usr/bin/${alternative_name} ${alternative_name} /usr/bin/python${python_system_version} 1000",
-      unless  => "/usr/bin/${alternative_name} --version | grep --quiet '${python_system_version}.'",
-    }
-  }
-
   exec { 'Ensure pip is initialized for certbot':
     require => [Package["python${python_certbot_version}"],Package['python3-pip']],
     command => "/usr/bin/python${python_certbot_version} -m pip install --upgrade pip setuptools setuptools-rust",

--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -14,7 +14,7 @@ class profile::pkgrepo (
   include profile::firewall
   include profile::letsencrypt
 
-  # 'Ubuntu 20.04+ are not supported (createrepo package absent).'
+  # Ubuntu 20.04+ are not supported (createrepo package absent).
   case $facts['os']['distro']['codename'] {
     'bionic': {
       # Needed so we can generate repodata on the machine
@@ -31,7 +31,7 @@ class profile::pkgrepo (
         unless  => '/usr/bin/python --version 2>&1 | grep --quiet "2\.7\."',
       }
     }
-    # TODO: add support of Ubuntu 22.04 Jammy with the createrepo-c package instead
+    # TODO: add support of Ubuntu 22.04 Jammy with the createrepo-c package instead. Ref. https://github.com/jenkins-infra/release/issues/202.
     default: {
       fail('[profile::pkgrepo] Unsupported Ubuntu distribution (ref. "createrepo" package).')
     }

--- a/spec/classes/profile/pkgrepo_spec.rb
+++ b/spec/classes/profile/pkgrepo_spec.rb
@@ -20,14 +20,6 @@ describe 'profile::pkgrepo' do
   it { expect(subject).to contain_class 'apache' }
 
   context 'Ubuntu 18.04 Bionic' do
-    # let(:facts) {
-    #   :os => {
-    #     :distro => {
-    #       :codename => 'bionic'
-    #     },
-    #   },
-    # }
-
     it 'installs the createrepo(8) package on Ubuntu bionic with python set to 2.7' do
       expect(subject).to contain_package('createrepo').with({
         :ensure => :present,

--- a/spec/classes/profile/pkgrepo_spec.rb
+++ b/spec/classes/profile/pkgrepo_spec.rb
@@ -19,11 +19,31 @@ describe 'profile::pkgrepo' do
   it { expect(subject).to contain_class 'profile::pkgrepo' }
   it { expect(subject).to contain_class 'apache' }
 
-  it 'needs createrepo(8) so we can generate repodata' do
-    expect(subject).to contain_package('createrepo').with({
-      :ensure => :present,
-    })
+  context 'Ubuntu 18.04 Bionic' do
+    # let(:facts) {
+    #   :os => {
+    #     :distro => {
+    #       :codename => 'bionic'
+    #     },
+    #   },
+    # }
+
+    it 'installs the createrepo(8) package on Ubuntu bionic with python set to 2.7' do
+      expect(subject).to contain_package('createrepo').with({
+        :ensure => :present,
+      })
+
+      expect(subject).to contain_package('python2.7').with({
+        :ensure => :present,
+      })
+
+      expect(subject).to contain_exec('Define python2.7 as the default system python').with({
+        :command => '/usr/bin/update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1000',
+        :unless  => '/usr/bin/python --version 2>&1 | grep --quiet "2\.7\."',
+      })
+    end
   end
+
 
   context 'repository directories' do
     platforms = ['debian', 'opensuse', 'redhat']

--- a/spec/classes/profile/pkgrepo_spec.rb
+++ b/spec/classes/profile/pkgrepo_spec.rb
@@ -36,7 +36,6 @@ describe 'profile::pkgrepo' do
     end
   end
 
-
   context 'repository directories' do
     platforms = ['debian', 'opensuse', 'redhat']
     variants = [nil, 'stable', 'rc', 'stable-rc']


### PR DESCRIPTION
This PR is a fixup of https://github.com/jenkins-infra/jenkins-infra/pull/2659.

It ensures that the `createrepo` command line works as expected on the VM pkg.origin.jenkins.io in order to package Jenkins core when releasing a weekly or LTS.


https://github.com/jenkins-infra/jenkins-infra/pull/2659 did change the symlink `/usr/bin/python`from `python2.7` to `python3.x` using the `update-alternative.

This behavior is fixed here but only on pkg.origin.jenkins.io + removed from Let's Encrypt profiles to avoid the issue to reappear due to certbot (which needs `python3.8`).


Additionnaly, as `createrepo(8)` does not exist on Ubuntu 20.04 and later, the profile fails if not executed on Ubuntu 18.04. This is a safety measure to ensure that we'll fail fast (and we'll have to fix this) once we'll upgrade out from Ubuntu 18.04.
(NB. https://github.com/jenkins-infra/release/issues/202 and https://github.com/jenkinsci/packaging/pull/317 were tentative to move to `createrepo-c` instead, but wasn't done since it's still on pkg.origin.jenkins.io)