### PR TITLE
chore(updatecli) fix all in one container image detection by checking ARM64 and x86 are different

### DIFF
--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -21,12 +21,24 @@ sources:
       repository: "packer-images"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-  getLatestInboundAllInOneContainerImage:
+  getLatestInboundAllInOneContainerImageX86:
     kind: dockerdigest
+    name: Get digest of the jenkinsciinfra/jenkins-agent-ubuntu-22.04 image
+    dependson:
+      - packerImageVersion
     spec:
       image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04"
-      tag: "latest"
+      tag: '{{ source "packerImageVersion"}}'
       architecture: amd64
+  getLatestInboundAllInOneContainerImageARM:
+    kind: dockerdigest
+    name: Get digest of the jenkinsciinfra/jenkins-agent-ubuntu-22.04 image
+    dependson:
+      - packerImageVersion
+    spec:
+      image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04"
+      tag: '{{ source "packerImageVersion"}}'
+      architecture: arm64
   getLatestInboundMaven8WindowsContainerImage:
     kind: dockerdigest
     spec:
@@ -91,6 +103,13 @@ sources:
           pattern: 'windows_disk_size_gb = (\d*)'
           captureindex: 1
 
+conditions:
+  checkAllInOneContainerImages:
+    disablesourceinput: true
+    name: Check that x86 and arm64 all in one images are different
+    kind: shell
+    spec:
+      command: test {{ source "getLatestInboundAllInOneContainerImageX86" }} != {{ source "getLatestInboundAllInOneContainerImageARM" }}
 
 targets:
   setWindowsVMAgentDiskSize:

--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -27,24 +27,6 @@ sources:
       image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04"
       tag: "latest"
       architecture: amd64
-  getLatestInboundMaven8ContainerImage:
-    kind: dockerdigest
-    spec:
-      image: "jenkinsciinfra/inbound-agent-maven"
-      tag: "jdk8"
-      architecture: amd64
-  getLatestInboundMaven11ContainerImage:
-    kind: dockerdigest
-    spec:
-      image: "jenkinsciinfra/inbound-agent-maven"
-      tag: "jdk11"
-      architecture: amd64
-  getLatestInboundMaven17ContainerImage:
-    kind: dockerdigest
-    spec:
-      image: "jenkinsciinfra/inbound-agent-maven"
-      tag: "jdk17"
-      architecture: amd64
   getLatestInboundMaven8WindowsContainerImage:
     kind: dockerdigest
     spec:
@@ -109,101 +91,6 @@ sources:
           pattern: 'windows_disk_size_gb = (\d*)'
           captureindex: 1
 
-conditions:
-  LatestInboundAllInOneContainerImage:
-    name: 'Test if LatestInboundAllInOneContainerImage : jenkinsciinfra/jenkins-agent-ubuntu-22.04:{{ source `getLatestInboundAllInOneContainerImage` }} published on the registry'
-    kind: dockerimage
-    sourceid: getLatestInboundAllInOneContainerImage
-    spec:
-      image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04"
-      tag: "latest"
-      architecture: amd64
-  LatestInboundMaven8ContainerImage:
-    name: 'Test if LatestInboundMaven8ContainerImage : jenkinsciinfra/inbound-agent-maven:{{ source `getLatestInboundMaven8ContainerImage` }} published on the registry'
-    kind: dockerimage
-    sourceid: getLatestInboundMaven8ContainerImage
-    spec:
-      image: "jenkinsciinfra/inbound-agent-maven"
-      tag: "jdk8"
-      architecture: amd64
-  LatestInboundMaven11ContainerImage:
-    name: 'Test if LatestInboundMaven11ContainerImage : jenkinsciinfra/inbound-agent-maven:{{ source `getLatestInboundMaven11ContainerImage` }} published on the registry'
-    kind: dockerimage
-    sourceid: getLatestInboundMaven11ContainerImage
-    spec:
-      image: "jenkinsciinfra/inbound-agent-maven"
-      tag: "jdk11"
-      architecture: amd64
-  LatestInboundMaven17ContainerImage:
-    name: 'Test if LatestInboundMaven17ContainerImage : jenkinsciinfra/inbound-agent-maven:{{ source `getLatestInboundMaven17ContainerImage` }} published on the registry'
-    kind: dockerimage
-    sourceid: getLatestInboundMaven17ContainerImage
-    spec:
-      image: "jenkinsciinfra/inbound-agent-maven"
-      tag: "jdk17"
-      architecture: amd64
-  LatestInboundMaven8WindowsContainerImage:
-    name: 'Test if LatestInboundMaven8WindowsContainerImage : jenkinsciinfra/inbound-agent-maven:{{ source `getLatestInboundMaven8WindowsContainerImage` }} published on the registry'
-    kind: dockerimage
-    sourceid: getLatestInboundMaven8WindowsContainerImage
-    spec:
-      image: "jenkinsciinfra/inbound-agent-maven"
-      tag: "jdk8-nanoserver"
-      architecture: amd64
-  LatestInboundMaven11WindowsContainerImage:
-    name: 'Test if LatestInboundMaven11WindowsContainerImage : jenkinsciinfra/inbound-agent-maven:{{ source `getLatestInboundMaven11WindowsContainerImage` }} published on the registry'
-    kind: dockerimage
-    sourceid: getLatestInboundMaven11WindowsContainerImage
-    spec:
-      image: "jenkinsciinfra/inbound-agent-maven"
-      tag: "jdk11-nanoserver"
-      architecture: amd64
-  LatestInboundMaven17WindowsContainerImage:
-    name: 'Test if LatestInboundMaven17WindowsContainerImage : jenkinsciinfra/inbound-agent-maven:{{ source `getLatestInboundMaven17WindowsContainerImage` }} published on the registry'
-    kind: dockerimage
-    sourceid: getLatestInboundMaven17WindowsContainerImage
-    spec:
-      image: "jenkinsciinfra/inbound-agent-maven"
-      tag: "jdk17-nanoserver"
-      architecture: amd64
-  LatestInboundMaven19WindowsContainerImage:
-    name: 'Test if LatestInboundMaven19indowsContainerImage : jenkinsciinfra/inbound-agent-maven:{{ source `getLatestInboundMaven19WindowsContainerImage` }} published on the registry'
-    kind: dockerimage
-    sourceid: getLatestInboundMaven19WindowsContainerImage
-    spec:
-      image: "jenkinsciinfra/inbound-agent-maven"
-      tag: "jdk19-nanoserver"
-      architecture: amd64
-  LatestInboundWebBuilderContainerImage:
-    name: 'Test if LatestInboundWebBuilderContainerImage : jenkinsciinfra/builder:{{ source `getLatestInboundWebBuilderContainerImage` }} published on the registry'
-    kind: dockerimage
-    sourceid: getLatestInboundWebBuilderContainerImage
-    spec:
-      image: "jenkinsciinfra/builder"
-      tag: "latest"
-      architecture: amd64
-  LatestInboundJDK11ContainerImage:
-    name: 'Test if LatestInboundJDK11ContainerImage : jenkins/inbound-agent:{{ source `getLatestInboundJDK11ContainerImage` }} published on the registry'
-    kind: dockerimage
-    sourceid: getLatestInboundJDK11ContainerImage
-    spec:
-      image: "jenkins/inbound-agent"
-      tag: "latest-jdk11"
-      architecture: amd64
-  LatestUbuntuAgentAMIArm64:
-    name: "Test if getLatestUbuntuAgentAMIArm64 Image Published on AWS"
-    kind: aws/ami
-    sourceid: getLatestUbuntuAgentAMIArm64
-    spec:
-      region: us-east-2
-      sortby: creationDateDesc
-      filters:
-        - name: "name"
-          values: "jenkins-agent-ubuntu-22.04-arm64-*"
-        - name: "tag:build_type"
-          values: "prod"
-        - name: "tag:version"
-          values: '{{ source "packerImageVersion" }}'
 
 targets:
   setWindowsVMAgentDiskSize:


### PR DESCRIPTION
This PR adds a safety net to the updatecli process in charge of updating the container image for agents in ci.jenkins.io.

The https://github.com/jenkins-infra/jenkins-infra/pull/2790 bumped the agent template from 1.3.0 to 1.4.0 (including JDK upgrades) but had to be reverted by #2795 because container agents were all erroring with the error message` standard_init_linux.go:228: exec user process caused: exec format error error`.

This message is typical of an ARM64 binary executed on a x86 machine. After checking the container the container checksum in the 1.4.0 release build in jenkins-infra/packer-images with @smerle33 , we confirmed that the checksum in #2790 was associated to the `arm64` image.

This behavior is unexpected:

- The updatecli manifest explicitly defines an `amd64` platform so it does not make sense
- However, a careful review of the commits of #2790 shows that the checksum was changed twice, as if there was a timing impact. 

Timeline explains the behavior:
- At 17:14 UTC, the "latest" tag was updated by pushing the `amd64`  (command `docker image push  --all ...` for the AMD64 stage)
- At 17:19 UTC, updatecli issued a commit (https://github.com/jenkins-infra/jenkins-infra/pull/2790/commits/5f8e48954435f96dfb47f13224a9aa769776013c) updating the checksum to the correct `amd64`
- At 17:21, the "latest" tag was updated by pushing the `arm64`  (command `docker image push  --all ...` for the ARM64 stage)
- At 17:36, updatecli issued a commit changing to the checksum of the "latest" wich is now.. `arm64` (https://github.com/jenkins-infra/jenkins-infra/pull/2790/commits/4b1f2b54acedbcb57ee90a6af37e13cc3d5687fd)
- Same minute, the manifest of the image was updated with both architectures by the build.
- At 17:44, the PR was merged
- Updatecli opened a subsequent PR with the correct checksum later (https://github.com/jenkins-infra/jenkins-infra/pull/2793/commits/5f8e48954435f96dfb47f13224a9aa769776013c) with the result of the manifest's checsum for the proper architecture.


The following changes are brought by this PR to protect us from this problem. Please note that the packer-image deployment process must be improved to avoid this timeline issue though.

- Adding a source to retrieve the `arm64` image (would fail if none)
- Adding a condition failing if the checsums are the same for both `amd64` and `arm64`
- (nice to have) get the checksum of the tagged image and not the `latest` (to allow not pushing `latest` and the tag t the same time)


----

Boyscout: cleaned up the manifest by removing:
- Unused and legacy sources (the former linux inbound agents that were replaced by the all in one)
- Conditions for AMI and docker image: there is no need to check them as the sources are using the same code. If a source retrieve a value, then the condition will always be valid.