### PR TITLE
Revert "feat: enable Datadog configuration on `ci.jenkins.io`"

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -471,8 +471,6 @@ profile::jenkinscontroller::jcasc:
               - maven-19-windows
   artifact_caching_proxy:
     disabled: false
-  datadog:
-    host: "ci.jenkins.io"
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor # Provides ANSI color in the UI when checking log outputs
@@ -488,7 +486,6 @@ profile::jenkinscontroller::plugins:
   - configuration-as-code # Required for CasC
   - credentials # Provides Jenkins Credentials management
   - credentials-binding # Bind Jenbkins credentials to variables in jobs
-  - datadog # Datadog plugin
   - docker-workflow # Provides the "withDockerContainer" pipeline keyword
   - ec2 # AWS EC2 VM agents
   - embeddable-build-status # https://github.com/jenkins-infra/helpdesk/issues/3013


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2836 until we found out how the Datadog agent in the VM host can communicate with the controller in the Docker container.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3573#issuecomment-1584540488