### PR TITLE
fix(openvpn) add ports 22 and 5432 to iptables nat rules + ensure default forward policy is accept

### DIFF
--- a/hieradata/clients/vpn.jenkins.io.yaml
+++ b/hieradata/clients/vpn.jenkins.io.yaml
@@ -3,21 +3,14 @@ profile::openvpn::networks:
   eth0:
     name: Subnet 'dmz' of network 'prod-jenkins-public-prod'
     route-metric: 100
-    macaddress: 00:0d:3a:0e:4b:1c
     network_cidr: 10.0.99.0/24
   eth1:
     name: Subnet 'data-tier' of network 'prod-jenkins-public-prod'
     route-metric: 200
-    macaddress: 00:0d:3a:0e:4f:89
     network_cidr: 10.0.2.0/24
     peered_network_cidrs:
       # Network 'prod-jenkins-private-prod-vnet' through peering
       - 10.240.0.0/14
-  eth2:
-    name: Subnet 'app-tier' of network 'prod-jenkins-public-prod'
-    route-metric: 300
-    macaddress: 00:0d:3a:0e:4e:7e
-    network_cidr: 10.0.1.0/24
 profile::openvpn::vpn_network:
   name: default
   cidr: 10.8.0.0/24 # Normal VPN

--- a/hieradata/vagrant/roles/openvpn.yaml
+++ b/hieradata/vagrant/roles/openvpn.yaml
@@ -3,12 +3,10 @@ profile::openvpn::networks:
   eth0:
     name: Subnet 'dmz' of network 'prod-jenkins-public-prod'
     route-metric: 100
-    macaddress: 00:0d:3a:0e:4b:1c
     network_cidr: 172.17.0.0/24
   eth1:
     name: Subnet 'data-tier' of network 'prod-jenkins-public-prod'
     route-metric: 200
-    macaddress: 00:0d:3a:0e:4f:89
     network_cidr: 192.168.0.10/24
     peered_network_cidrs:
       - 10.1.0.0/16
@@ -16,7 +14,7 @@ profile::openvpn::vpn_network:
   name: default
   cidr: 10.8.0.0/24
   # TODO: replace by a conversion from cidr
-  netmask: 255.255.254.0
+  netmask: 255.255.255.0
 
 profile::openvpn::auth_ldap_password: 's3cr3t'
 profile::openvpn::auth_ldap_url: 'ldaps://ldap'

--- a/spec/classes/profile/openvpn_spec.rb
+++ b/spec/classes/profile/openvpn_spec.rb
@@ -13,12 +13,17 @@ describe 'profile::openvpn' do
   it { expect(subject).to contain_package 'net-tools' }
 
   it { expect(subject).to contain_firewall '107 accept incoming 443 connections' }
+  it { expect(subject).to contain_firewall '107 accept incoming 22 connections' }
+  it { expect(subject).to contain_firewallchain('FORWARD:filter:IPv4').with(
+    :ensure => 'present',
+    :policy => 'accept',
+  )}
 
   # Routing from VPN networks to eth1 network
-  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.100.0/24 on ports 80/443" }
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 192.168.100.0/24 on ports 22/80/443/5432" }
 
   # Routing from VPN networks to eth1 peered networks
-  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 10.0.0.0/16 on ports 80/443" }
+  it { expect(subject).to contain_firewall "100 allow routing from 127.0.10.0/24 to 10.0.0.0/16 on ports 22/80/443/5432" }
   it { expect(subject).to contain_exec "addroute 10.0.0.0 through 192.168.100.1 (NIC eth1)" }
 
   # Disable network config in cloud-init if there is more than two network interfaces


### PR DESCRIPTION
While [upgrading Ubuntu to 22.04](https://github.com/jenkins-infra/helpdesk/issues/2982#issuecomment-1604546958) on vpn.jenkins.io, the routing from VPN network (`10.0.8.0/24`) to the ci.jenkins.io / cert.ci.jenkins.io network (`10.0.2.0/24`) was broken.

This PR follows up https://github.com/jenkins-infra/docker-openvpn/pull/283 (applied in #2921) and fixes the following elements:

- Ensure the default FORWARD policy is `accept` in iptables (fixed manually on the VM with the command `iptables --policy FORWARD ACCEPT`) otherwise no packet are forwarded between networks
  - With Ubuntu 18.04, this setting was not blocking packages but I don't understand why. I guess iptables version in Ubuntu 22.04 is stricter with rules order.
- Ensure the (now unused, because we are migrating to `public-vnet`) network `10.0.1.0/24` is not set up. The network interface was removed from the VM manually in Azure
- Fix the `10.0.8.0` netmask which was not `/24` (same as https://github.com/jenkins-infra/docker-openvpn/pull/283)
- Since recent iptables is stricter, explicitly allow ports 22 and 5432 when crossing networks from VPN nets