### PR TITLE
feat(ci.jenkins.io) enable datadog full integration with logs and traces

### DIFF
--- a/dist/profile/manifests/datadog_pluginsite_check.pp
+++ b/dist/profile/manifests/datadog_pluginsite_check.pp
@@ -11,16 +11,16 @@ class profile::datadog_pluginsite_check (
     ensure => file,
     source => "puppet:///modules/${module_name}/datadog_pluginsite_check/plugins_api_check.py",
     path   => '/etc/datadog-agent/checks.d/plugins_api_check.py',
-    owner  => $::datadog_agent::params::dd_user,
-    group  => $::datadog_agent::params::dd_group,
+    owner  => $datadog_agent::params::dd_user,
+    group  => $datadog_agent::params::dd_group,
     notify => Service[$datadog_agent::params::service_name],
   }
 
   file { 'plugins_api_check.yaml':
     ensure  => file,
     content => template("${module_name}/datadog_pluginsite_check/plugins_api_check.yaml.erb"),
-    owner   => $::datadog_agent::params::dd_user,
-    group   => $::datadog_agent::params::dd_group,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
     path    => "${facts['datadog_agent::params::conf_dir']}/plugins_api_check.yaml",
     notify  => Service[$datadog_agent::params::service_name],
   }

--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -11,15 +11,6 @@ class profile::docker {
 
   include datadog_agent::integrations::docker_daemon
 
-  # Restrict UDP dogStatsD traffic only from loopback or docker0
-  firewall {
-    '901 Drop all non local dogStatsD UDP/8125 inbound requests':
-      proto   => 'udp',
-      dport   => 8125,
-      iniface => ['! lo', '! docker0'],
-      action  => 'drop',
-  }
-
   # Ensure that the datadog user has the right group to access docker
   user { $datadog_agent::params::dd_user:
     ensure  => present,

--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -247,7 +247,7 @@ class profile::jenkinscontroller (
     $jcasc_java_opts = ''
   }
 
-  if $jcasc_final_config['datadog'] and $jcasc_final_config['datadog']['collectBuildLogs'] {
+  if $jcasc_final_config['datadog'] {
     firewall { '901 accept datadog local metrics collection':
       proto   => 'udp',
       dport   => $datadog['metrics_collection_port'],
@@ -255,34 +255,36 @@ class profile::jenkinscontroller (
       action  => 'reject',
     }
 
-    firewall { '902 accept datadog local jenkins logs collection':
-      proto   => 'tcp',
-      dport   => $datadog['logs_collection_port'],
-      iniface => 'docker0',
-      action  => 'accept',
-    }
-
-    firewall { '903 accept datadog local trace collection':
+    firewall { '902 accept datadog local trace collection':
       proto   => 'tcp',
       dport   => $datadog['traces_collection_port'],
       iniface => 'docker0',
       action  => 'accept',
     }
 
-    file { "${datadog_agent::params::conf_dir}/jenkins.d":
-      ensure  => directory,
-      owner   => $datadog_agent::params::dd_user,
-      group   => $datadog_agent::params::dd_group,
-      mode    => '0755',
-      require => Class['datadog_agent'],
-    }
-    file { "${datadog_agent::params::conf_dir}/jenkins.d/conf.yaml":
-      ensure  => file,
-      owner   => $datadog_agent::params::dd_user,
-      group   => $datadog_agent::params::dd_group,
-      mode    => '0644',
-      require => File["${datadog_agent::params::conf_dir}/jenkins.d"],
-      content => template("${module_name}/jenkinscontroller/datadog_jenkins_conf.yaml.erb"),
+    if $jcasc_final_config['datadog']['collectBuildLogs'] {
+      firewall { '905 accept datadog local jenkins logs collection':
+        proto   => 'tcp',
+        dport   => $datadog['logs_collection_port'],
+        iniface => 'docker0',
+        action  => 'accept',
+      }
+
+      file { "${datadog_agent::params::conf_dir}/jenkins.d":
+        ensure  => directory,
+        owner   => $datadog_agent::params::dd_user,
+        group   => $datadog_agent::params::dd_group,
+        mode    => '0755',
+        require => Class['datadog_agent'],
+      }
+      file { "${datadog_agent::params::conf_dir}/jenkins.d/conf.yaml":
+        ensure  => file,
+        owner   => $datadog_agent::params::dd_user,
+        group   => $datadog_agent::params::dd_group,
+        mode    => '0644',
+        require => File["${datadog_agent::params::conf_dir}/jenkins.d"],
+        content => template("${module_name}/jenkinscontroller/datadog_jenkins_conf.yaml.erb"),
+      }
     }
   }
 

--- a/dist/profile/templates/jenkinscontroller/casc/datadog.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/datadog.yaml.erb
@@ -4,11 +4,13 @@ unclassified:
     # Select the `Datadog Agent` mode (DSD).
     reportWith: "DSD"
     # Configure the `Agent` host
-    targetHost: <%= @jcasc['datadog']['targetHost'] ? @jcasc['datadog']['targetHost'] : '127.0.0.1' %>
+    targetHost: "<%= @jcasc['datadog']['targetHost'] ? @jcasc['datadog']['targetHost'] : '127.0.0.1' %>"
     # Configure the agent port
-    targetPort: <%= @jcasc['datadog']['targetPort'] ? @jcasc['datadog']['targetPort'] : 8125 %>
+    targetPort: <%= @datadog['metrics_collection_port'] %>
     # Configure the `Traces Collection` port
-    targetTraceCollectionPort: <%= @jcasc['datadog']['targetTraceCollectionPort'] ? @jcasc['datadog']['targetTraceCollectionPort'] : 8126 %>
+    targetTraceCollectionPort: <%= @datadog['traces_collection_port'] %>
+    # Configure the `Logs Collection` port
+    targetLogCollectionPort: <%= @datadog['logs_collection_port'] %>
     # Enable CI Visibility flag
     enableCiVisibility: <%= @jcasc['datadog']['enableCiVisibility'] ? @jcasc['datadog']['enableCiVisibility'] : true %>
     # (Optional) Configure your CI Instance name

--- a/dist/profile/templates/jenkinscontroller/datadog_jenkins_conf.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/datadog_jenkins_conf.yaml.erb
@@ -1,0 +1,6 @@
+### MANAGED BY PUPPET
+logs:
+  - type: tcp
+    port: <%= @datadog['metrics_collection_port'] %>
+    service: <%= @jcasc['datadog']['host'] %>
+    source: jenkins

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -24,6 +24,9 @@ accounts:
       - sudo
 # Per-host Datadog configuration
 datadog_agent::host: "ci.jenkins.io"
+datadog_agent::non_local_traffic: true # Allow jenkins container to contact the agent for metrics
+datadog_agent::apm_enabled: true
+datadog_agent::apm_non_local_traffic: true # Allow jenkins container to contact the agent for traces and logs
 datadog_agent::agent_extra_options:
   bind_host: "0.0.0.0" # All hosts interfaces to allow container access
 profile::jenkinscontroller::anonymous_access: true
@@ -476,6 +479,9 @@ profile::jenkinscontroller::jcasc:
   datadog:
     host: "ci.jenkins.io"
     targetHost: "172.17.0.1" # docker0 interface
+    targetLogCollectionPort: 8127
+    collectBuildLogs: true
+    emitConfigChangeEvents: true
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor # Provides ANSI color in the UI when checking log outputs

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -12,6 +12,11 @@ lookup_options:
 profile::jenkinscontroller::letsencrypt: false
 # Per-host Datadog configuration
 datadog_agent::host: "vagrant.local"
+datadog_agent::non_local_traffic: true # Allow jenkins container to contact the agent for metrics
+datadog_agent::apm_enabled: true
+datadog_agent::apm_non_local_traffic: true # Allow jenkins container to contact the agent for traces and logs
+datadog_agent::agent_extra_options:
+  bind_host: "0.0.0.0" # All hosts interfaces to allow container access
 profile::jenkinscontroller::ci_fqdn: 'localhost'
 profile::jenkinscontroller::ci_resource_domain: 'assets.localhost'
 profile::jenkinscontroller::proxy_port: 443
@@ -348,6 +353,9 @@ profile::jenkinscontroller::jcasc:
     disabled: false
   datadog:
     host: "vagrant.local"
+    targetHost: "172.18.0.1" # docker0 interface in vagrant is non standard (because docker in docker)
+    collectBuildLogs: true
+    emitConfigChangeEvents: true
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3573

This PR enables the full Jenkins integration for ci.jenkins.io.

It is an "all-in-one" PR because the JCasc datadog plugin and the datadog agent plugin are pretty tied in this case.

It introduces the following changes:

- Ports for metrics, traces and logs collection are defined as top-level variable of the profile `jenkinscontroller` to allow reusability across different profiles
  - Direct consequence: the firewall definition controlling the dogstats UDP moved from profile `docker` to `jenkinscontroller`
- A few code cleanups along the way (ensuring proper owner and mode for datadog related changes, removing deprecated puppet hierdata syntaxes, YAML JCasc bgufix for datadog binding field)