### PR TITLE
feat(ci.jenkins.io) setup cik8s-bom with a single agent template using JDK17 by default, with nodeSelector and tolerations

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -259,6 +259,22 @@ jenkins:
           - name: "<%= agent['imagePullSecrets'] %>"
         <%- end -%>
           slaveConnectTimeout: 100
+        <%- if agent['nodeSelector'] -%>
+          nodeSelector: "<%= agent['nodeSelector'] %>"
+        <%- end -%>
+        <%- if agent['tolerations'] -%>
+          yaml: |-
+            apiVersion: "v1"
+            kind: "Pod"
+            spec:
+              tolerations:
+                <%- agent['tolerations'].each do |toleration| -%>
+                - key: "<%= toleration["key"] %>"
+                  operator: "<%= toleration["operator"] %>"
+                  value: "<%= toleration["value"] %>"
+                  effect: "<%= toleration["effect"] %>"
+                <%- end -%>
+          <%- end -%>
           yamlMergeStrategy: "override"
           volumes:
           - emptyDirVolume:

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -222,39 +222,19 @@ profile::jenkinscontroller::jcasc:
         max_capacity: 150 # Max 50 workers (16 CPU / 32 G) with 3 pods (4 CPU / 8G) each
         url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAqqsX9flKf0ph1t5xPw8sSHwqWS5kxPicvdb9UG3137GIv/wRAzoUxLPRnjDER3SJrN7QTFFSblCxXEXMv3OtCBZH+k0y2CX4M+eC1VUcHsEYdKdiWwzJNw8qo8W8gO4kr2raneDNhGRjmDazcPJaLLcht7gTNQSr2RQdFe0GuDEps33oMzS1/fT/YbOzfg4O6yZDC9mbg2IcryhCK7RGqhDRVTQ6DFTW1RhN2o0GdoY0k0NK46Y4zCR71NACy0PHNOL6cRnBUQfc7kCFDw8/ISFJRAihxAWAG631jHGoUh26H+gXXfoQHZppSnIuGfUCoTn52lul9zoKrc7c2GKZhzB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCXHTqrSVgZnWeEyj1rnEISgFDZ/ZoneDJR74i4SLb+hIgRDuznKj9D16zFgUOhaZZP8GIxaaAJ3ruVPlmjD5mAMAknhwfpOzRM/puRDSglpEBOZJrBvRXGwceFiv1LgnAqIw==]
         agent_definitions:
-          - name: jnlp-maven-8
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-8
-            labels:
-              - maven
-              - maven-8
-              - jdk8
-            cpus: 4
-            memory: 8
-          - name: jnlp-maven-11
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-11
-            labels:
-              - maven-11
-              - jdk11
-            cpus: 4
-            memory: 8
-          - name: jnlp-maven-17
+          - name: jnlp-maven-bom
             imageName: jnlp-maven-all-in-one
             javaHome: /opt/jdk-17
             labels:
-              - maven-17
-              - jdk17
+              - maven-bom
             cpus: 4
             memory: 8
-          - name: jnlp-maven-19
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-19
-            labels:
-              - maven-19
-              - jdk19
-            cpus: 4
-            memory: 8
+            nodeSelector: "ci.jenkins.io/agents-density=3"
+            tolerations:
+              - key: "ci.jenkins.io/bom"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
       cik8s:
         enabled: true
         provider: "aws"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -107,15 +107,6 @@ profile::jenkinscontroller::jcasc:
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
   cloud_agents:
     kubernetes:
-      cik8s-bom:
-        enabled: true
-        provider: "aws"
-        credentialsId: "cik8s-jenkins-agent-bom-sa-token"
-        serverCertificate: SuperSecretThatShouldBeEncryptedInProduction
-        defaultNamespace: jenkins-agents-bom
-        max_capacity: 345 # Max 15 workers (96 CPU / 192+ Gb) with 23 pods (4 CPU / 8G) each
-        url: SuperSecretThatShouldBeEncryptedInProduction
-        # No agent_definitions: Jenkinsfile based
       cik8s:
         enabled: true
         provider: "aws"
@@ -125,6 +116,19 @@ profile::jenkinscontroller::jcasc:
         url: SuperSecretThatShouldBeEncyptedInProduction
         defaultNamespace: jenkins-agents
         agent_definitions:
+          - name: jnlp-maven-bom
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-17
+            labels:
+              - maven-bom
+            cpus: 4
+            memory: 8
+            nodeSelector: "ci.jenkins.io/agents-density=3"
+            tolerations:
+              - key: "ci.jenkins.io/bom"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
           - name: jnlp-maven-8
             imageName: jnlp-maven-all-in-one
             javaHome: /opt/jdk-8
@@ -176,59 +180,7 @@ profile::jenkinscontroller::jcasc:
         max_capacity: 30 # Max 10 workers (16 CPU / 32 G) with 3 pods (3*4 CPU / 3*8G) each
         url: SuperSecretThatShouldBeEncryptedInProduction
         defaultNamespace: jenkins-agents
-        agent_definitions:
-          - name: jnlp-maven-8
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-8
-            labels:
-              - maven
-              - maven-8
-              - jdk8
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-maven-11
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-11
-            labels:
-              - maven-11
-              - jdk11
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-maven-17
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-17
-            labels:
-              - maven-17
-              - jdk17
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-maven-19
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-19
-            labels:
-              - maven-19
-              - jdk19
-            cpus: 4
-            memory: 8
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp-webbuilder
-            agentJavaBin: java
-            cpus: 2
-            memory: 4
-            labels:
-              - node
-              - webbuilder
-              - ruby
-            imagePullSecrets: dockerhub-credential
-          - name: jnlp
-            labels:
-              - default
-            cpus: 1
-            memory: 1
-            imagePullSecrets: dockerhub-credential
+        # No agent definitions (to test an empty cloud)
     ec2:
       aws-us-east-2:
         region: us-east-2


### PR DESCRIPTION
This PR sets up the `cik8s-bom` for https://github.com/jenkins-infra/helpdesk/issues/3521 to have only a single pod template:
- JDK17 is used by default (and JDK11 for the agent execution)
  - The JDK version is expected to be switched using `tool` instruction in the calling pipeline
- Node selector and toleration are set to ensure only the [BOM "normal" node pool](https://github.com/jenkins-infra/aws/pull/396) is used
- Agent template is set up with the `maven-bom` label


Note: Vagrant's hierdata update to cover most cases without being a direct copy of the production