### PR TITLE
Revert "Bump the Concat Puppet Module to 7.4.0"

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -41,7 +41,7 @@ mod 'rootexpert-snap', '1.1.0'
 # Apache and its dependencies
 mod 'puppetlabs-apache', '9.1.2'
 
-mod 'puppetlabs-concat', '7.4.0'
+mod 'puppetlabs-concat', '7.3.3'
 
 # For managing server-side ssh configuration options
 mod 'saz-ssh', '5.0.0'


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2756

Because the production fails with the following error:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: no parameter named 'create_empty_file' (file: /etc/puppetlabs/code/environments/production/modules/concat/manifests/init.pp, line: 126) on Concat_file[/etc/ssh/sshd_config] (file: /etc/puppetlabs/code/environments/production/modules/concat/manifests/init.pp, line: 126) on node trusted-agent-1
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```