### PR TITLE
fix(jenkins::controller) do not use ACP for maven repositories with id `local`

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk</mirrorOf>
+                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!in-project,!local</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>

--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!in-project,!local</mirrorOf>
+                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3567#issuecomment-1539563324

Needs a twin in jenkins-infra/kubernetes-management

This PR adds exlcusions from the ACP configurations file for any Maven repository which id would be `in-project` or `local` to allow loading JAR from source code local files.