### PR TITLE
fix(letsencrypt) ensure that the apache plugin for certbot is installed

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -50,14 +50,14 @@ class profile::letsencrypt (
     unless  => "/usr/bin/python${python_certbot_version} -m pip list --format=json | /bin/grep --quiet setuptools-rust",
   }
 
-  exec { 'Install certbot':
+  exec { 'Install certbot and certbot-apache plugin':
     require => [Package["python${python_certbot_version}"],Package['python3-pip'], Exec['Ensure pip is initialized for certbot']],
-    command => "/usr/bin/python${python_certbot_version} -m pip install --upgrade pyopenssl certbot==${certbot_version} acme==${certbot_version}",
+    command => "/usr/bin/python${python_certbot_version} -m pip install --upgrade pyopenssl certbot==${certbot_version} certbot-apache==${certbot_version} acme==${certbot_version}",
     creates => '/usr/local/bin/certbot',
   }
 
   exec { 'Install certbot-dns-azure plugin':
-    require => Exec['Install certbot'],
+    require => Exec['Install certbot and certbot-apache plugin'],
     command => "/usr/bin/python${python_certbot_version} -m pip install --upgrade certbot-dns-azure",
     unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet dns-azure',
   }

--- a/spec/classes/profile/letsencrypt_spec.rb
+++ b/spec/classes/profile/letsencrypt_spec.rb
@@ -5,9 +5,14 @@ describe 'profile::letsencrypt' do
     it {
       expect(subject).to contain_package('python3.8')
       expect(subject).to contain_package('python3-pip')
+
       expect(subject).to contain_exec('Install certbot-dns-azure plugin').with({
         :command => '/usr/bin/python3.8 -m pip install --upgrade certbot-dns-azure',
         :unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet dns-azure',
+      })
+
+      expect(subject).to contain_exec('Install certbot and certbot-apache plugin').with({
+        :command => '/usr/bin/python3.8 -m pip install --upgrade pyopenssl certbot==1.32.0 certbot-apache==1.32.0 acme==1.32.0',
       })
 
       expect(subject).to contain_class('letsencrypt').with_config({
@@ -41,6 +46,11 @@ describe 'profile::letsencrypt' do
     it {
       expect(subject).to contain_package('python3.8')
       expect(subject).to contain_package('python3-pip')
+
+      expect(subject).to contain_exec('Install certbot and certbot-apache plugin').with({
+        :command => '/usr/bin/python3.8 -m pip install --upgrade pyopenssl certbot==1.32.0 certbot-apache==1.32.0 acme==1.32.0',
+      })
+
       expect(subject).to contain_exec('Install certbot-dns-azure plugin').with({
         :command => '/usr/bin/python3.8 -m pip install --upgrade certbot-dns-azure',
         :unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet dns-azure',


### PR DESCRIPTION
This PR is related to jenkins-infra/helpdesk#3446 .

It adds the pip package `certbot-apache` to fix the regression from #2659 which forgot to ensure this plugin is present to fulfill the HTTP renewal method case.

It also adds unit test to make it a requirement for future changes.