### PR TITLE
feat(azure.ci.jenkins.io) add a global build discarder policy

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -174,7 +174,7 @@ class profile::jenkinscontroller (
       'jenkinscontroller/casc/tools.yaml.erb',
       # Opt-out with `profile::jenkinscontroller::jcasc.artifact_caching_proxy: false`
       'jenkinscontroller/casc/artifact-caching-proxy.yaml.erb',
-      # Opt-out with `profile::jenkinscontroller::jcasc.unclassified: false`
+      # Opt-in with `profile::jenkinscontroller::jcasc.unclassified.data
       'jenkinscontroller/casc/unclassified.yaml.erb',
     ],
     config_dir => 'casc.d', # Relative to the jenkins_home

--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -174,6 +174,8 @@ class profile::jenkinscontroller (
       'jenkinscontroller/casc/tools.yaml.erb',
       # Opt-out with `profile::jenkinscontroller::jcasc.artifact_caching_proxy: false`
       'jenkinscontroller/casc/artifact-caching-proxy.yaml.erb',
+      # Opt-out with `profile::jenkinscontroller::jcasc.unclassified: false`
+      'jenkinscontroller/casc/unclassified.yaml.erb',
     ],
     config_dir => 'casc.d', # Relative to the jenkins_home
   }

--- a/dist/profile/templates/jenkinscontroller/casc/unclassified.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/unclassified.yaml.erb
@@ -1,0 +1,4 @@
+<%- if @jcasc['unclassified'] && @jcasc['unclassified']['data'] -%>
+unclassified:
+  <%= @jcasc['unclassified']['data'] %>
+<%- end -%>

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -41,6 +41,15 @@ profile::jenkinscontroller::memory_limit: '30g'
 profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAywKTuF4pmWjFgHZyW+wo4D5MDYRf7gVelgeLcIsZJy8t+Sw17vWA96vGIaAD2tklGILSn6snhskSYroQHkdv13gQGW1zcpP5N9wqhMOoA5nXrh9Gnb1F5JlPGlQyUxTA5gi+zjV8+B6athfjpKbkvK91RDkOPMMOkqBALp5E1xlsBpicri5Q1znik9shGPzccONvRw+wWsm0jPquoEdO1EnR17yqN60BOk1ZelY3AV9grLR6OZrRg8M6hl4JcI5SMfm9XUPB0BWQhHwZHlIW8sAmnR9aC7bsCEk16DH82V/HrBaJBYa8GiAr3LBFzy2jiNB0F/oK7XdVsN8AQyW6UjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDf4FrZNE5uqT3JiM8XUcSRgCCf8HyZFe7GPU+5puax+7Q50f+jT99rOmyBZg20AQTJeQ==]
+  unclassified:
+    data: |-
+      buildDiscarders:
+          configuredBuildDiscarders:
+          - "jobBuildDiscarder"
+          - defaultBuildDiscarder:
+              discarder:
+                logRotator:
+                  numToKeepStr: "5"
   tools:
     groovy:
       groovy: # Default version is named "groovy"
@@ -412,6 +421,7 @@ profile::jenkinscontroller::plugins:
   - azure-vm-agents # Azure VM Agents
   - blueocean # A nice view for pipelines
   - buildtriggerbadge # Add an icon with the build cause in the build history
+  - build-discarder # Remove older builds if no policy defined - https://github.com/jenkins-infra/helpdesk/issues/3495
   - cloudbees-folder # Provides a job type "Folder"
   - code-coverage-api # Provides nice code covergae view in the Web UI (used by multiple downstream plugins)
   - config-file-provider # Used to provide Maven settings for proxies

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -430,6 +430,7 @@ profile::jenkinscontroller::plugins:
   - blueocean
   - build-timeout
   - buildtriggerbadge
+  - build-discarder # Remove older builds if no policy defined - https://github.com/jenkins-infra/helpdesk/issues/3495
   - cloudbees-folder
   - code-coverage-api
   - config-file-provider


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3495

Tested on a local vagrant VM with 2 cases:

- No `jcasc.unclassified` section: the file is created empty (case for trusted.ci and cert.ci)
- With the hieradata defined for azure.ci.jenkins.io: worked as excpected (no JCasc reload error and the config is present)