### PR TITLE
chore(updatecli) improve maven manifest to track "deployed" version and manage s390x agent version

### DIFF
--- a/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml
@@ -14,13 +14,21 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
+  getPackerImageDeployedVersion:
+    kind: yaml
+    name: Retrieve the current version of the Packer images used in production
+    spec:
+      file: ./hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version"
   # Retrieving Maven from packer-images to synchronize its version across our infra
   # See https://github.com/jenkins-infra/docker-inbound-agents/issues/18
   getMavenVersionFromPackerImages:
     kind: file
     name: Get the latest Maven version set in packer-images
+    dependson:
+      - getPackerImageDeployedVersion
     spec:
-      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/main/provisioning/tools-versions.yml
+      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getPackerImageDeployedVersion" }}/provisioning/tools-versions.yml
       matchpattern: 'maven_version:\s"(.*)"'
     transformers:
       - findsubmatch:
@@ -38,6 +46,7 @@ targets:
   setMavenVersion:
     name: "Bump Maven version on tools"
     kind: yaml
+    sourceid: getMavenVersionFromPackerImages
     spec:
       file: hieradata/common.yaml
       key: "profile::jenkinscontroller::jcasc.tools_default_versions.maven"

--- a/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml
@@ -43,7 +43,7 @@ conditions:
       command: curl --connect-timeout 5 --location --head --fail --silent --show-error https://archive.apache.org/dist/maven/maven-3/{{ source `getMavenVersionFromPackerImages` }}/binaries/apache-maven-{{ source `getMavenVersionFromPackerImages` }}-bin.tar.gz
 
 targets:
-  setMavenVersion:
+  setMavenToolVersion:
     name: "Bump Maven version on tools"
     kind: yaml
     sourceid: getMavenVersionFromPackerImages
@@ -51,6 +51,28 @@ targets:
       file: hieradata/common.yaml
       key: "profile::jenkinscontroller::jcasc.tools_default_versions.maven"
     scmid: default
+  setMavenPathFors390x:
+    name: "Bump Maven path on s390x permanent agent setup"
+    kind: yaml
+    sourceid: getMavenVersionFromPackerImages
+    transformers:
+      - addprefix: /home/jenkins/tools/apache-maven-
+      - addsuffix: /bin
+    spec:
+      file: hieradata/clients/azure.ci.jenkins.io.yaml
+      key: "profile::jenkinscontroller::jcasc.permanent_agents.s390x-agent.envVars.PATH+MAVEN"
+    scmid: default
+  setMavenToolVersionFors390x:
+    name: "Bump Maven path on s390x permanent agent setup"
+    kind: yaml
+    sourceid: getMavenVersionFromPackerImages
+    transformers:
+      - addprefix: /home/jenkins/tools/apache-maven-
+    spec:
+      file: hieradata/clients/azure.ci.jenkins.io.yaml
+      key: "profile::jenkinscontroller::jcasc.permanent_agents.s390x-agent.toolLocation[0].home"
+    scmid: default
+
 
 actions:
   default:


### PR DESCRIPTION
This PR fixes the updatecli manfiest tracking the Maven version deployed on our controllers with 2 changes:

- Ensure that the retrieved Maven version is the one deployed to production (instead of the version merged on the principal branch of the jenkins-infra/packer-image repository)
- Tracks the version of Maven on the `s390x` permanent agent (to avoid manual PRs as #2691 ). 
  - cc @MarkEWaite this "automatic track" means that we (Jenkins infra including you) will have to keep the Maven installation in the `s390x` agent up to date to follow the rest of ci.jenkins.io (as this installation is managed by hand today).