### PR TITLE
fix(letsencrypt) ensure that certbot-apache is installed separtely

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -50,14 +50,20 @@ class profile::letsencrypt (
     unless  => "/usr/bin/python${python_certbot_version} -m pip list --format=json | /bin/grep --quiet setuptools-rust",
   }
 
-  exec { 'Install certbot and certbot-apache plugin':
+  exec { 'Install certbot':
     require => [Package["python${python_certbot_version}"],Package['python3-pip'], Exec['Ensure pip is initialized for certbot']],
-    command => "/usr/bin/python${python_certbot_version} -m pip install --upgrade pyopenssl certbot==${certbot_version} certbot-apache==${certbot_version} acme==${certbot_version}",
+    command => "/usr/bin/python${python_certbot_version} -m pip install --upgrade pyopenssl certbot==${certbot_version} acme==${certbot_version}",
     creates => '/usr/local/bin/certbot',
   }
 
+  exec { 'Install certbot-apache plugin':
+    require => Exec['Install certbot'],
+    command => "/usr/bin/python${python_certbot_version} -m pip install --upgrade certbot-apache==${certbot_version}",
+    unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet apache',
+  }
+
   exec { 'Install certbot-dns-azure plugin':
-    require => Exec['Install certbot and certbot-apache plugin'],
+    require => Exec['Install certbot'],
     command => "/usr/bin/python${python_certbot_version} -m pip install --upgrade certbot-dns-azure",
     unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet dns-azure',
   }

--- a/spec/classes/profile/letsencrypt_spec.rb
+++ b/spec/classes/profile/letsencrypt_spec.rb
@@ -6,13 +6,13 @@ describe 'profile::letsencrypt' do
       expect(subject).to contain_package('python3.8')
       expect(subject).to contain_package('python3-pip')
 
-      expect(subject).to contain_exec('Install certbot-dns-azure plugin').with({
-        :command => '/usr/bin/python3.8 -m pip install --upgrade certbot-dns-azure',
-        :unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet dns-azure',
+      expect(subject).to contain_exec('Install certbot').with({
+        :command => '/usr/bin/python3.8 -m pip install --upgrade pyopenssl certbot==1.32.0 acme==1.32.0',
       })
 
-      expect(subject).to contain_exec('Install certbot and certbot-apache plugin').with({
-        :command => '/usr/bin/python3.8 -m pip install --upgrade pyopenssl certbot==1.32.0 certbot-apache==1.32.0 acme==1.32.0',
+      expect(subject).to contain_exec('Install certbot-apache plugin').with({
+        :command => '/usr/bin/python3.8 -m pip install --upgrade certbot-apache==1.32.0',
+        :unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet apache',
       })
 
       expect(subject).to contain_class('letsencrypt').with_config({
@@ -47,8 +47,13 @@ describe 'profile::letsencrypt' do
       expect(subject).to contain_package('python3.8')
       expect(subject).to contain_package('python3-pip')
 
-      expect(subject).to contain_exec('Install certbot and certbot-apache plugin').with({
-        :command => '/usr/bin/python3.8 -m pip install --upgrade pyopenssl certbot==1.32.0 certbot-apache==1.32.0 acme==1.32.0',
+      expect(subject).to contain_exec('Install certbot').with({
+        :command => '/usr/bin/python3.8 -m pip install --upgrade pyopenssl certbot==1.32.0 acme==1.32.0',
+      })
+
+      expect(subject).to contain_exec('Install certbot-apache plugin').with({
+        :command => '/usr/bin/python3.8 -m pip install --upgrade certbot-apache==1.32.0',
+        :unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet apache',
       })
 
       expect(subject).to contain_exec('Install certbot-dns-azure plugin').with({


### PR DESCRIPTION
This PR is a fixup of #2692 to ensure that the lifecycle of the plugin `certbot-apache` is separated from `certbot` itself to automate installation when needed