### PR TITLE
feat(controllers) set EC2 agent template to a default of 1 minute of idle before being terminated

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -147,9 +147,7 @@ jenkins:
         ebsEncryptRootVolume: DEFAULT
         ebsOptimized: false
         hostKeyVerificationStrategy: ACCEPT_NEW
-        <%- if agent['idleTerminationMinutes'] -%>
-        idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] %>"
-        <%- end -%>
+        idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] ? agent['idleTerminationMinutes'] : 1 %>"
         instanceCapStr: "<%= agent['maxInstances'] %>"
         jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
         labelString: "<%= agent['os'] + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['labels'].join(' ') %>"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3421

This PR ensures that the EC2 agents have a default of 1 minute of idleTermination time instead of the 30 min default of the plugin (when JCasc does not specify the attrbiute, which was our case).

Of course, a different value can be specified per agent through hieradata.


Expected benefits:

- Less credits spent in AWS as the machine should be stopped earlier in average
- Less "weird state / disconnected idle machines" as the spot instances won't have time to be reclaimed: Jenkins will garbage collect before.