### PR TITLE
chore(updatecli) fix agent templates manfiest

### DIFF
--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -129,8 +129,8 @@ targets:
       key: "profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version"
     scmid: default
   setInboundAllInOneContainerImage:
-    sourceid: getLatestInboundAllInOneContainerImage
-    name: "Bump container agent image jenkinsciinfra/jenkins-agent-ubuntu-22.04 (AllInOne)"
+    sourceid: getLatestInboundAllInOneContainerImageX86
+    name: "Bump container agent image jenkinsciinfra/jenkins-agent-ubuntu-22.04 (AllInOne) for x86"
     kind: yaml
     spec:
       file: hieradata/common.yaml


### PR DESCRIPTION
This PR fixes the error message `ERROR: the specified sourceid "getLatestInboundAllInOneContainerImage" for condition[id] does not exist`

Fixup of #2796 