### PR TITLE
Revert "fix(ci.jenkins.io): disable digital ocean during their network outage"

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -225,7 +225,7 @@ profile::jenkinscontroller::jcasc:
             cpus: 1
             memory: 1
       doks:
-        enabled: false
+        enabled: true
         provider: do
         credentialsId: "doks-jenkins-agent-sa-token"
         serverCertificate: >


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#2911 now that https://status.digitalocean.com/incidents/bclmy32d12p0 is solved.

Besides, both Digital Ocean clusters had been upgraded to Kubernetes 1.25 (as per https://github.com/jenkins-infra/helpdesk/issues/3582) 