### PR TITLE
chore(module sshkeys_core) track with updatecli and bump to 2.4.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -46,7 +46,7 @@ mod 'puppetlabs-concat', '7.3.3'
 # For managing server-side ssh configuration options
 mod 'saz-ssh', '5.0.0'
 # Dependency
-mod 'puppetlabs-sshkeys_core', '1.0.2'
+mod 'puppetlabs-sshkeys_core', '2.4.0'
 
 mod 'puppetlabs-lvm', '1.4.0'
 mod 'datadog-datadog_agent', '3.20.0'

--- a/updatecli/weekly.d/puppet-modules/sshkeys_core.yaml
+++ b/updatecli/weekly.d/puppet-modules/sshkeys_core.yaml
@@ -1,0 +1,58 @@
+---
+name: Bump the `sshkeys_core` Puppet Module
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    kind: githubrelease
+    name: Get the latest puppetlabs-sshkeys_core module version
+    spec:
+      owner: puppetlabs
+      repository: puppetlabs-sshkeys_core
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+conditions:
+  testPuppetModuleExists:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --verbose --silent --show-error --location --fail --head --output /dev/null https://forge.puppet.com/v3/files/puppetlabs-sshkeys_core-{{ source "latestVersion" }}.tar.gz
+
+targets:
+  puppetfile:
+    name: "Update Puppetfile with the latest sshkeys_core module version"
+    kind: file
+    sourceid: latestVersion
+    spec:
+      file: Puppetfile
+      matchpattern: >
+        mod 'puppetlabs-sshkeys_core'(.*)
+      replacepattern: >
+        mod 'puppetlabs-sshkeys_core', '{{ source "latestVersion" }}'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump the `sshkeys_core` Puppet Module {{ source "latestVersion" }}
+    spec:
+      labels:
+        - puppet-module
+        - dependencies


### PR DESCRIPTION
Following up on https://github.com/jenkins-infra/jenkins-infra/pull/2714, it appears that we do not use the latest module version