### PR TITLE
feat(ci.jenkins.io) enable datadog plugin dogStatsD reporting

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -473,6 +473,8 @@ profile::jenkinscontroller::jcasc:
               - maven-19-windows
   artifact_caching_proxy:
     disabled: false
+  datadog:
+    host: "ci.jenkins.io"
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor # Provides ANSI color in the UI when checking log outputs
@@ -488,6 +490,7 @@ profile::jenkinscontroller::plugins:
   - configuration-as-code # Required for CasC
   - credentials # Provides Jenkins Credentials management
   - credentials-binding # Bind Jenbkins credentials to variables in jobs
+  - datadog # Datadog plugin
   - docker-workflow # Provides the "withDockerContainer" pipeline keyword
   - ec2 # AWS EC2 VM agents
   - embeddable-build-status # https://github.com/jenkins-infra/helpdesk/issues/3013

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -475,6 +475,7 @@ profile::jenkinscontroller::jcasc:
     disabled: false
   datadog:
     host: "ci.jenkins.io"
+    targetHost: "172.17.0.1" # docker0 interface
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor # Provides ANSI color in the UI when checking log outputs


### PR DESCRIPTION
Related to jenkins-infra/helpdesk#3573

- Reverts #2901
- Updates the datadog agent hosts to the `docker0` IP value (as per #2909 )