### PR TITLE
hotfix: add ruby puppet module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -10,6 +10,7 @@ mod 'puppetlabs-stdlib', '8.5.0'
 mod 'puppetlabs-puppetserver_gem', '1.1.0'
 mod 'puppetlabs-inifile', '1.4.3'
 mod 'puppetlabs-vcsrepo', '1.1.0'
+mod 'puppetlabs-ruby', '1.0.1'
 
 # Used for setting up ntp daemons on all machines to have a correct time
 mod 'puppetlabs-ntp', '7.3.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -7,10 +7,10 @@ mod 'puppet-systemd', '4.1.0'
 mod 'puppetlabs-stdlib', '8.5.0'
 
 # Used for installing gems for the puppetserver, like with hiera-eyaml
-mod 'puppetlabs-puppetserver_gem', '1.1.0'
+mod 'puppetlabs-puppetserver_gem', '1.1.0' # Required by datadog_agent - https://forge.puppet.com/modules/datadog/datadog_agent/dependencies
 mod 'puppetlabs-inifile', '1.4.3'
 mod 'puppetlabs-vcsrepo', '1.1.0'
-mod 'puppetlabs-ruby', '1.0.1'
+mod 'puppetlabs-ruby', '1.0.1' # Required by datadog_agent - https://forge.puppet.com/modules/datadog/datadog_agent/dependencies
 
 # Used for setting up ntp daemons on all machines to have a correct time
 mod 'puppetlabs-ntp', '7.3.0'


### PR DESCRIPTION
The PR #2765 removed the `puppetlabs/ruby` module from dependencies, thinking it was only used by the (removed) `apachecompressor` module.

Alas, it is *also* a dependency of the `datadog_agent` module as per https://forge.puppet.com/modules/datadog/datadog_agent/dependencies, *despite* the fact this `ruby` module is deprecated.