### PR TITLE
feat(ci.jenkins.io) allow containers to use dogStatsD protocol with the host datadog agent

### DIFF
--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -11,6 +11,15 @@ class profile::docker {
 
   include datadog_agent::integrations::docker_daemon
 
+  # Restrict UDP dogStatsD traffic only from loopback or docker0
+  firewall {
+    '901 Drop all non local dogStatsD UDP/8125 inbound requests':
+      proto   => 'udp',
+      dport   => 8125,
+      iniface => ['! lo', '! docker0'],
+      action  => 'drop',
+  }
+
   # Ensure that the datadog user has the right group to access docker
   user { $datadog_agent::params::dd_user:
     ensure  => present,

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -24,6 +24,8 @@ accounts:
       - sudo
 # Per-host Datadog configuration
 datadog_agent::host: "ci.jenkins.io"
+datadog_agent::agent_extra_options:
+  bind_host: "0.0.0.0" # All hosts interfaces to allow container access
 profile::jenkinscontroller::anonymous_access: true
 profile::jenkinscontroller::admin_ldap_groups:
   - admins


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3573

- https://forge.puppet.com/modules/datadog/datadog_agent/readme#configuration-variables shows that a map can be used to pass additional extra options to the datadog agent conf
- A firewall rule is added to the Docker profile to allow containers to communicate with the dogstatsd