### PR TITLE
tests(Vagrant) fix vagrant for ubuntu 22.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,9 +41,9 @@ Vagrant.configure("2") do |config|
                 puppet.environment = "vagrant"
                 puppet.facter = {
                     "vagrant"    => "1",
-                    "veggie"     => "veggie",
-                    "clientcert" => "veggie",
-                    "hiera_role" => "veggie",
+                    "veggie"     => veggie,
+                    "clientcert" => veggie,
+                    "hiera_role" => veggie,
                 }
                 puppet.working_directory = "/vagrant"
                 puppet.manifests_path = "manifests"

--- a/vagrant-docker/Dockerfile
+++ b/vagrant-docker/Dockerfile
@@ -60,11 +60,12 @@ RUN chmod 600 /home/vagrant/.ssh/authorized_keys \
 # Install the puppet agent
 # hadolint ignore=DL3008,DL3059
 RUN package_path=/tmp/puppetrelease.deb \
-  && curl --silent --show-error --location --output "${package_path}" "http://apt.puppetlabs.com/puppet6-release-$(grep UBUNTU_CODENAME /etc/os-release | cut -d= -f2).deb" \
+  # Use focal even if we are in jammy as there are no puppet agent package for 6.x
+  && curl --silent --show-error --location --output "${package_path}" "http://apt.puppetlabs.com/puppet6-release-focal.deb" \
   && dpkg -i "${package_path}" \
   && rm -f /tmp/puppetrelease.deb \
   && apt-get update --quiet \
-  && apt-get install --no-install-recommends --yes --quiet puppet \
+  && apt-get install --no-install-recommends --yes --quiet puppet-agent=6.* \
   && apt-get clean \
   && rm -Rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
As part of https://github.com/jenkins-infra/helpdesk/issues/2982#issuecomment-1604546958, the default Ubuntu distribution used for tests was upgraded in #2920 which broke the Vagrant local test system.

This PR ensures that Vagrant system works, at least on the `openvpn` Hiera role (to allow partial testing of #2922) with the following changes:

- Install puppet agent 6.x from `focal` (Ubuntu 20.04`) Puppetlabs's APT channel instead of `jammy` (22.04) because their Jammy channel only provides 7.y.
- Fix an bug we had since some months with Vagrnat not loding the proper hieradata roles: we were setting the `hiera_role` to the litteral string `veggie` string while we would have wanted the "value of the `veggie` variable".