### PR TITLE
feat(ci.jenkins.io) use new instance kind for highmem Linux: `Standard_D8ads_v5`, spot with ephemeral disks

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -19,7 +19,7 @@ jenkins:
         doNotUseMachineIfInitFails: true
         enableMSI: false
         enableUAMI: false
-        ephemeralOSDisk: false
+        ephemeralOSDisk: "<%= agent['ephemeralOSDisk'] ? agent['ephemeralOSDisk'] : false %>"
       <%- if agent['initScript'] && !agent['initScript'].empty? -%>
         executeInitScriptAsRoot: true
         initScript: |
@@ -48,7 +48,7 @@ jenkins:
         location: "<%= agent['location'] %>"
         noOfParallelJobs: 1
         osDiskSize: <%= agent['osDiskSize'] ? agent['osDiskSize'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskSize'] %>
-        osDiskStorageAccountType: <%= agent['osDiskStorageAccountType'] ? agent['osDiskStorageAccountType'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskStorageAccountType'] %>
+        osDiskStorageAccountType: <%= agent['ephemeralOSDisk'] ? "Standard_LRS" : (agent['osDiskStorageAccountType'] ? agent['osDiskStorageAccountType'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskStorageAccountType']) %>
         osType: "<%= agent['os'].to_s == "windows" ? 'Windows' : 'Linux' %>"
       <%- if agent['idleTerminationMinutes'] -%>
         retentionStrategy:

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -511,7 +511,8 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAG/Diw4+KrBubbNNGJxe7yGXyJJUSSbhWIRXcLBYGPxo14g/jsZLqyoO7yW7mN36IUnByMnBhQemcp2gGXj7x4GXBwbrABRd4UhIJMfMoAaKjFktl2FQk1YRdgBFDmCd7+FeOSn4GsCG1w/IVSpN1ezlqBdVqiMuG3RSyEByVBHvLXBQLulGp/ZsKGoJkW2gFTLnjxSbpu3fB8Y2KtiZ6RT3IlfnGS5Yfhl9vBxTcxgzvRrjK2h6QjVFSz/r+unAhpPKZ8BPlFCQta7/HF1bzWE4G7fX+rYiNtTAH3aWdOlD/okMUlhzsByIzi74VFvHREFVOkD908Gds7kzMh3qptjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDg3jrltbTU6EQUsnrJ7+VRgCCtEzUFqD1vyGyzqY4dHdJpD1CrMKnVM/JW0AT+y6573g==]
           location: "East US 2"
-          instanceType: Standard_D8s_v3 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
           architecture: amd64
           labels:
             - ubuntu
@@ -526,7 +527,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: "prod-jenkins-public-prod"
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
-          spot: false
+          spot: true
           initScript: *BootstrapDatadogScript
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -327,8 +327,9 @@ profile::jenkinscontroller::jcasc:
           os: "ubuntu"
           storageAccount: SuperSecretThatShouldBeEncryptedInProduction
           location: "East US 2"
-          instanceType: Standard_D16s_v3 # 16 vCPUS / 64 Gb
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           architecture: amd64
+          ephemeralOSDisk: true # Should set osDiskStorageAccountType to Standard_LRS
           labels:
             - highmem
             - highram
@@ -341,7 +342,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: "prod-jenkins-public-prod"
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
-          spot: false
+          spot: true
           initScript: *BootstrapDatadogScript
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"


### PR DESCRIPTION
As pointed in https://github.com/jenkins-infra/helpdesk/issues/3551#issuecomment-1545726927, this PR introduces the following configuration change to the "High Memory" instances on ci.jenkins.io:

- Change instance type from `Standard_D8s_v3` to `Standard_D8ads_v5` (ref. https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series).
  - Same amount of vCPUs and memory, but CPU is way more powerfull, and new instance has up to 300 Gb of temp storage instead of 200
  - Price is a bit more on-demand ($0.4120 vs $0.3840 before) BUT spot price is way cheaper ($0.0412 vs $0.1695 before).

- Use ephemeral OS disk: wether we stick to old instance type or new one, the local storage or temp storage are able to use 150 Gb of OS disk. It avoid paying $0.05 / hour for a Managed Premium SSD 

- Enable Spot: the new instance type is 9x cheaper and the eviction rate is 0-5 % (it was 10 to 15 % with the DS_v3 serie)
  - Please note that both `hihgmem` pipeline users now uses the `retry()` method with agent failure detection: https://github.com/jenkinsci/jenkins/blob/6cd05ada0dab757c009581643602bf260d17c0ec/Jenkinsfile#L201C1-L202 and https://github.com/jenkinsci/acceptance-test-harness/blob/d8d38af2189ca3beac5502fd9700e59a3337805a/Jenkinsfile#L107C1-L108