### PR TITLE
feat(*.trusted.ci.jenkins.io) add the 3 Azure VMs for trusted.ci.jenkins.io under puppet management puppet management

### DIFF
--- a/hieradata/clients/agent.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/agent.trusted.ci.jenkins.io.yaml
@@ -1,0 +1,8 @@
+---
+# Per-host Datadog configuration
+datadog_agent::host: "agent.trusted.ci.jenkins.io"
+# Allow trusted.ci.jenkins.io controller to use SSH for the agent connection
+profile::buildagent::ssh_keys:
+  trusted.ci.jenkins.io:
+    type: ed25519
+    key: AAAAC3NzaC1lZDI1NTE5AAAAINdeZJh/nqgNvkhSph152vK/9vWzEzYXd6GWk68edm2E

--- a/hieradata/clients/bounce.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/bounce.trusted.ci.jenkins.io.yaml
@@ -1,0 +1,12 @@
+---
+accounts:
+  wfollonier:
+    ssh_keys:
+      wfollonier:
+        key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC3oj0NN9UL1dIfBP44JDsOj/bGX/DG/GIv82imhgWbCQvsKcPczb32+W+zVo+OF3mADX4EoBG681GGopjYCKLreo8D3nFSP/+kdAt0lEqbufzoLvSyyxa0RUHDwzVQIiMiNlzDiWqLRkF2TdeFDl5u+bbdPTYCGil5/qZ3Ro8sG9ayWXMxh+f+s0MAU9qFIwau838RF2R9OCMjmPodW/zf+Mcq+SqrbZyYfYha5jOWxoN8IdrGuAOQeYks7mrXC6qq5N9ojUtMKONvayFwNOsuC0U8PYUtukkHVnm2IK9KM1A38HDlV9eTF8ac7yCUHLlttmoIBdLUuLJAw72BQkK/
+  notmyfault:
+    ssh_keys:
+      notmyfault:
+        key: AAAAB3NzaC1yc2EAAAADAQABAAABgQD4jyaQucbqLmDZ+WiAS0bjXTTlOr7Jx+1gUs4pT5LzlL/ijg7Fa7FGK/96U5lUJKvmuF2oGI53n3JfwJuRsuKe2yTdlMrRKREn/jUBP4LnNeVs77Fau25jPERJAgo+lz3BBlRfPJ6AYdMRiVWr9ZsKJILGB9UpALjSJkN3F+W66Dm51Xjw7SiScKs5xKb+s5WisIlJp6MC1T0z24DFAu/X08f2A2jGpHloF6R6FHUPVYewc5bjj72DrFIP+6M+1k1mBzyr/5COBgbFxStrT+wk+spA9U8fhOiFWDcmpEnfJa8qwMBDwSkiwWdDgEeEbepFgeNgzfBxY0vSbBtV2rbm2Chy8yUj0EKERZIIGHo3yowP6pyK78QJceuBFd3jzzlaOotdI1ce5tFDR51FMbAAKY2YYm//LmwZcxXVC0k2Vd5kMOmRtM3Iv4WT836ZvkhMxUi+fC0HbKXMsEwXnitNmGO0c9JKe9XbMYqKCsCVoeEjL0+8nMiLkId5ZMxFyKc=
+# Per-host Datadog configuration
+datadog_agent::host: "bounce.trusted.ci.jenkins.io"

--- a/hieradata/clients/trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/trusted.ci.jenkins.io.yaml
@@ -1,0 +1,143 @@
+---
+lookup_options:
+  "^profile::jenkinscontroller::jcasc$":
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+  "^letsencrypt":
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+
+accounts:
+  wfollonier:
+    ssh_keys:
+      wfollonier:
+        key: AAAAB3NzaC1yc2EAAAADAQABAAABAQC3oj0NN9UL1dIfBP44JDsOj/bGX/DG/GIv82imhgWbCQvsKcPczb32+W+zVo+OF3mADX4EoBG681GGopjYCKLreo8D3nFSP/+kdAt0lEqbufzoLvSyyxa0RUHDwzVQIiMiNlzDiWqLRkF2TdeFDl5u+bbdPTYCGil5/qZ3Ro8sG9ayWXMxh+f+s0MAU9qFIwau838RF2R9OCMjmPodW/zf+Mcq+SqrbZyYfYha5jOWxoN8IdrGuAOQeYks7mrXC6qq5N9ojUtMKONvayFwNOsuC0U8PYUtukkHVnm2IK9KM1A38HDlV9eTF8ac7yCUHLlttmoIBdLUuLJAw72BQkK/
+    groups:
+      - sudo
+  notmyfault:
+    ssh_keys:
+      notmyfault_rsa:
+        key: AAAAB3NzaC1yc2EAAAADAQABAAABgQD4jyaQucbqLmDZ+WiAS0bjXTTlOr7Jx+1gUs4pT5LzlL/ijg7Fa7FGK/96U5lUJKvmuF2oGI53n3JfwJuRsuKe2yTdlMrRKREn/jUBP4LnNeVs77Fau25jPERJAgo+lz3BBlRfPJ6AYdMRiVWr9ZsKJILGB9UpALjSJkN3F+W66Dm51Xjw7SiScKs5xKb+s5WisIlJp6MC1T0z24DFAu/X08f2A2jGpHloF6R6FHUPVYewc5bjj72DrFIP+6M+1k1mBzyr/5COBgbFxStrT+wk+spA9U8fhOiFWDcmpEnfJa8qwMBDwSkiwWdDgEeEbepFgeNgzfBxY0vSbBtV2rbm2Chy8yUj0EKERZIIGHo3yowP6pyK78QJceuBFd3jzzlaOotdI1ce5tFDR51FMbAAKY2YYm//LmwZcxXVC0k2Vd5kMOmRtM3Iv4WT836ZvkhMxUi+fC0HbKXMsEwXnitNmGO0c9JKe9XbMYqKCsCVoeEjL0+8nMiLkId5ZMxFyKc=
+    groups:
+      - sudo
+docker::log_opt::max-size: "100m"
+docker::log_opt::max-file: 2
+# Per-host Datadog configuration
+datadog_agent::host: "controller.trusted.ci.jenkins.io"
+profile::jenkinscontroller::ci_fqdn: "trusted.ci.jenkins.io"
+profile::jenkinscontroller::proxy_port: 1443
+profile::jenkinscontroller::anonymous_access: false
+profile::jenkinscontroller::admin_ldap_groups:
+  - admins
+  - trusted-admins
+profile::jenkinscontroller::letsencrypt: true
+profile::letsencrypt::dns_azure:
+  sp_client_id: "ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAjozNf8C99Hs50rLQcAEqcn0vQ2JqcUaguERQNHg59912qdRAVbUZyHinfaW5AsH9Z88SpUXWQ14NGz6Cr2X+fa3jU41s1z+uk/oHcqCSU1gn0qUyqCAdI4lMY0pcFGu6xmraL7RYie772KuoNrpmkI/+YYQOWBOcbaCvKbaIj2cx4t13mBbTffJ6nmRi9QJBc7OOX/ZS/t+xmcLazNPAWx0CgL7VjFiFQYgVeJ4ujjC2ER2B6X7eB+M7eyPP6+I7LSjGYfVq7x36D+phjYWQY0U/EcDnYMq4Cw1mME0PCeJegaqGy7vzlpIT4RFx6PquC7AfVniTNRjVG7q6TvpLtTBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCF7GnhDkq2+IPICNEk0RcKgDAXTkVVnaDM/gCzpotuP8HrZTzV7IP1HbV8IUx4nH+OWJ8rNRUQq+2VpK/yR+J5Kiw=]" # application_id
+  sp_client_secret: "ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAtVSz93ptGxGIX+XKdWRxvbUN1NUAFYySQeQovJk5pxN+CLwRCNvIwoGvJnE+DVSPW2YF9zN2EHDt5nR8Bcv6wWhsKP+RMxjZ8aZyCdFTai+s83blMhLxguGEi5LxkJlFGVMzSQU3ycXeRlYr+9vFv5+evSkT9o75zduYpUfdPVNfsKAFej2Fd3427KujBKMPIXsNbQCzPYr1kXVZesnXQ4ph605hEsLA+Wjdl9dS8HfLujK/Lz1V20lJGOLSHyIfrX5NTdXih8vq3hjNs32kmvhjKgilvhaPvLqXMkUWOnEEyOwwAQ1HuyR767QgrnFpnc09OwTNfHuHPt3/C/ncvjBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBtoRAi9TxsIDS1vUrzpsSkgDA0NYQWVJai5K/e1j2VpBPn102ZeAfUOLIuw8Xvci5RAElZjxamUt/VGVHVVB7o4lY=]" # application_password.
+  tenant_id: "ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAkgR5pF4ipEnUpbYCk8zBlTnWsu76DjWw2Nc7lCLnu15JO0E5hp3RExxp6S+mxpFBEnAVAul+ZtuDO9/zuIm7Evqg28yAfRMT1nIe3CcZhr1RBz/aSfoirE9qRSX87iGKGlkt9Xe6fFtNhBJ+HZmHSBCv9gHQAA7UYlJ85wp0Jhioj6Jsq0QRAPxKbkoRQ4tUGy7g6kYVMrS5gTuJzfF6eSTisJ8v+y+AqDDxh/ImUEtt5Ci+Cfizk5qrvtNopM+d9EFp7hggxZHp+pwmUIiGMa6zKw5zK+yv5O+D7u28XzsMof/2CRAlVZddph8QyZJzPJdN4HhrGtTFvCjt4QxZmzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBD+pYc/BGBpdj/nG0PmzYkgDDeOpYnPPb669742yPihHnDvpBJFyhENejHd3fEGumuo8v4fDQW5GbJBLLWNOj1wuk=]" # subscription id
+  zones:
+    trusted.ci.jenkins.io: "ENC[PKCS7,MIIB+wYJKoZIhvcNAQcDoIIB7DCCAegCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEASG7O5Dd1mktyw1PoHKIqIy3ge/MQa0LQOWUoyYD6oxjepDnJs6s7YksaO8S4SwDtfhUMX73eJO4Js8FvTLv8t2xfz5/x+e7O5Lw+UaaU/oNPPvMyekxzgslePUdlTZr5JL8bFEuMB7F5Y83dsLMMY6uvy0xf6n6Xr8kPTXIuYk9T1IxzSzNfKvbWcl09yOMjJphR/gA8ckTm7B0hP+1dQq+1f4WPH7qxqWkdvRUpiLnwEUMbdXYQk8mjP0HMSRAt6NA1j0kpgN2QtX7wLH97i483SpySKC/16AaELtKkCwrW7rmf2XX2CnVfBTDb7ikl6xRifIq6lcvNf6K9LhH6uTCBvQYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQLKeuqbeUNcwsVlTZBbg5qoCBkCS1IHK8y5PY/Ov7LlFYFupyQ7E3B+WMIIqMGT+snl7cnsXDjUsOJmzo2P9ReELDId8L7abvZdsmoGp47a85+iTscARNTjtyO5mEHhTvlE778r0NNQKj62Yto4roq5zGDET+zYUu4O4VB3HfyGNOXvi0J27tifLicOEsTtJf3SrNndR7ZWH+kmLMu2HTpApl9g==]"
+profile::jenkinscontroller::groovy_init_enabled: true
+profile::jenkinscontroller::groovy_d_lock_down_jenkins: "present"
+profile::jenkinscontroller::groovy_d_set_up_git: "present"
+profile::jenkinscontroller::memory_limit: "7g"
+profile::jenkinscontroller::jcasc:
+  enabled: true
+  reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAlreoLMhSaHCcZZaL1r7BQgmqUVbqWs+e2kaj0cn+r8o4N/qKZGXkkYBN9xhK+b5MRe2cTlfQ9J3gFFLFa6i1n1GrM/WwNMUm/cVYA2eGFNcV3ruUfigyriIrIaQVm7KIQZqv+RIQoZHJ1cWy+CdKg2hXi4KUBSawl1V3VXjSD4ZJEWv96KSceJZRTzVjZW66iD8i8Uq50WvHhvivMfHkaghowz626w/ejz0AettIKCVL9/j0B1iVv+ghOyd4A5kyIYJKR0BwQLpfKFoXY/0uhB7toZWSe7TUS7hzTAfYNhyTbS0aaczsa7pshiFZzxHAdvMeU7om4N1Dj+5LDUgAsDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBByyf8QkfPXbWYxJbMykP8SgCAQ5ncRq7jZddH/cFcb+xHJzKluSoRQU3fnSKJ8fnbEQA==]
+  tools:
+    groovy:
+      groovy: # Default version is named "groovy"
+        version: "2.4.7"
+    jdk:
+      jdk8:
+        installers:
+          linux-amd64:
+            type: "zip"
+            label: "(linux && amd64) || updatecenter || census"
+  permanent_agents:
+    agent-1:
+      remoteFS: /home/jenkins/agent-workspace
+      numExecutors: 2
+      mode: EXCLUSIVE
+      labels:
+        - updatecenter
+        - census
+      ssh:
+        host: "agent.trusted.ci.jenkins.io"
+        credentialsId: "trusted-agent-1-ssh-key"
+        maxNumRetries: 0
+        retryWaitTime: 0
+        hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII6p0lupt11K5Htbzw+yYs2GMiQsVF63jSW7/eGqjWSh"
+  cloud_agents:
+    azure-vm-agents:
+      azureCredentialsId: "azure-sponsorship-credentials"
+      resource_group: jenkinsinfra-trustedvmagents
+      agent_definitions:
+        - name: "ubuntu-22"
+          description: "Ubuntu 22.04 LTS"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXhMrX6DhUDJU5Ug4nLaRGGPWFHT2u9ZnxTQuXVQTBbR3Pb8pOYr/kWxQJmZTpVoqEnanVineZn1PFTxVVkjHUirX3kKgdwu3pZTrzaklBex1C1us64SmHErbHds0KeE/EX03k+Gti/V9W1z9jcTueHSld58olNCAb5oNbyo6noqLAZehoQLS39eRvsQDb4sYmVUv9X7daZ7Zu+kCYBtBZyfDNbRFMSOYcbj9WuygCwAijVGIC6q9hJWZYe/5DKAUZnynWDdPmtzDytrc3qKDaHSQ+5nQYORcO9vTuAevUoHis5elQ8dm6VWGiyvafx7xKzqbNghu9xGz/5IA/zzC9TBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBEbhkLOEK5AaKPTV2CVxhagCAx5gsM01ONtqyQ7FRhnqOtyISGBXJtdfdcJXbp2MSBtw==]
+          location: "East US"
+          instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
+          spotInstance: true
+          architecture: amd64
+          labels:
+            - java
+            - linux
+            - docker
+            - maven-11
+            - jdk11
+          maxInstances: 7 # Quota of 56 vCPUs
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: false
+        - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2019"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEACyYOJKI6ZUkaYxvjc2B28AgmrulBjPZu4/1CgWkG9UDeDL36IaKtwZpbrunMC1iomzchJeeamWP97FYXZEuL+UrjtksLyDWMwXRjH+reENg8zXkm0d3ixajOAxyWMp8oWBQXHbF6sabFthVFsyH/NHiJNK7SathpmEZb2CV4Wijh2OEqWD9siJiIuG6ltkOO3lof2v83QG7FdBiiUq19k3vZQ7DQa8ew8jqH0+/+nMoMnpSg93PY/CJ5ty5Wp1gKEl3fZoLWT9ajwsPSAdQz7aK74/eYkSfbFY8EYPxSteAsLZz/OUJjhKpQQH8OUiYj88caw6uw+hnCdUI7ii+goTBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBcFfMvnXKFZn9P6fwpv38CgCBZNquRP9m0BnCJIVRT+f8AvBve8ReanZIVHLCtKasF4w==]
+          location: "East US"
+          instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
+          spotInstance: true
+          architecture: amd64
+          labels:
+            - docker-windows
+          maxInstances: 7 # Quota of 56 vCPUs
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: false
+# These are plugins we need only in our trusted-ci environment
+profile::jenkinscontroller::plugins:
+  - ansicolor
+  - azure-vm-agents
+  - blueocean
+  - build-timeout
+  - buildtriggerbadge
+  - cloudbees-folder
+  - credentials
+  - credentials-binding
+  - configuration-as-code
+  - docker-workflow
+  - git-client
+  - git
+  - github
+  - github-branch-source
+  - groovy
+  - jobConfigHistory
+  - ldap
+  - lockable-resources
+  - mailer
+  - parallel-test-executor
+  - pipeline-graph-view
+  - pipeline-stage-view
+  - pipeline-utility-steps
+  - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs
+  - ssh-slaves # SSH Build Agent to implement "outbound agents"
+  - throttle-concurrents
+  - timestamper
+  - toolenv
+  - workflow-aggregator
+  - workflow-multibranch

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -78,6 +78,7 @@ node 'azure.ci.jenkins.io' {
   include role::jenkins::controller
 }
 
+# TODO: remove if https://github.com/jenkins-infra/helpdesk/issues/3486 is finished with success
 # Jenkins controller for trusted.ci.jenkins.io
 node 'trusted-ci' {
   $hiera_role = 'trustedci'
@@ -91,6 +92,7 @@ node 'cert-ci' {
   include role::privateci
 }
 
+# TODO: remove if https://github.com/jenkins-infra/helpdesk/issues/3486 is finished with success
 node 'trusted-agent-1' {
   notice('This agent is trusted!')
   $hiera_role = 'trustedagent'
@@ -107,6 +109,7 @@ node 'private.vpn.jenkins.io' {
   include role::openvpn
 }
 
+# TODO: remove if https://github.com/jenkins-infra/helpdesk/issues/3486 is finished with success
 # SSH Bastion used to reach trusted.ci and its trusted-agent-1
 node 'bounce' {
   include role::bounce

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -111,3 +111,14 @@ node 'private.vpn.jenkins.io' {
 node 'bounce' {
   include role::bounce
 }
+
+## New VMs (Azure) for trusted.ci.jenkins.io
+node 'bounce.trusted.ci.jenkins.io' {
+  include role::bounce
+}
+node 'agent.trusted.ci.jenkins.io' {
+  include role::updatecenter
+}
+node 'trusted.ci.jenkins.io' {
+  include role::jenkins::controller
+}


### PR DESCRIPTION
This PR "only" adds the 3 new machines for trusted (ref. https://github.com/jenkins-infra/helpdesk/issues/3486).

It uses the "puyppet hostnames" from https://github.com/jenkins-infra/azure/pull/344


Merging this PR won't trigger a puppet agent runs on this VM: they need an initial binding from an admin on the puppet master, so no impact expected