### PR TITLE
fix(artifact-caching-proxy): add exception for `jitpack.io` Maven repository

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local</mirrorOf>
+                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local,!jitpack.io</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>


### PR DESCRIPTION
This exception is added to fix the build of https://github.com/jenkinsci/ircbot-plugin which relies on https://github.com/pircbotx/pircbotx/ whose binary releases (and snapshots) are published to https://jitpack.io/#pircbotx/pircbotx/, not mirrored in our Maven repositories for now.

Twin PR: https://github.com/jenkins-infra/kubernetes-management/pull/4049

Ref: https://github.com/jenkins-infra/helpdesk/issues/3591