### PR TITLE
hotfix(ci.jenkins.io) correct YAML anchors

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -317,7 +317,21 @@ profile::jenkinscontroller::jcasc:
               - arm64linux
             useAsMuchAsPossible: false
             spot: true
-            userData: *BootstrapDatadogScript
+            userData: &BootstrapDatadogScript
+              - "#!/bin/bash"
+              - "set -eux"
+              - echo "START CLOUDINIT"
+              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAW9BiXpCNMlAH54d0IZ1/gXtl3GE0h5EiwhaIweCD4fXb9EPE7K5BAhBX2U531nOZ/sbMemXv15WTk36bJa1cjSCj798+w2pYGwHCje1LDjrtIsTdJ7Dw7bb+yOf4hGy+ftTecStAlel+yTL0YHRvIoiCDUCq7WtsjeYgQQa7lG/B3ZuFMlecCXP+/l42/VXmxUJUwheHKplKT4pPDCjAVk71zftJ0LKJtyQl0sSb0s3KBh25Xm8FbLb7ivMzRl3HSuwg+KHugU2dl1wi4jB/bEmDnIlaCNaIeVoXPKT6ncpB/hRR0UHAt8SEylUPoUq8Zv93dhakANb08702gq2o4TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA9W77G8ItivOxMmWZ59Sd+gDDQBGi6BayDGIx9W72gXXr+vcUgWt++jt7LqxQvGqr4lP0jb+gFdnRmeDmltPm/dWo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+              - systemctl stop datadog-agent.service
+              - mkdir -p /var/log/datadog /etc/datadog-agent
+              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+              - chmod 640 /etc/datadog-agent/datadog.yaml
+              - chown dd-agent:dd-agent /var/log/datadog
+              - chmod 770 /var/log/datadog
+              - systemctl start datadog-agent.service
+              - rm -f /etc/sudoers.d/90-cloud-init-users
+              - echo "END CLOUDINIT"
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
       resource_group: eastus-cijenkinsio


### PR DESCRIPTION
This PR correct the following puppet agent errors on ci.jenkins.io:

```console
Mar 21 11:13:19 ci puppet-agent[23231]: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Lookup of key 'lookup_options' failed: Unable to parse (/etc/puppetlabs/code/environments/production/hieradata/clients/azure.ci.jenkins.io.yaml): mapping values are not allowed here at line 320 column 22 (file: /etc/puppetlabs/code/environments/production/dist/profile/manifests/accounts.pp, line: 5, column: 15) on node azure.ci.jenkins.io
```

It's a fixup of https://github.com/jenkins-infra/jenkins-infra/pull/2701 by using the correct YAML anchor.