### PR TITLE
chore(jenkins controllers) refactor cloud template for azure-vms to only use one cloud and set max VM limit at template levels

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -2,16 +2,14 @@
 jenkins:
   clouds:
   <%- if @jcasc['cloud_agents']['azure-vm-agents'] && !@jcasc['cloud_agents']['azure-vm-agents'].empty? -%>
-    <%- # Creating one cloud per template because there is no "maxVirtualMachinesLimit" directive applicable for a single template -%>
-    <%- @jcasc['cloud_agents']['azure-vm-agents']['agent_definitions'].each do |agent| -%>
   - azureVM:
       azureCredentialsId: "<%= @jcasc['cloud_agents']['azure-vm-agents']['azureCredentialsId'] %>"
-      cloudName: "azure-<%= agent['name'] %>"
+      cloudName: "azure-vms"
       deploymentTimeout: 1200
       existingResourceGroupName: "<%= @jcasc['cloud_agents']['azure-vm-agents']['resource_group'] %>"
-      maxVirtualMachinesLimit: <%= agent['maxInstances'] %>
       resourceGroupReferenceType: "existing"
       vmTemplates:
+    <%- @jcasc['cloud_agents']['azure-vm-agents']['agent_definitions'].each do |agent| -%>
       - agentLaunchMethod: "SSH"
         agentWorkspace: "<%= @jcasc['agents_setup'][agent['os']]['agentDir'] %>"
         credentialsId: "<%= agent['credentialsId'] %>"
@@ -65,6 +63,9 @@ jenkins:
         templateName: "<%= agent['name'] %>"
         usageMode: "<%= agent['useAsMuchAsPossible'] == true ? 'NORMAL' : 'EXCLUSIVE' %>"
         virtualMachineSize: "<%= agent['instanceType'] %>"
+        <%- if agent['maxInstances'] -%>
+        maxVirtualMachinesLimit: <%= agent['maxInstances'] %>
+        <%- end -%>
       <%- if agent['usePrivateIP'] -%>
         usePrivateIP: true
         virtualNetworkName: "<%= agent['virtualNetworkName'] %>"


### PR DESCRIPTION
Since https://github.com/jenkinsci/azure-vm-agents-plugin/releases/tag/822.v3a18fc3d2de1, the maximum limit or simultaneous VMs can be set per template instead of only per-cloud level before.

This PR refactors the template to ensure that we only use 1 Azure VM Cloud (and 1 set of connections/GC to Azure API) and set VM limits per template.