### PR TITLE
feat(letsencrypt) switch crontab to a custom one (instead of the Puppet letsencrypt module)

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -19,6 +19,14 @@ class profile::letsencrypt (
     ensure => 'absent',
   }
 
+  # Custom crontab to control the renew command (absolute path, logging to var log, etc.)
+  cron { 'certbot-renew-all':
+    command => "bash -c 'date && /usr/local/bin/certbot renew' >>/var/log/certbot-renew-all.log 2>&1",
+    user    => 'root',
+    hour    => 6, # Once a day during UTC night
+    require => [Package['certbot'],Package['cron']],
+  }
+
   case $facts['os']['distro']['codename'] {
     'bionic': {
       $python_certbot_version = '3.8'

--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -22,6 +22,10 @@ class profile::letsencrypt (
   }
 
   # Custom crontab to control the renew command (absolute path, logging to var log, etc.)
+  package { 'cron':
+    ensure => installed,
+  }
+
   cron { 'certbot-renew-all':
     command => "bash -c 'date && ${certbot_bin} renew' >>/var/log/certbot-renew-all.log 2>&1",
     user    => 'root',

--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -22,15 +22,12 @@ class profile::letsencrypt (
   }
 
   # Custom crontab to control the renew command (absolute path, logging to var log, etc.)
-  package { 'cron':
-    ensure => installed,
-  }
-
+  # Package 'crontab' already installed here
   cron { 'certbot-renew-all':
     command => "bash -c 'date && ${certbot_bin} renew' >>/var/log/certbot-renew-all.log 2>&1",
     user    => 'root',
     hour    => 6, # Once a day during UTC night
-    require => [Package['certbot'],Package['cron']],
+    require => [Package['certbot']],
   }
 
   case $facts['os']['distro']['codename'] {

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -87,9 +87,6 @@ accounts:
 # Lets Encrypt settings
 letsencrypt::config::email: "tyler@monkeypox.org"
 letsencrypt::config::server: "https://acme-staging-v02.api.letsencrypt.org/directory" # Staging by default
-letsencrypt::renew_cron_ensure: "present"
-letsencrypt::renew_cron_minute: 0
-letsencrypt::renew_cron_hour: 6
 profile::letsencrypt::plugin: apache
 profile::pkgrepo::ssh_keys:
   release.ci.jenkins.io:

--- a/spec/classes/profile/letsencrypt_spec.rb
+++ b/spec/classes/profile/letsencrypt_spec.rb
@@ -25,6 +25,12 @@ describe 'profile::letsencrypt' do
       expect(subject).to contain_file('/etc/letsencrypt/azure.ini').with({
         :ensure  => 'absent',
       })
+      expect(subject).to contain_package('cron')
+      expect(subject).to contain_cron('certbot-renew-all').with({
+        :command => "bash -c 'date && /usr/local/bin/certbot renew' >>/var/log/certbot-renew-all.log 2>&1",
+        :user    => 'root',
+        :hour    => 6,
+      })
     }
   end
 

--- a/spec/classes/profile/letsencrypt_spec.rb
+++ b/spec/classes/profile/letsencrypt_spec.rb
@@ -25,7 +25,6 @@ describe 'profile::letsencrypt' do
       expect(subject).to contain_file('/etc/letsencrypt/azure.ini').with({
         :ensure  => 'absent',
       })
-      expect(subject).to contain_package('cron')
       expect(subject).to contain_cron('certbot-renew-all').with({
         :command => "bash -c 'date && /usr/local/bin/certbot renew' >>/var/log/certbot-renew-all.log 2>&1",
         :user    => 'root',


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3500

This PR switches the [Puppet Letsencrypt](https://forge.puppet.com/modules/puppet/letsencrypt/readme)'s crontab used for renewing certificates with a custom crontab rule.

The goal us is to:

- Specify an absolute path for the `certbot` command, which is specified knowing the installation method
- Log into a `/var/log/*` file the execution result (to surface errors such as in https://github.com/jenkins-infra/helpdesk/issues/3500)
- To control parameters passed to `certbot`