### PR TITLE
fix(ci.jenkins.io): breaking change in config as code on plugin azure-vm

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -10,8 +10,7 @@ jenkins:
       resourceGroupReferenceType: "existing"
       vmTemplates:
     <%- @jcasc['cloud_agents']['azure-vm-agents']['agent_definitions'].each do |agent| -%>
-      - agentLaunchMethod: "SSH"
-        launcher:
+      - launcher:
           ssh:
             preInstallSsh: false
         agentWorkspace: "<%= @jcasc['agents_setup'][agent['os']]['agentDir'] %>"

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -50,7 +50,6 @@ jenkins:
         osDiskSize: <%= agent['osDiskSize'] ? agent['osDiskSize'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskSize'] %>
         osDiskStorageAccountType: <%= agent['osDiskStorageAccountType'] ? agent['osDiskStorageAccountType'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskStorageAccountType'] %>
         osType: "<%= agent['os'].to_s == "windows" ? 'Windows' : 'Linux' %>"
-        preInstallSsh: false
       <%- if agent['idleTerminationMinutes'] -%>
         retentionStrategy:
           azureVMCloudRetentionStrategy:

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -11,6 +11,9 @@ jenkins:
       vmTemplates:
     <%- @jcasc['cloud_agents']['azure-vm-agents']['agent_definitions'].each do |agent| -%>
       - agentLaunchMethod: "SSH"
+        launcher:
+          ssh:
+            preInstallSsh: false
         agentWorkspace: "<%= @jcasc['agents_setup'][agent['os']]['agentDir'] %>"
         credentialsId: "<%= agent['credentialsId'] %>"
         diskType: "managed"


### PR DESCRIPTION
as per https://github.com/jenkinsci/azure-vm-agents-plugin/releases/tag/846.v5a_f7e3dce959

```
Changes configuration as code users need to make

SSH Launcher:

agentLaunchMethod: "SSH"

becomes

launcher: "ssh"

Inbound launcher:

agentLaunchMethod: "JNLP"

becomes

launcher: "inbound"

SSH options set:

agentLaunchMethod: "SSH"
preInstallSsh: true
sshConfig: "ForwardAgent yes"

becomes

launcher:
  ssh:
    preInstallSsh: true
    sshConfig: "ForwardAgent yes"
```