### PR TITLE
chore(updatecli) fix maven manifest following up quote removals

### DIFF
--- a/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml
@@ -29,10 +29,10 @@ sources:
       - getPackerImageDeployedVersion
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getPackerImageDeployedVersion" }}/provisioning/tools-versions.yml
-      matchpattern: 'maven_version:\s"(.*)"'
+      matchpattern: 'maven_version:\s(.*)'
     transformers:
       - findsubmatch:
-          pattern: 'maven_version:\s"(.*)"'
+          pattern: 'maven_version:\s(.*)'
           captureindex: 1
 
 conditions:


### PR DESCRIPTION
Since https://github.com/jenkins-infra/packer-images/pull/701 (required due to a behavioral change in updatecli 0.51.x), the Maven version tracking is failing.

This PR updates the regexp to fix the process and get rid of the error message

```
ERROR: ✗ no line matched in the file "https://raw.githubusercontent.com/jenkins-infra/packer-images/1.10.0/provisioning/tools-versions.yml" for the pattern "maven_version:\\s\"(.*)\""
```