### PR TITLE
chore: disable az-cli telemetry on every controller

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/jenkins.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/jenkins.yaml.erb
@@ -2,6 +2,11 @@
 jenkins:
   # No builds on controller
   numExecutors: 0
+  globalNodeProperties:
+  - envVars:
+      env:
+      - key: "AZURE_COLLECT_TELEMETRY"
+        value: "false"
 unclassified:
   shell:
     shell: "/bin/bash"


### PR DESCRIPTION
https://learn.microsoft.com/en-us/cli/azure/azure-cli-configuration

We might want to configure that when installing az-cli instead.