### PR TITLE
hotfix(ci.jenkins.io) Unify Azure VM instance limits to 50

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -8,6 +8,7 @@ jenkins:
       deploymentTimeout: 1200
       existingResourceGroupName: "<%= @jcasc['cloud_agents']['azure-vm-agents']['resource_group'] %>"
       resourceGroupReferenceType: "existing"
+      maxVirtualMachinesLimit: <%= @jcasc['cloud_agents']['azure-vm-agents']['maxInstances'] %>
       vmTemplates:
     <%- @jcasc['cloud_agents']['azure-vm-agents']['agent_definitions'].each do |agent| -%>
       - launcher:

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -457,6 +457,7 @@ profile::jenkinscontroller::jcasc:
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
       resource_group: eastus-cijenkinsio
+      maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
       agent_definitions:
         - name: "ubuntu-22"
           description: "Ubuntu 22.04 LTS"
@@ -474,7 +475,7 @@ profile::jenkinscontroller::jcasc:
             - linux
             - docker
             - linux-amd64
-          maxInstances: 80
+          maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
@@ -497,7 +498,7 @@ profile::jenkinscontroller::jcasc:
             - ubuntu
             - arm64docker
             - arm64linux
-          maxInstances: 80
+          maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
@@ -522,7 +523,7 @@ profile::jenkinscontroller::jcasc:
             - highram
             - docker-highmem
             - linux-amd64-big
-          maxInstances: 40
+          maxInstances: 50
           useAsMuchAsPossible: false
           usePrivateIP: true
           credentialsId: "jenkinsvmagents-userpass"
@@ -545,7 +546,7 @@ profile::jenkinscontroller::jcasc:
             - docker-windows
             - docker-windows-2019
             - windows
-          maxInstances: 80
+          maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
@@ -567,7 +568,7 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - docker-windows-2022
-          maxInstances: 40
+          maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true


### PR DESCRIPTION
Since https://github.com/jenkins-infra/jenkins-infra/pull/2810, it appears that not settings the top level `maxVirtualMachinesLimit` for Azure VM Cloud defines it to `10` by default (cc @timja is it expected?)

Following https://github.com/jenkins-infra/jenkins-infra/pull/2828 and https://github.com/jenkins-infra/jenkins-infra/pull/2829 , the new limit is the "Region spot vCPUs" set to 400, hence the limit of 50 for the worst case (8 vCPUS).