### PR TITLE
fix(ci.jenkins.io): disable digital ocean during their network outage

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -222,7 +222,7 @@ profile::jenkinscontroller::jcasc:
             cpus: 1
             memory: 1
       doks:
-        enabled: true
+        enabled: false
         provider: do
         credentialsId: "doks-jenkins-agent-sa-token"
         serverCertificate: >


### PR DESCRIPTION
lots of alerts about network outage on digital ocean on both doks and doks-public