### PR TITLE
feat(trusted.ci) define data disk mounts for controller.trusted and agent.trusted

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -120,8 +120,20 @@ node 'bounce.trusted.ci.jenkins.io' {
   include role::bounce
 }
 node 'agent.trusted.ci.jenkins.io' {
+  mount { '/home/jenkins':
+    ensure => 'mounted',
+    atboot => 'true',
+    device => 'UUID=d87e9734-13a2-4e45-b906-6410a913c148',
+    fstype => 'ext4',
+  }
   include role::updatecenter
 }
-node 'trusted.ci.jenkins.io' {
+node 'controller.trusted.ci.jenkins.io' {
+  mount { '/var/lib/jenkins':
+    ensure => 'mounted',
+    atboot => 'true',
+    device => 'UUID=60de6f1a-4c88-47c6-928d-4dcb55e02f21',
+    fstype => 'ext4',
+  }
   include role::jenkins::controller
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3486

This PR defines, as code, the mount for the controller and agent data disks.
Tested manually on the infrastructure as it is really hard to test inside the Docker + Vagrant setup.


Notes:

- Manual (but one-time)  operation is required to identifiy and format the data disk on each machine is needed. We could try to automate using cloud-init but that would mean spending a LOT of time on destroying-creating a new VM so better easier like this:
  - Retrieving the device name: `lsblk -l`
  - An initial formatting of the data disk was required with `mkfs.ext4 /dev/<device>`
  - UUID of the formatted device can be obtained wether with `lsblk -O` or `ls -l /dev/disk/by-uuid`
- Manual test as done with a full reboot to ensure mount path is still present after rebooting
- https://forge.puppet.com/modules/puppetlabs/mount_core/reference needs a subsequent update to 1.2.0 (needs updatecli manifest to track)