### PR TITLE
fixup(ci.jenkins.io) correct datadog <-> jenkins integration

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -284,6 +284,7 @@ class profile::jenkinscontroller (
         mode    => '0644',
         require => File["${datadog_agent::params::conf_dir}/jenkins.d"],
         content => template("${module_name}/jenkinscontroller/datadog_jenkins_conf.yaml.erb"),
+        notify  => Service['datadog-agent'],
       }
     }
   }

--- a/dist/profile/templates/jenkinscontroller/datadog_jenkins_conf.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/datadog_jenkins_conf.yaml.erb
@@ -1,6 +1,6 @@
 ### MANAGED BY PUPPET
 logs:
   - type: tcp
-    port: <%= @datadog['metrics_collection_port'] %>
+    port: <%= @datadog['logs_collection_port'] %>
     service: <%= @jcasc['datadog']['host'] %>
     source: jenkins

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -479,7 +479,6 @@ profile::jenkinscontroller::jcasc:
   datadog:
     host: "ci.jenkins.io"
     targetHost: "172.17.0.1" # docker0 interface
-    targetLogCollectionPort: 8127
     collectBuildLogs: true
     emitConfigChangeEvents: true
 # These are plugins we need in our ci environment


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/jenkins-infra/pull/2912 during a post-code review with @smerle33 

- There was an issue in the jenkins logger setup template. Caught with the `noop`:
The following diff should not be there (8127 is the proper port to use)
```
--- /etc/datadog-agent/conf.d/jenkins.d/conf.yaml       2023-06-21 15:40:22.422250442 +0000
+++ /tmp/puppet-file20230622-18495-13ugi92      2023-06-22 14:06:42.159713678 +0000
@@ -1,5 +1,6 @@
+### MANAGED BY PUPPET
 logs:
   - type: tcp
-    port: 8127
+    port: 8125
     service: ci.jenkins.io
     source: jenkins
```

- Removed a hieradata unused attribute
- Add a notification to restart the datadog agent when the logger config for jenkins is created/updated