### PR TITLE
feat(trusted.ci) Update instance type for Azure VM ephemeral agents

### DIFF
--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -99,7 +99,8 @@ profile::jenkinscontroller::jcasc:
           os: "ubuntu"
           storageAccount: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAwlTuXgbIkiSzGStNLeY1vD/P6W+qHMs6Y5iiS7zlten659BfucBRoYQ6+I2SdoJ3P8BF/jGE8unno4a950CVYYKNO9E8Nlf8CkEVBMOQx5wykRO8cDxcMF2iLuhyIGSQhHENqagzRAAE26rDzQBZqfCL4a2btGHOLlaNZuO4Tv/Y8WfYKDCvh3hysYnaSY2OND176rE9fQfBjRYx0rwY2EMTQq/cw5qosQYYn8j6b/EiFUr1IHZ4jKmGiYY435TJW36VsgwlSuGYhXVVaLxzx3/5Sotw6upheMhinHGe38LKBhj/bB+P5lVqzuFLIOUmFoOl+XZZEv6EZF/W1mIlXTA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDugu9cOmhNUqPfIw5W77CEgBCkCNrdzkuYRj5YXCJNl+Qq]
           location: "East US 2"
-          instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
           spot: true
           initScript: *InboundAgentInitShellScript
           architecture: amd64
@@ -109,7 +110,7 @@ profile::jenkinscontroller::jcasc:
             - docker
             - maven-11
             - jdk11
-          maxInstances: 7 # Quota of 56 vCPUs
+          maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
@@ -122,13 +123,13 @@ profile::jenkinscontroller::jcasc:
           os: "windows"
           storageAccount: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEALl/EWRs6+6Wmr6p6Ce6GxeZeh3WoZuMtDpT2BHQrRvfMzKVda6HSvvaA7aMHVeyxzfwxay+kWDQN/cpbUIP9LjEAR1dIGxtKbDTEnglmtViZkvZyyG1HgXKNUAs1ZZNzmwHD7WHKxxnjvK5AjKjro9HqgitnuhokIWS8keqJ93fe1ClJs23mh5uPk6fV60MATqy7EIp7M0oEJGyWlJmE0mTbID3rVNDGGXrVENXaPNzoys+g/HC0/ydRn1Dt2jIGhTY9ej0w8YJ7mwIyW7DF2viYi2J7ipOUPqDGKOH5I3CV2t4NhWupV/cEPCfTla9mwIk/6x2iP0wWBOBJkrWqLzA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDeZ0akYFi7qYGMRUZy0ylWgBAZ/EnT5I3LzVkpzLBVM3M5]
           location: "East US 2"
-          instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           spot: true
           initScript: *InboundAgentInitShellScript
           architecture: amd64
           labels:
             - docker-windows
-          maxInstances: 7 # Quota of 56 vCPUs
+          maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -45,6 +45,22 @@ profile::jenkinscontroller::groovy_init_enabled: true
 profile::jenkinscontroller::groovy_d_lock_down_jenkins: "present"
 profile::jenkinscontroller::groovy_d_set_up_git: "present"
 profile::jenkinscontroller::memory_limit: "7g"
+# Non functionnal key used to factorize code with a YAML anchor
+x-inbound-agent-init-shell-script: &InboundAgentInitShellScript
+  - "#!/bin/bash"
+  - "set -eux"
+  - echo "START CLOUDINIT"
+  - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAp1EN//8Rqd5PGR3qbiLEQcU7VjkMclipg9nIMG5YNafcma1VOu1DJX1laH3pGdJHwYOqVOGsiMBZDojWhgd1IEHCI9P+9MrU9a7gog+aEsZFKi2fSpw/o/U0+tA7yDhMhSireOwi+E9rXOOojHOlVPXCOsas3V0PT9tvr7zHadSZj10d10L5uX/oNaLQXGwDnAU3AT7TRlGETEI+FP50P/IyoN5SOb+UDECfsJnQkvQAux20UaRXUXT35ECDQmULnf3BR0Zzmpbqji1Mn+aEV/8NIBAfTUfTRbzFEsVDznfB/qIOt7YBKKQwiiOy8tjIFXQN4nSNFOuJ/v8f95TDZDBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCjHiqfdYeWfOw5ydrp6+AFgDBLVhQVC2dqv5nYd9QJjxoJkoPoUARsf1J3Wycg+ZH9Daf3EGDuhoaEp79z0+ksKoo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+  - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+  - systemctl stop datadog-agent.service
+  - mkdir -p /var/log/datadog /etc/datadog-agent
+  - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+  - chmod 640 /etc/datadog-agent/datadog.yaml
+  - chown dd-agent:dd-agent /var/log/datadog
+  - chmod 770 /var/log/datadog
+  - systemctl start datadog-agent.service
+  - rm -f /etc/sudoers.d/90-cloud-init-users
+  - echo "END CLOUDINIT"
 profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAlreoLMhSaHCcZZaL1r7BQgmqUVbqWs+e2kaj0cn+r8o4N/qKZGXkkYBN9xhK+b5MRe2cTlfQ9J3gFFLFa6i1n1GrM/WwNMUm/cVYA2eGFNcV3ruUfigyriIrIaQVm7KIQZqv+RIQoZHJ1cWy+CdKg2hXi4KUBSawl1V3VXjSD4ZJEWv96KSceJZRTzVjZW66iD8i8Uq50WvHhvivMfHkaghowz626w/ejz0AettIKCVL9/j0B1iVv+ghOyd4A5kyIYJKR0BwQLpfKFoXY/0uhB7toZWSe7TUS7hzTAfYNhyTbS0aaczsa7pshiFZzxHAdvMeU7om4N1Dj+5LDUgAsDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBByyf8QkfPXbWYxJbMykP8SgCAQ5ncRq7jZddH/cFcb+xHJzKluSoRQU3fnSKJ8fnbEQA==]
@@ -84,7 +100,8 @@ profile::jenkinscontroller::jcasc:
           storageAccount: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAwlTuXgbIkiSzGStNLeY1vD/P6W+qHMs6Y5iiS7zlten659BfucBRoYQ6+I2SdoJ3P8BF/jGE8unno4a950CVYYKNO9E8Nlf8CkEVBMOQx5wykRO8cDxcMF2iLuhyIGSQhHENqagzRAAE26rDzQBZqfCL4a2btGHOLlaNZuO4Tv/Y8WfYKDCvh3hysYnaSY2OND176rE9fQfBjRYx0rwY2EMTQq/cw5qosQYYn8j6b/EiFUr1IHZ4jKmGiYY435TJW36VsgwlSuGYhXVVaLxzx3/5Sotw6upheMhinHGe38LKBhj/bB+P5lVqzuFLIOUmFoOl+XZZEv6EZF/W1mIlXTA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDugu9cOmhNUqPfIw5W77CEgBCkCNrdzkuYRj5YXCJNl+Qq]
           location: "East US 2"
           instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
-          spotInstance: true
+          spot: true
+          initScript: *InboundAgentInitShellScript
           architecture: amd64
           labels:
             - java
@@ -106,7 +123,8 @@ profile::jenkinscontroller::jcasc:
           storageAccount: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEALl/EWRs6+6Wmr6p6Ce6GxeZeh3WoZuMtDpT2BHQrRvfMzKVda6HSvvaA7aMHVeyxzfwxay+kWDQN/cpbUIP9LjEAR1dIGxtKbDTEnglmtViZkvZyyG1HgXKNUAs1ZZNzmwHD7WHKxxnjvK5AjKjro9HqgitnuhokIWS8keqJ93fe1ClJs23mh5uPk6fV60MATqy7EIp7M0oEJGyWlJmE0mTbID3rVNDGGXrVENXaPNzoys+g/HC0/ydRn1Dt2jIGhTY9ej0w8YJ7mwIyW7DF2viYi2J7ipOUPqDGKOH5I3CV2t4NhWupV/cEPCfTla9mwIk/6x2iP0wWBOBJkrWqLzA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDeZ0akYFi7qYGMRUZy0ylWgBAZ/EnT5I3LzVkpzLBVM3M5]
           location: "East US 2"
           instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
-          spotInstance: true
+          spot: true
+          initScript: *InboundAgentInitShellScript
           architecture: amd64
           labels:
             - docker-windows

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -50,7 +50,7 @@ x-inbound-agent-init-shell-script: &InboundAgentInitShellScript
   - "#!/bin/bash"
   - "set -eux"
   - echo "START CLOUDINIT"
-  - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAp1EN//8Rqd5PGR3qbiLEQcU7VjkMclipg9nIMG5YNafcma1VOu1DJX1laH3pGdJHwYOqVOGsiMBZDojWhgd1IEHCI9P+9MrU9a7gog+aEsZFKi2fSpw/o/U0+tA7yDhMhSireOwi+E9rXOOojHOlVPXCOsas3V0PT9tvr7zHadSZj10d10L5uX/oNaLQXGwDnAU3AT7TRlGETEI+FP50P/IyoN5SOb+UDECfsJnQkvQAux20UaRXUXT35ECDQmULnf3BR0Zzmpbqji1Mn+aEV/8NIBAfTUfTRbzFEsVDznfB/qIOt7YBKKQwiiOy8tjIFXQN4nSNFOuJ/v8f95TDZDBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCjHiqfdYeWfOw5ydrp6+AFgDBLVhQVC2dqv5nYd9QJjxoJkoPoUARsf1J3Wycg+ZH9Daf3EGDuhoaEp79z0+ksKoo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+  - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAhoDM4a7hdCAgZikQ/SE3mE3jO4zQkYkDCiDRR1zF6dOMEagx2ztsVT+Rr4c5W9mpyor4K0O5GriZVmh+zlR7icucFf9o59w/PS8ryDMNYIRMMW2wfvMKj+xz8YEeNGbNEWyg8lempPmt+zXq5zSxon/Mz8gcC8rLbxugPVawxEO48x3wL46qpA0TzilaiHPFG90/WiEmu5HCme4kDqPhg+ArYiH5n7KGZUEqv3iYYRF5GzsLe+MCCINz3Q9AKHADAOG3kcf4SWsl+mDsq+iA9GIsk1ouRdX9iiRAstPzxrDv2NJYPZRpRNgG3L9dmruAIeqtvZCf1xGGRgFSEmws7zBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBscnDbb0G00Fk3iaK2BNkZgDB7S/qP+jE2P88vv/pieLchcEROoUgd/OG2WGZm5e0p7MMi3n3EOun4Eh9sVEPCy30=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
   - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
   - systemctl stop datadog-agent.service
   - mkdir -p /var/log/datadog /etc/datadog-agent

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -17,6 +17,22 @@ profile::jenkinscontroller::ci_resource_domain: 'assets.localhost'
 profile::jenkinscontroller::proxy_port: 443
 profile::jenkinscontroller::groovy_init_enabled: false
 profile::jenkinscontroller::memory_limit: '14g'
+# Non functional key used to factorize code with a YAML anchor
+x-inbound-agent-init-shell-script: &InboundAgentInitShellScript
+  - "#!/bin/bash"
+  - "set -eux"
+  - echo "START CLOUDINIT"
+  - "sed 's/api_key:.*/api_key: SuperSecretThatShouldBeEncryptedInProduction/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+  - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+  - systemctl stop datadog-agent.service
+  - mkdir -p /var/log/datadog /etc/datadog-agent
+  - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+  - chmod 640 /etc/datadog-agent/datadog.yaml
+  - chown dd-agent:dd-agent /var/log/datadog
+  - chmod 770 /var/log/datadog
+  - systemctl start datadog-agent.service
+  - rm -f /etc/sudoers.d/90-cloud-init-users
+  - echo "END CLOUDINIT"
 profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: SuperSecretThatShouldBeEncryptedInProduction
@@ -181,98 +197,6 @@ profile::jenkinscontroller::jcasc:
         url: SuperSecretThatShouldBeEncryptedInProduction
         defaultNamespace: jenkins-agents
         # No agent definitions (to test an empty cloud)
-    ec2:
-      aws-us-east-2:
-        region: us-east-2
-        credentialsId: "aws-credentials-jenkins-ci"
-        sshKeysCredentialsId: "ec2-agent-ssh-2021-06"
-        agent_definitions:
-          - description: "Ubuntu 20.04 LTS"
-            maxInstances: 20
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            os_version: "20.04"
-            architecture: "amd64"
-            labels:
-              - java
-              - docker
-              - linux
-              - linux-amd64
-            useAsMuchAsPossible: true
-            spot: true
-            userData: &BootstrapDatadogScript
-              - "#!/bin/bash"
-              - "set -eux"
-              - echo "START CLOUDINIT"
-              - "sed 's/api_key:.*/api_key: SuperSecretThatShouldBeEncryptedInProduction/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-              - systemctl stop datadog-agent.service
-              - mkdir -p /var/log/datadog /etc/datadog-agent
-              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-              - chmod 640 /etc/datadog-agent/datadog.yaml
-              - chown dd-agent:dd-agent /var/log/datadog
-              - chmod 770 /var/log/datadog
-              - systemctl start datadog-agent.service
-              - rm -f /etc/sudoers.d/90-cloud-init-users
-              - echo "END CLOUDINIT"
-          - description: "Windows 2019"
-            maxInstances: 10
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "windows"
-            os_version: "2019"
-            architecture: "amd64"
-            labels:
-              - docker-windows
-              - docker-windows-2019
-            useAsMuchAsPossible: true
-            spot: false
-            userData:
-              #this script is ran before the agent service startup so no need to restart it
-              - <powershell>
-              - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretThatShouldBeEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
-              - </powershell>
-          - description: "Windows 2022"
-            maxInstances: 10
-            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
-            os: "windows"
-            os_version: "2022"
-            architecture: "amd64"
-            labels:
-              - docker-windows-2022
-              - windows-2022
-            useAsMuchAsPossible: true
-            spot: false
-            userData:
-              #this script is ran before the agent service startup so no need to restart it
-              - <powershell>
-              - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretThatShouldBeEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
-              - </powershell>
-          - description: "High memory ubuntu 20.04 (ondemand)"
-            maxInstances: 50
-            instanceType: M54xlarge # 16 vCPUS / 64 Gb
-            os: "ubuntu"
-            os_version: "20.04"
-            architecture: "amd64"
-            labels:
-              - highmem
-              - highram
-              - docker-highmem
-              - linux-amd64-big
-            useAsMuchAsPossible: false
-            spot: false
-            userData: *BootstrapDatadogScript
-          - description: "ARM64 ubuntu 20.04"
-            maxInstances: 5
-            instanceType: A1Xlarge # 4 vCPUs / 8 Gb
-            os: "ubuntu"
-            os_version: "20.04"
-            architecture: "arm64"
-            labels:
-              - arm64docker
-              - arm64linux
-            useAsMuchAsPossible: false
-            spot: true
-            userData: *BootstrapDatadogScript
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
       resource_group: eastus-cijenkinsio
@@ -298,7 +222,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript: *BootstrapDatadogScript
+          initScript: *InboundAgentInitShellScript
         - name: "ubuntu-22-arm64"
           description: "Ubuntu 22.04 LTS ARM64"
           imageDefinition: jenkins-agent-ubuntu-22.04-arm64
@@ -320,7 +244,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript: *BootstrapDatadogScript
+          initScript: *InboundAgentInitShellScript
         - name: "ubuntu-20-highmem"
           description: "Ubuntu 20.04 LTS Highmem"
           imageDefinition: jenkins-agent-ubuntu-20.04-amd64
@@ -343,7 +267,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
           spot: true
-          initScript: *BootstrapDatadogScript
+          initScript: *InboundAgentInitShellScript
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64
@@ -444,7 +368,6 @@ profile::jenkinscontroller::plugins:
   - credentials-binding
   - datadog
   - docker-workflow
-  - ec2
   - embeddable-build-status
   - git-client
   - git


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3486

This PR updates the instance type for trusted.ci.jenkins.io's VM agents to use the same serie as ci.jenkins.io (introduced in https://github.com/jenkins-infra/jenkins-infra/pull/2829).

- These VMs are using ephemeral disks instead of managed disk: faster to boot, cheaper, for the same performances (local NVMe)
- Used the same instance size as the "highmem" on ci.jenkins.io: same amount of vCPUs but 32Gb of memory instead of 28Gb.
- Enabled datadog agent on these machines to collect system metrics:
  - Permanent agent already has the agent enabled
  - We have to be sure that these machines aren't overkill for the tasks on trusted.ci.jenkins.io, so we need metrics

Please note that;
- This PR has been tested with the local vagrant setup (see the hieradata/vagrant change)
- The ci.jenkins.io and cert.ci.jenkins.io controller does not benefit from the "generic init script change": should be subsequent PRs