### PR TITLE
hotfix(pkgrepo) add missing SSH public key to mirrorbrain user (to unblock core release)

### DIFF
--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -12,6 +12,7 @@ class profile::pkgrepo (
   String $mirror_user                   = 'mirrorbrain',
   String $mirror_group                  = 'mirrorbrain',
   Array[String] $mirror_other_groups    = ['www-data'],
+  Hash $ssh_keys                        = {},
 ) {
   include stdlib # Required to allow using stlib methods and custom datatypes
   include apache
@@ -65,6 +66,7 @@ class profile::pkgrepo (
     # Allow apache user to read some of the files in this directory, through the "read" permission for groups
     groups         => $mirror_other_groups,
     require        => Group[$mirror_group],
+    ssh_keys       => $ssh_keys
   }
 
   exec { "Ensure ${mirror_git_remote} is cloned to ${mirror_scripts}":

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -89,6 +89,9 @@ letsencrypt::config::server: "https://acme-staging-v02.api.letsencrypt.org/direc
 letsencrypt::renew_cron_ensure: "present"
 letsencrypt::renew_cron_minute: 0
 letsencrypt::renew_cron_hour: 6
+profile::pkgrepo::ssh_keys:
+  release.ci.jenkins.io:
+    key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDBi5DJcmDRAa6J7d4Zj9alGw0ZNwDftfKPNqyMoJrbRyvqvhKi8z0mg5HMK+ohkc+Xk5+HWpLNf36nn4b+Jn9g2CZJfzkt2SL7HbCN4eVLkQmqmWG/y9HCSmld9bTVWFy1zD34qNiaZw1ldsusvokyU/LTIgWHsCtbsgMoE+CzRKKRJXDrUmnY4e4q5leTHjOdShlrFiakyy5XYtUKG0zlnJMqIvxyTSo+jKKA1iNeW0hP8knu4uhFCGcYOZps1eNH2z+7Vq+wq6lsNfU11CDfuCSZBG24VNMMf75giFVc2PdAzlWrY+BXi7QeDaPUqilMf3d2egKb/dFxhkTGQL11
 profile::archives::rsync_hosts_allow:
   - localhost
   - archives.jenkins.io


### PR DESCRIPTION
The PR #2710 added back the management of the user `mirrorbrain` on the pkg.origin.jenkins.io VM.

This management was:

- Removed in #2185 
- Not run (puppet agent disabled) since 2019

The unforeseen consquence of deploying #2710 was to cleanup the content of the `$HOME/.ssh/authorized_keys` file for the `mirrorbrain` user which failed the release  of Jenkins 2.397.

The infra team manually added back the public SSH key, with the agent disabled on pkg.origin.jenkins.io.

This PR aims at fixing the configuration as code to track this key.

- Tested on a local Vagrant VM
- Puppet agent disabled on the VM: will run a `noop` once merged, and report back there