### PR TITLE
feat(ci.jenkins.io) enable S3 artifact manager globally

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -52,6 +52,11 @@ profile::jenkinscontroller::jcasc:
                   numToKeepStr: "5"
   artifact-manager:
     data: |-
+      unclassified:
+        artifactManager:
+          artifactManagerFactories:
+          - jclouds:
+              provider: "s3"
       aws:
         awsCredentials:
           credentialsId: "aws-s3-artifact-manager"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -20,8 +20,22 @@ profile::jenkinscontroller::memory_limit: '14g'
 profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: SuperSecretThatShouldBeEncryptedInProduction
+  unclassified:
+    data: |-
+      buildDiscarders:
+          configuredBuildDiscarders:
+          - "jobBuildDiscarder"
+          - defaultBuildDiscarder:
+              discarder:
+                logRotator:
+                  numToKeepStr: "5"
   artifact-manager:
     data: |-
+      unclassified:
+        artifactManager:
+          artifactManagerFactories:
+          - jclouds:
+              provider: "s3"
       aws:
         awsCredentials:
           credentialsId: "aws-s3-artifact-manager"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3496

Fixup of #2782: forgot to enable the Artifact Manager in the "Manage Jenkins" section. Tested manually on ci.jenkins.io.