### PR TITLE
feat(ci.jenkins.io) use AWS S3 Artifact Manager to store artifacts and stashes

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -41,7 +41,8 @@ class profile::jenkinscontroller (
 -Duser.home=${container_jenkins_home} \
 -Djenkins.install.runSetupWizard=false \
 -Djenkins.model.Jenkins.slaveAgentPort=50000 \
--Dhudson.model.WorkspaceCleanupThread.retainForDays=2", # Must be Java 11 compliant!
+-Dhudson.model.WorkspaceCleanupThread.retainForDays=2 \
+-Dio.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig.deleteStashes=true", # Must be Java 11 compliant!
 ) {
   include stdlib # Required to allow using stlib methods and custom datatypes
   include apache
@@ -176,6 +177,8 @@ class profile::jenkinscontroller (
       'jenkinscontroller/casc/artifact-caching-proxy.yaml.erb',
       # Opt-in with `profile::jenkinscontroller::jcasc.unclassified.data
       'jenkinscontroller/casc/unclassified.yaml.erb',
+      # Opt-in with `profile::jenkinscontroller::jcasc.artifact-manager.data
+      'jenkinscontroller/casc/artifact-manager.yaml.erb',
     ],
     config_dir => 'casc.d', # Relative to the jenkins_home
   }

--- a/dist/profile/templates/jenkinscontroller/casc/artifact-manager.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-manager.yaml.erb
@@ -1,0 +1,3 @@
+<%- if @jcasc['artifact-manager'] && @jcasc['artifact-manager']['data'] -%>
+<%= @jcasc['artifact-manager']['data'] %>
+<%- end -%>

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -50,6 +50,19 @@ profile::jenkinscontroller::jcasc:
               discarder:
                 logRotator:
                   numToKeepStr: "5"
+  artifact-manager:
+    data: |-
+      aws:
+        awsCredentials:
+          credentialsId: "aws-s3-artifact-manager"
+          region: "us-east-2"
+        s3:
+          container: "ci-jenkins-io-artifacts"  # Resource defined in jenkins-infra/aws/ci.jenkins.io.tf
+          disableSessionToken: false            # For non AWS services only
+          prefix: "ci.jenkins.io/"              # Rule of thumb: Controller's hostname
+          useHttp: false                        # TLS for everyone \o/
+          usePathStyleUrl: false                # For non AWS services only
+          useTransferAcceleration: false        # Too expensive
   tools:
     groovy:
       groovy: # Default version is named "groovy"
@@ -417,6 +430,7 @@ profile::jenkinscontroller::jcasc:
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor # Provides ANSI color in the UI when checking log outputs
+  - artifact-manager-s3 # Store Artifact and stashes in AWS S3 (instead of the VM JENKINS_HOME directory)
   - azure-container-agents # ACI agents
   - azure-vm-agents # Azure VM Agents
   - blueocean # A nice view for pipelines

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -20,6 +20,19 @@ profile::jenkinscontroller::memory_limit: '14g'
 profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: SuperSecretThatShouldBeEncryptedInProduction
+  artifact-manager:
+    data: |-
+      aws:
+        awsCredentials:
+          credentialsId: "aws-s3-artifact-manager"
+          region: "us-east-2"
+        s3:
+          container: "localhost-test-bucket"    # Resource defined in jenkins-infra/aws/<controller_hostname>.tf
+          disableSessionToken: false            #
+          prefix: "localhost/"                  # Rule of thumb: Controller's hostname
+          useHttp: false                        # TLS for everyone \o/
+          usePathStyleUrl: false                # For non AWS services only
+          useTransferAcceleration: false        # Too expensive
   tools:
     groovy:
       groovy: # Default version is named "groovy"
@@ -425,6 +438,7 @@ profile::jenkinscontroller::jcasc:
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor
+  - artifact-manager-s3 # Store Artifact and stashes in AWS S3 (instead of the VM JENKINS_HOME directory)
   - azure-container-agents
   - azure-vm-agents
   - blueocean


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3496
Requires https://github.com/jenkins-infra/aws/pull/395

This PR adds the required JCasc configuration for ci.jenkins.io (and the local vagrant VM setup to allow testing) to enable Artifact Manager in S3.

Please note that stash deletion i enabled through the Java option (https://plugins.jenkins.io/artifact-manager-s3/#plugin-content-delete-stash) but not artifact deletion (a custom GC would be preferred).
