### PR TITLE
fix(artifact-caching-proxy): add exception for `atlassian-public` Maven repository

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots</mirrorOf>
+                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>


### PR DESCRIPTION
This exception is added to fix the build of https://github.com/jenkinsci/confluence-publisher-plugin which has `org.codehaus.jackson:jackson-core-asl:jar:1.9.13-atlassian-6` as dependency, not mirrored in our Maven repositories.

Twin PR: https://github.com/jenkins-infra/kubernetes-management/pull/3749

Ref: https://github.com/jenkins-infra/helpdesk/issues/3434