### PR TITLE
feat(ci.jenkins.io) switch azure-vm agents to inbound mode in the new public-vnet network

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -49,7 +49,7 @@ x-inbound-agent-init-shell-script: &InboundAgentInitShellScript
   - "#!/bin/bash"
   - "set -eux"
   - "systemctl stop datadog-agent.service"
-  - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAsWqyLkQWkd97Rot0v3lWTaiHtWcXZfJP8ur8923TUIhZhjpjlrFGBRW8mohqYkscGA0vbimrBAswpFqxBilGAWrJVOfghBvO+SigkpT0hWVTktDzLdflwllMWnUI+/Cwsx/RMTKGjyv+EuFv0snGalqq5kUhUGanGNh2BNdykW+x3/BvJ793z1UzVGVTScXcldaSaY8LtlT4H5iyU9IutDWnRbd9tbDx+h5aWT9TRyZWVZ8dLCKbLkHn7YwmoubBnB8qQBkuSXB2iQSXbZh6MhtLbz+ZTcIeM/Tf4VT5GpNxNpV87rb62Bq4pq/kcF4M67YfSYsQlUDk1dlmq5bBxzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBATsYfp1P1bBgzXdFTPffQugDC29FFXkX08E9VHb2A1K5vYBMVouzvW1btpI6s6HuNvWCQ5U3XAKR9yV4GGVZR5N7Q=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+  - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAT9BWfs3enI0U6WkDGdAiqBe4xpFm+0qeJWiWWScrMxVXuNGHkxIdWSuMCiNUH9VhZ6R4KWFJ6Tu+YO/NIHbrx11mP8H1tmkRCZvTcoT6kfoL9UIQR/KLFE2beR/yD9yeE17WfDDNwYhKH4guT5W6jAW2TJhf0Dxd1Te7xHWeKUFRTYO0oqttB2nerVtXR/VngXi5VaX2Fy7BSoS0XS9Xfm9gmH7+vbvhe2P0r8MzgwxQLC9Flnm82O5J4hJJOQAd3az2O2gE3OtcLc+DWssGWyD0qOto2Uddc+1yntziGvb/9fTATXBzhCyHjOMxCYBNTw2tU9TNzuxye0XVzrgflzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBSiIfcfze71H2k0BDT05uHgDAgYKkTv2zyhDZV15MEhUWyKxcJoeFyOb/QGKr2BZwNGibGL+hYDYd3bTodvl9XvV8=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
   - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
   - "mkdir -p /var/log/datadog /etc/datadog-agent"
   - "chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml"
@@ -61,7 +61,7 @@ x-inbound-agent-init-shell-script: &InboundAgentInitShellScript
 # Non functionnal key used to factorize code with a YAML anchor
 x-inbound-agent-init-powershell-script: &InboundAgentInitPowershellScript
   - "# Setup datadog"
-  - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAVZLKxJjFL5KJ0S9Wixn+A2WqMMoYcbMLQ8KifFzIFZUFTWd0qYFlfi6+FOr/XMGIORFuSI+gI9hCob/0uljrJpu87/IrLPMHqofAb363iqnwulpIdf/LOF/oUEQrJQNCfwxT3rHSUy5LJ49wT/lB+IN6ZUvLpsvmgC0eHHWYFFrYomXl8u0GLT4TRXra1FR5yOGgkgMAb+N9nWkqLpBHUYNfz9AYXhOo+iblHRXpqDWG3WNBkNlK8GMhl0GoA6Ajrt05ghXgD4mQ55akyGfiFk0nNRYYVX2Cy/rbd3i7Xn7PalQpVPufczencizGXZQUYnhHPHUGGD0DiE4el5KcqzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBtpyQMbwa9PN9XtXACfl60gDAZpO2yV4aIssORLxgFJEGaUleashjG/zka0x2AFJ+xOXOGdOeZXq5Rd8sgHJkUpck=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+  - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAmwMbmOSN7udvc3Wusth2Qn2KpaHjrTyU9jecbHh4Ss0n6LhaKpkIgqRWGLLBxt0CgxWWc1CWIPaCSg4C1G9NKfS1F73pCNKj9QMF7KLN8irJ7jZB5E24GTXiDlQx/3bp+cCU2o7lADWxnREuPNpovnh2iKid0S/2bSHNIZ0qvG0EY/gwVf+fIY5oQeSPcfgjqdNiXcTCoilKqj6aio+wWyxVJp5hQkY/WjvB86jHKQ+S6eiM586O40m6hYPZodNjeBsy5Xsohd7Et4nb4/6MfHBhB9MaCFJsvewTkG67YgcD+EgKiy0t3HmLLKY6nz3bK1T111j8/L40v93NsE+/CzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDalkCXPiD8NYFJ9OaqladKgDAwWTtNXSTPXKgz+6vLvs7bTLu7weBMuHqDq8gzeoMqsLmWmc04CHt1h8s7yAeSBPo=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
   - "& \"$env:ProgramFiles\\Datadog\\Datadog Agent\\bin\\agent.exe\" restart"
   - "# Setup inbound agent"
   - "$jenkinsserverurl = $args[0]"
@@ -494,7 +494,7 @@ profile::jenkinscontroller::jcasc:
               - "#!/bin/bash"
               - "set -eux"
               - echo "START CLOUDINIT"
-              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAp1EN//8Rqd5PGR3qbiLEQcU7VjkMclipg9nIMG5YNafcma1VOu1DJX1laH3pGdJHwYOqVOGsiMBZDojWhgd1IEHCI9P+9MrU9a7gog+aEsZFKi2fSpw/o/U0+tA7yDhMhSireOwi+E9rXOOojHOlVPXCOsas3V0PT9tvr7zHadSZj10d10L5uX/oNaLQXGwDnAU3AT7TRlGETEI+FP50P/IyoN5SOb+UDECfsJnQkvQAux20UaRXUXT35ECDQmULnf3BR0Zzmpbqji1Mn+aEV/8NIBAfTUfTRbzFEsVDznfB/qIOt7YBKKQwiiOy8tjIFXQN4nSNFOuJ/v8f95TDZDBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCjHiqfdYeWfOw5ydrp6+AFgDBLVhQVC2dqv5nYd9QJjxoJkoPoUARsf1J3Wycg+ZH9Daf3EGDuhoaEp79z0+ksKoo=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAfLhH0PrMFmMjRbcDQVldZXt0hWOxDOv8Tk4z8HC9H2UbhDVZT+lkyoeuDzBwBZq4XyOCTjuSMINcjuZwfpHuiKnXxrFZ+G0YtivdxO2ExqeB56FBif2qMhWN0KctO2tGLyamOMgGFsLcRd+ZU8rjzSVG/BvmifHNQkWze85yYn3UMyRhuGyLvz6ZTIqFT6bWqx11VlRXrJMVU5spLQnCESj8yzzx/5XEuVaHroxY07ZxAJ8UnhSw7rgk3DzVRm5aeyJp1lGglF42dZQNcfmRG0+9YeGd7aYtp3FBAoLpAdvh5DN9T85GCODj6teqKNfwI2TYnfawd0udxS5I52EIpjBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDC7+3ivGIova6Zk3qkmlr5gDCntWs3tYo0UZLVPb9ElrROuc0sl+CoDFQyxBuwaZFs81/BeikVhjbt1dwSxfu/Kdg=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
               - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
               - systemctl stop datadog-agent.service
               - mkdir -p /var/log/datadog /etc/datadog-agent

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -44,6 +44,51 @@ profile::jenkinscontroller::block_remote_access_api: true
 profile::jenkinscontroller::groovy_d_lock_down_jenkins: 'present'
 profile::jenkinscontroller::groovy_d_set_up_git: 'present'
 profile::jenkinscontroller::memory_limit: '30g'
+# Non functionnal key used to factorize code with a YAML anchor
+x-inbound-agent-init-shell-script: &InboundAgentInitShellScript
+  - "#!/bin/bash"
+  - "set -eux"
+  - "systemctl stop datadog-agent.service"
+  - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAsWqyLkQWkd97Rot0v3lWTaiHtWcXZfJP8ur8923TUIhZhjpjlrFGBRW8mohqYkscGA0vbimrBAswpFqxBilGAWrJVOfghBvO+SigkpT0hWVTktDzLdflwllMWnUI+/Cwsx/RMTKGjyv+EuFv0snGalqq5kUhUGanGNh2BNdykW+x3/BvJ793z1UzVGVTScXcldaSaY8LtlT4H5iyU9IutDWnRbd9tbDx+h5aWT9TRyZWVZ8dLCKbLkHn7YwmoubBnB8qQBkuSXB2iQSXbZh6MhtLbz+ZTcIeM/Tf4VT5GpNxNpV87rb62Bq4pq/kcF4M67YfSYsQlUDk1dlmq5bBxzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBATsYfp1P1bBgzXdFTPffQugDC29FFXkX08E9VHb2A1K5vYBMVouzvW1btpI6s6HuNvWCQ5U3XAKR9yV4GGVZR5N7Q=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+  - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+  - "mkdir -p /var/log/datadog /etc/datadog-agent"
+  - "chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml"
+  - "chmod 640 /etc/datadog-agent/datadog.yaml"
+  - "chown dd-agent:dd-agent /var/log/datadog"
+  - "chmod 770 /var/log/datadog"
+  - "systemctl start datadog-agent.service"
+  - "rm -f /etc/sudoers.d/90-cloud-init-users" # Remove jenkins user from admins
+# Non functionnal key used to factorize code with a YAML anchor
+x-inbound-agent-init-powershell-script: &InboundAgentInitPowershellScript
+  - "# Setup datadog"
+  - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAVZLKxJjFL5KJ0S9Wixn+A2WqMMoYcbMLQ8KifFzIFZUFTWd0qYFlfi6+FOr/XMGIORFuSI+gI9hCob/0uljrJpu87/IrLPMHqofAb363iqnwulpIdf/LOF/oUEQrJQNCfwxT3rHSUy5LJ49wT/lB+IN6ZUvLpsvmgC0eHHWYFFrYomXl8u0GLT4TRXra1FR5yOGgkgMAb+N9nWkqLpBHUYNfz9AYXhOo+iblHRXpqDWG3WNBkNlK8GMhl0GoA6Ajrt05ghXgD4mQ55akyGfiFk0nNRYYVX2Cy/rbd3i7Xn7PalQpVPufczencizGXZQUYnhHPHUGGD0DiE4el5KcqzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBtpyQMbwa9PN9XtXACfl60gDAZpO2yV4aIssORLxgFJEGaUleashjG/zka0x2AFJ+xOXOGdOeZXq5Rd8sgHJkUpck=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+  - "& \"$env:ProgramFiles\\Datadog\\Datadog Agent\\bin\\agent.exe\" restart"
+  - "# Setup inbound agent"
+  - "$jenkinsserverurl = $args[0]"
+  - "$vmname = $args[1]"
+  - "$secret = $args[2]"
+  - "# Download the service wrapper"
+  - "$wrapperExec = 'c:\\jenkins\\jenkins-agent.exe'"
+  - "$configFile = 'c:\\jenkins\\jenkins-agent.xml'"
+  - "$agentSource = $jenkinsserverurl + 'jnlpJars/agent.jar'"
+  - "mkdir C:\\jenkins"
+  - "$wc = New-Object System.Net.WebClient"
+  - "$wc.DownloadFile('https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW.NET461.exe', $wrapperExec)"
+  - "$wc.DownloadFile('https://raw.githubusercontent.com/Azure/jenkins/master/agents_scripts/jenkins-slave.exe.config', 'c:\\jenkins\\jenkins-agent.exe.config')"
+  - "$wc.DownloadFile('https://raw.githubusercontent.com/Azure/jenkins/master/agents_scripts/jenkins-slave.xml', $configFile)"
+  - "# Prepare config"
+  - "Write-Output 'Executing agent process...'"
+  - "$configExec = 'C:\\tools\\jdk-11\\bin\\java'"
+  - "$configArgs = '-jnlpUrl \"{0}/computer/{1}/jenkins-agent.jnlp\" -workDir C:\\jenkins\\workDir' -f $jenkinsserverurl, $vmname"
+  - "if ($secret) {"
+  - "    $configArgs += \" -secret `\"$secret`\"\""
+  - "}"
+  - "(Get-Content $configFile).replace('@JAVA@', $configExec) | Set-Content $configFile"
+  - "(Get-Content $configFile).replace('@ARGS@', $configArgs) | Set-Content $configFile"
+  - "(Get-Content $configFile).replace('@SLAVE_JAR_URL', $agentSource) | Set-Content $configFile"
+  - "# Install the service"
+  - "& $wrapperExec install"
+  - "& $wrapperExec start"
 profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAywKTuF4pmWjFgHZyW+wo4D5MDYRf7gVelgeLcIsZJy8t+Sw17vWA96vGIaAD2tklGILSn6snhskSYroQHkdv13gQGW1zcpP5N9wqhMOoA5nXrh9Gnb1F5JlPGlQyUxTA5gi+zjV8+B6athfjpKbkvK91RDkOPMMOkqBALp5E1xlsBpicri5Q1znik9shGPzccONvRw+wWsm0jPquoEdO1EnR17yqN60BOk1ZelY3AV9grLR6OZrRg8M6hl4JcI5SMfm9XUPB0BWQhHwZHlIW8sAmnR9aC7bsCEk16DH82V/HrBaJBYa8GiAr3LBFzy2jiNB0F/oK7XdVsN8AQyW6UjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDf4FrZNE5uqT3JiM8XUcSRgCCf8HyZFe7GPU+5puax+7Q50f+jT99rOmyBZg20AQTJeQ==]
@@ -141,7 +186,43 @@ profile::jenkinscontroller::jcasc:
         provider: "aws"
         credentialsId: "cik8s-jenkins-agent-experiments-sa-token"
         serverCertificate: >
-          ENC[PKCS7,MIIGbQYJKoZIhvcNAQcDoIIGXjCCBloCAQAxggEhMIIBHQIBAD AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAX9aUCsHRgd/0iEDHcmVLP5cyHG S1mTOHbvcioa1WTyCkNIL5usxAJc7B1ZMKd4mzMFh5lEB6qbpHFj8ZO506A+ xjy3FPHwJUjsmrsBFFfGgahlK5S6NQ3b8McxJ51d3i09kKk5CGTCr08rcULP joxkJ1EjgGLg/GVAsIRUMowiyuDPFyJbbNXpKvEV4titqmxKSzaEcfnjmOq5 swkmNwyAWebvq1kT6C2Mw4hY+Vc4T/Xx/8j5Aea/Hag8GiDtj6p1NRH7jqP6 wkRDGKQi31iAEqtFBEuvOQJGbO19XIGdUqOt3JhcMaIcBEzXuvzf/yybhToZ RELB8jE2FNnX5Z3TCCBS4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEFKbkB lnCl/XeO35dkB8V0SAggUAFaJsbppysYLenrvEtl8SslNAr9pKCdv6W3BHRW fCYtRlcGJE51d1LjcPj0avQZ4iTUXPgyoiavQvUbwvwTn10IP6FofxZFmxwE 7k87VF8knNzKpgcR8ugCH5Sp7QBXTaHVPm6xK8K8clBX57P0boZa2i2vQwxH x1G0yOET+FJ1Htu6TymzxXIdUUFQECAM7R/RxwxvdyvPt1k80sH4TC5qw/gK je5kpohnJoatdMf4D8yBqOQ8BX/KDGanT/Faep0vY9jbOCzRfkVSa/c+aY6x wb6xWEJqHKONPKactlEwGkloQ/SRZ+cAEp6KQJYOZDaNoxriTCu+qY9Cf/0O i1izlA6VCQ22Ys++1ATgcpbNxbNx3oUYPbh8/Za8B3AjQfdVSnPM9fKhbOu+ 7OI5NL+ZVbAtXgCdY55k4NSbSbHmf77wxa+yz+jmXe97U2LPJOLSLy8XUS2n 7zdX17MtbECV07MTlFX386/GJ3pWwwv1u4mOiCOMmeJbX8NMIKSoxX4fuAT0 aWPDs+zCZUvuGowpByEtEZvM4qrHwQ3eDae/HcXoDVngJRZjVU44eS5LyvIW B3xQL2+VqtH7X/v7y3cnBEMg1NhGUlk2D9mqlINSh9vI4u6ehzBHRTBdtEoU 187GFmlpapgiMuidmkvR8zto1U/cTkplVBRoev+z7hdXGA464eexBO7KD0LU 69NmoOyOEMnWUwnxFzE55goTxQaN86vCB6HzR3mK2x9L18ye1MqiD+HUZPQT cdPVjQVeh+6JoH1maEhveG8z3fkA5SHXUjTaLjJXUyUwr7qT/hTM2JRenSia eelfbcvMZe6mXP8rTcWlMFs/O5RqGHu2rxQaGPtoq+e5zdDJJmG6F7kBGKqR styJrjxiYXPySlLFEt1agIci/FdTkXgYGgv7ypTy6xnVyWs26osJYmnWmQuM a/NZ0hilJo47jJcO/sTDRPEeFdgIebW79ALv3QXHXCdkE4nuaPBppkEsdI0a RzBHprXpxX5Y6mBvMmCEUdzC4UNNfC3cSnUyY1cvUNbINw3m+/OjPJ9Eua/m 0qI2AzaT1i0nBKwQVQzmaURokI/dwtK5UrPMetwZJMbpY68FgH9sedQCa1Xt EPfmXoUiL6BOpsrKhnmP2yGJTKXlbvMXRogiExBHfeeXr+Sdx9iQ+4g69xYT hiO5Kqs/fPQ9/7alCPlwyA11vFsBbDlaLpzD2EROXyttd+G1MAg9KqBPe2Os IHQbUhmmfWOWt88yfkYxFpjUnrwjLrf/110rIE7QMYoq1UanARfFbHyzUyPf hhbIH6VQX0yjmkpQJ9ELIKLLk3X6p2ZuFFuN8F6u0RBoXPITWwrpKXszGCOh 9Rs3twovMpAKx/S6cDvwUvgGlRh+8PMkl94pgj3zhER95Z1f08tztNuFiC7H h74KW0mWSoafgPXma/alogL+eyNbeeDmwO3du8HVl7NHuXDZS52mgnRBzcOZ rVKrYaSROkhU75VHv2kLMAJYPJX9hNpOG3lkCjT4IMcOnpuvUONpKn1eLXFH OoBgq8sTIsYsPIAJZdwptEpf21MnnINhwHFvn/RYs1mFZYQyTRAJNUFlSc0Y 8xlRF9VyfRB6PwUns4/lO5SPXYRlShjNDPPQ6Pe3sGx0CN9IdP0U+1oDVD+i e3vSG2XfqeOPy0F3q5S7PmHmoSoi3QE+lAWRxvepS4lUce9rk=]
+          ENC[PKCS7,MIIGbQYJKoZIhvcNAQcDoIIGXjCCBloCAQAxggEhMIIBHQIBAD
+          AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAX9aUCsHRgd/0iEDHcmVLP5cyHG
+          S1mTOHbvcioa1WTyCkNIL5usxAJc7B1ZMKd4mzMFh5lEB6qbpHFj8ZO506A+
+          xjy3FPHwJUjsmrsBFFfGgahlK5S6NQ3b8McxJ51d3i09kKk5CGTCr08rcULP
+          joxkJ1EjgGLg/GVAsIRUMowiyuDPFyJbbNXpKvEV4titqmxKSzaEcfnjmOq5
+          swkmNwyAWebvq1kT6C2Mw4hY+Vc4T/Xx/8j5Aea/Hag8GiDtj6p1NRH7jqP6
+          wkRDGKQi31iAEqtFBEuvOQJGbO19XIGdUqOt3JhcMaIcBEzXuvzf/yybhToZ
+          RELB8jE2FNnX5Z3TCCBS4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEFKbkB
+          lnCl/XeO35dkB8V0SAggUAFaJsbppysYLenrvEtl8SslNAr9pKCdv6W3BHRW
+          fCYtRlcGJE51d1LjcPj0avQZ4iTUXPgyoiavQvUbwvwTn10IP6FofxZFmxwE
+          7k87VF8knNzKpgcR8ugCH5Sp7QBXTaHVPm6xK8K8clBX57P0boZa2i2vQwxH
+          x1G0yOET+FJ1Htu6TymzxXIdUUFQECAM7R/RxwxvdyvPt1k80sH4TC5qw/gK
+          je5kpohnJoatdMf4D8yBqOQ8BX/KDGanT/Faep0vY9jbOCzRfkVSa/c+aY6x
+          wb6xWEJqHKONPKactlEwGkloQ/SRZ+cAEp6KQJYOZDaNoxriTCu+qY9Cf/0O
+          i1izlA6VCQ22Ys++1ATgcpbNxbNx3oUYPbh8/Za8B3AjQfdVSnPM9fKhbOu+
+          7OI5NL+ZVbAtXgCdY55k4NSbSbHmf77wxa+yz+jmXe97U2LPJOLSLy8XUS2n
+          7zdX17MtbECV07MTlFX386/GJ3pWwwv1u4mOiCOMmeJbX8NMIKSoxX4fuAT0
+          aWPDs+zCZUvuGowpByEtEZvM4qrHwQ3eDae/HcXoDVngJRZjVU44eS5LyvIW
+          B3xQL2+VqtH7X/v7y3cnBEMg1NhGUlk2D9mqlINSh9vI4u6ehzBHRTBdtEoU
+          187GFmlpapgiMuidmkvR8zto1U/cTkplVBRoev+z7hdXGA464eexBO7KD0LU
+          69NmoOyOEMnWUwnxFzE55goTxQaN86vCB6HzR3mK2x9L18ye1MqiD+HUZPQT
+          cdPVjQVeh+6JoH1maEhveG8z3fkA5SHXUjTaLjJXUyUwr7qT/hTM2JRenSia
+          eelfbcvMZe6mXP8rTcWlMFs/O5RqGHu2rxQaGPtoq+e5zdDJJmG6F7kBGKqR
+          styJrjxiYXPySlLFEt1agIci/FdTkXgYGgv7ypTy6xnVyWs26osJYmnWmQuM
+          a/NZ0hilJo47jJcO/sTDRPEeFdgIebW79ALv3QXHXCdkE4nuaPBppkEsdI0a
+          RzBHprXpxX5Y6mBvMmCEUdzC4UNNfC3cSnUyY1cvUNbINw3m+/OjPJ9Eua/m
+          0qI2AzaT1i0nBKwQVQzmaURokI/dwtK5UrPMetwZJMbpY68FgH9sedQCa1Xt
+          EPfmXoUiL6BOpsrKhnmP2yGJTKXlbvMXRogiExBHfeeXr+Sdx9iQ+4g69xYT
+          hiO5Kqs/fPQ9/7alCPlwyA11vFsBbDlaLpzD2EROXyttd+G1MAg9KqBPe2Os
+          IHQbUhmmfWOWt88yfkYxFpjUnrwjLrf/110rIE7QMYoq1UanARfFbHyzUyPf
+          hhbIH6VQX0yjmkpQJ9ELIKLLk3X6p2ZuFFuN8F6u0RBoXPITWwrpKXszGCOh
+          9Rs3twovMpAKx/S6cDvwUvgGlRh+8PMkl94pgj3zhER95Z1f08tztNuFiC7H
+          h74KW0mWSoafgPXma/alogL+eyNbeeDmwO3du8HVl7NHuXDZS52mgnRBzcOZ
+          rVKrYaSROkhU75VHv2kLMAJYPJX9hNpOG3lkCjT4IMcOnpuvUONpKn1eLXFH
+          OoBgq8sTIsYsPIAJZdwptEpf21MnnINhwHFvn/RYs1mFZYQyTRAJNUFlSc0Y
+          8xlRF9VyfRB6PwUns4/lO5SPXYRlShjNDPPQ6Pe3sGx0CN9IdP0U+1oDVD+i
+          e3vSG2XfqeOPy0F3q5S7PmHmoSoi3QE+lAWRxvepS4lUce9rk=]
         defaultNamespace: jenkins-agents-experiments
         max_capacity: 345 # Max 15 workers (96 CPU / 192+ Gb) with 23 pods (4 CPU / 8G) each
         url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAqqsX9flKf0ph1t5xPw8sSHwqWS5kxPicvdb9UG3137GIv/wRAzoUxLPRnjDER3SJrN7QTFFSblCxXEXMv3OtCBZH+k0y2CX4M+eC1VUcHsEYdKdiWwzJNw8qo8W8gO4kr2raneDNhGRjmDazcPJaLLcht7gTNQSr2RQdFe0GuDEps33oMzS1/fT/YbOzfg4O6yZDC9mbg2IcryhCK7RGqhDRVTQ6DFTW1RhN2o0GdoY0k0NK46Y4zCR71NACy0PHNOL6cRnBUQfc7kCFDw8/ISFJRAihxAWAG631jHGoUh26H+gXXfoQHZppSnIuGfUCoTn52lul9zoKrc7c2GKZhzB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCXHTqrSVgZnWeEyj1rnEISgFDZ/ZoneDJR74i4SLb+hIgRDuznKj9D16zFgUOhaZZP8GIxaaAJ3ruVPlmjD5mAMAknhwfpOzRM/puRDSglpEBOZJrBvRXGwceFiv1LgnAqIw==]
@@ -151,7 +232,43 @@ profile::jenkinscontroller::jcasc:
         provider: "aws"
         credentialsId: "cik8s-jenkins-agent-bom-sa-token"
         serverCertificate: >
-          ENC[PKCS7,MIIGbQYJKoZIhvcNAQcDoIIGXjCCBloCAQAxggEhMIIBHQIBAD AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAX9aUCsHRgd/0iEDHcmVLP5cyHG S1mTOHbvcioa1WTyCkNIL5usxAJc7B1ZMKd4mzMFh5lEB6qbpHFj8ZO506A+ xjy3FPHwJUjsmrsBFFfGgahlK5S6NQ3b8McxJ51d3i09kKk5CGTCr08rcULP joxkJ1EjgGLg/GVAsIRUMowiyuDPFyJbbNXpKvEV4titqmxKSzaEcfnjmOq5 swkmNwyAWebvq1kT6C2Mw4hY+Vc4T/Xx/8j5Aea/Hag8GiDtj6p1NRH7jqP6 wkRDGKQi31iAEqtFBEuvOQJGbO19XIGdUqOt3JhcMaIcBEzXuvzf/yybhToZ RELB8jE2FNnX5Z3TCCBS4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEFKbkB lnCl/XeO35dkB8V0SAggUAFaJsbppysYLenrvEtl8SslNAr9pKCdv6W3BHRW fCYtRlcGJE51d1LjcPj0avQZ4iTUXPgyoiavQvUbwvwTn10IP6FofxZFmxwE 7k87VF8knNzKpgcR8ugCH5Sp7QBXTaHVPm6xK8K8clBX57P0boZa2i2vQwxH x1G0yOET+FJ1Htu6TymzxXIdUUFQECAM7R/RxwxvdyvPt1k80sH4TC5qw/gK je5kpohnJoatdMf4D8yBqOQ8BX/KDGanT/Faep0vY9jbOCzRfkVSa/c+aY6x wb6xWEJqHKONPKactlEwGkloQ/SRZ+cAEp6KQJYOZDaNoxriTCu+qY9Cf/0O i1izlA6VCQ22Ys++1ATgcpbNxbNx3oUYPbh8/Za8B3AjQfdVSnPM9fKhbOu+ 7OI5NL+ZVbAtXgCdY55k4NSbSbHmf77wxa+yz+jmXe97U2LPJOLSLy8XUS2n 7zdX17MtbECV07MTlFX386/GJ3pWwwv1u4mOiCOMmeJbX8NMIKSoxX4fuAT0 aWPDs+zCZUvuGowpByEtEZvM4qrHwQ3eDae/HcXoDVngJRZjVU44eS5LyvIW B3xQL2+VqtH7X/v7y3cnBEMg1NhGUlk2D9mqlINSh9vI4u6ehzBHRTBdtEoU 187GFmlpapgiMuidmkvR8zto1U/cTkplVBRoev+z7hdXGA464eexBO7KD0LU 69NmoOyOEMnWUwnxFzE55goTxQaN86vCB6HzR3mK2x9L18ye1MqiD+HUZPQT cdPVjQVeh+6JoH1maEhveG8z3fkA5SHXUjTaLjJXUyUwr7qT/hTM2JRenSia eelfbcvMZe6mXP8rTcWlMFs/O5RqGHu2rxQaGPtoq+e5zdDJJmG6F7kBGKqR styJrjxiYXPySlLFEt1agIci/FdTkXgYGgv7ypTy6xnVyWs26osJYmnWmQuM a/NZ0hilJo47jJcO/sTDRPEeFdgIebW79ALv3QXHXCdkE4nuaPBppkEsdI0a RzBHprXpxX5Y6mBvMmCEUdzC4UNNfC3cSnUyY1cvUNbINw3m+/OjPJ9Eua/m 0qI2AzaT1i0nBKwQVQzmaURokI/dwtK5UrPMetwZJMbpY68FgH9sedQCa1Xt EPfmXoUiL6BOpsrKhnmP2yGJTKXlbvMXRogiExBHfeeXr+Sdx9iQ+4g69xYT hiO5Kqs/fPQ9/7alCPlwyA11vFsBbDlaLpzD2EROXyttd+G1MAg9KqBPe2Os IHQbUhmmfWOWt88yfkYxFpjUnrwjLrf/110rIE7QMYoq1UanARfFbHyzUyPf hhbIH6VQX0yjmkpQJ9ELIKLLk3X6p2ZuFFuN8F6u0RBoXPITWwrpKXszGCOh 9Rs3twovMpAKx/S6cDvwUvgGlRh+8PMkl94pgj3zhER95Z1f08tztNuFiC7H h74KW0mWSoafgPXma/alogL+eyNbeeDmwO3du8HVl7NHuXDZS52mgnRBzcOZ rVKrYaSROkhU75VHv2kLMAJYPJX9hNpOG3lkCjT4IMcOnpuvUONpKn1eLXFH OoBgq8sTIsYsPIAJZdwptEpf21MnnINhwHFvn/RYs1mFZYQyTRAJNUFlSc0Y 8xlRF9VyfRB6PwUns4/lO5SPXYRlShjNDPPQ6Pe3sGx0CN9IdP0U+1oDVD+i e3vSG2XfqeOPy0F3q5S7PmHmoSoi3QE+lAWRxvepS4lUce9rk=]
+          ENC[PKCS7,MIIGbQYJKoZIhvcNAQcDoIIGXjCCBloCAQAxggEhMIIBHQIBAD
+          AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAX9aUCsHRgd/0iEDHcmVLP5cyHG
+          S1mTOHbvcioa1WTyCkNIL5usxAJc7B1ZMKd4mzMFh5lEB6qbpHFj8ZO506A+
+          xjy3FPHwJUjsmrsBFFfGgahlK5S6NQ3b8McxJ51d3i09kKk5CGTCr08rcULP
+          joxkJ1EjgGLg/GVAsIRUMowiyuDPFyJbbNXpKvEV4titqmxKSzaEcfnjmOq5
+          swkmNwyAWebvq1kT6C2Mw4hY+Vc4T/Xx/8j5Aea/Hag8GiDtj6p1NRH7jqP6
+          wkRDGKQi31iAEqtFBEuvOQJGbO19XIGdUqOt3JhcMaIcBEzXuvzf/yybhToZ
+          RELB8jE2FNnX5Z3TCCBS4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEFKbkB
+          lnCl/XeO35dkB8V0SAggUAFaJsbppysYLenrvEtl8SslNAr9pKCdv6W3BHRW
+          fCYtRlcGJE51d1LjcPj0avQZ4iTUXPgyoiavQvUbwvwTn10IP6FofxZFmxwE
+          7k87VF8knNzKpgcR8ugCH5Sp7QBXTaHVPm6xK8K8clBX57P0boZa2i2vQwxH
+          x1G0yOET+FJ1Htu6TymzxXIdUUFQECAM7R/RxwxvdyvPt1k80sH4TC5qw/gK
+          je5kpohnJoatdMf4D8yBqOQ8BX/KDGanT/Faep0vY9jbOCzRfkVSa/c+aY6x
+          wb6xWEJqHKONPKactlEwGkloQ/SRZ+cAEp6KQJYOZDaNoxriTCu+qY9Cf/0O
+          i1izlA6VCQ22Ys++1ATgcpbNxbNx3oUYPbh8/Za8B3AjQfdVSnPM9fKhbOu+
+          7OI5NL+ZVbAtXgCdY55k4NSbSbHmf77wxa+yz+jmXe97U2LPJOLSLy8XUS2n
+          7zdX17MtbECV07MTlFX386/GJ3pWwwv1u4mOiCOMmeJbX8NMIKSoxX4fuAT0
+          aWPDs+zCZUvuGowpByEtEZvM4qrHwQ3eDae/HcXoDVngJRZjVU44eS5LyvIW
+          B3xQL2+VqtH7X/v7y3cnBEMg1NhGUlk2D9mqlINSh9vI4u6ehzBHRTBdtEoU
+          187GFmlpapgiMuidmkvR8zto1U/cTkplVBRoev+z7hdXGA464eexBO7KD0LU
+          69NmoOyOEMnWUwnxFzE55goTxQaN86vCB6HzR3mK2x9L18ye1MqiD+HUZPQT
+          cdPVjQVeh+6JoH1maEhveG8z3fkA5SHXUjTaLjJXUyUwr7qT/hTM2JRenSia
+          eelfbcvMZe6mXP8rTcWlMFs/O5RqGHu2rxQaGPtoq+e5zdDJJmG6F7kBGKqR
+          styJrjxiYXPySlLFEt1agIci/FdTkXgYGgv7ypTy6xnVyWs26osJYmnWmQuM
+          a/NZ0hilJo47jJcO/sTDRPEeFdgIebW79ALv3QXHXCdkE4nuaPBppkEsdI0a
+          RzBHprXpxX5Y6mBvMmCEUdzC4UNNfC3cSnUyY1cvUNbINw3m+/OjPJ9Eua/m
+          0qI2AzaT1i0nBKwQVQzmaURokI/dwtK5UrPMetwZJMbpY68FgH9sedQCa1Xt
+          EPfmXoUiL6BOpsrKhnmP2yGJTKXlbvMXRogiExBHfeeXr+Sdx9iQ+4g69xYT
+          hiO5Kqs/fPQ9/7alCPlwyA11vFsBbDlaLpzD2EROXyttd+G1MAg9KqBPe2Os
+          IHQbUhmmfWOWt88yfkYxFpjUnrwjLrf/110rIE7QMYoq1UanARfFbHyzUyPf
+          hhbIH6VQX0yjmkpQJ9ELIKLLk3X6p2ZuFFuN8F6u0RBoXPITWwrpKXszGCOh
+          9Rs3twovMpAKx/S6cDvwUvgGlRh+8PMkl94pgj3zhER95Z1f08tztNuFiC7H
+          h74KW0mWSoafgPXma/alogL+eyNbeeDmwO3du8HVl7NHuXDZS52mgnRBzcOZ
+          rVKrYaSROkhU75VHv2kLMAJYPJX9hNpOG3lkCjT4IMcOnpuvUONpKn1eLXFH
+          OoBgq8sTIsYsPIAJZdwptEpf21MnnINhwHFvn/RYs1mFZYQyTRAJNUFlSc0Y
+          8xlRF9VyfRB6PwUns4/lO5SPXYRlShjNDPPQ6Pe3sGx0CN9IdP0U+1oDVD+i
+          e3vSG2XfqeOPy0F3q5S7PmHmoSoi3QE+lAWRxvepS4lUce9rk=]
         defaultNamespace: jenkins-agents-bom
         max_capacity: 150 # Max 50 workers (16 CPU / 32 G) with 3 pods (4 CPU / 8G) each
         url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAqqsX9flKf0ph1t5xPw8sSHwqWS5kxPicvdb9UG3137GIv/wRAzoUxLPRnjDER3SJrN7QTFFSblCxXEXMv3OtCBZH+k0y2CX4M+eC1VUcHsEYdKdiWwzJNw8qo8W8gO4kr2raneDNhGRjmDazcPJaLLcht7gTNQSr2RQdFe0GuDEps33oMzS1/fT/YbOzfg4O6yZDC9mbg2IcryhCK7RGqhDRVTQ6DFTW1RhN2o0GdoY0k0NK46Y4zCR71NACy0PHNOL6cRnBUQfc7kCFDw8/ISFJRAihxAWAG631jHGoUh26H+gXXfoQHZppSnIuGfUCoTn52lul9zoKrc7c2GKZhzB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCXHTqrSVgZnWeEyj1rnEISgFDZ/ZoneDJR74i4SLb+hIgRDuznKj9D16zFgUOhaZZP8GIxaaAJ3ruVPlmjD5mAMAknhwfpOzRM/puRDSglpEBOZJrBvRXGwceFiv1LgnAqIw==]
@@ -174,7 +291,43 @@ profile::jenkinscontroller::jcasc:
         provider: "aws"
         credentialsId: "cik8s-jenkins-agent-sa-token"
         serverCertificate: >
-          ENC[PKCS7,MIIGbQYJKoZIhvcNAQcDoIIGXjCCBloCAQAxggEhMIIBHQIBAD AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAcFUGHAIS1cpW02YiIr2tRulEaU v995kpm6nnpadSQ31RABPU/0mTfU2VOgDUp2Grp7rma9LeB99js026jWXE+w RXcHBqZ3RNNvGwkB+KfWSU1Hh5EjEHf6eidRF19p4cslUsgzpIOOhcVL38yQ yI8i34MWK86SqPSgKhLR8uQCVLP1KrE4bGmFpmCcr9tcz3Dx/H6AwdtBB+WD GNtwDzMull6hhbG3nYsOLR0TubrlhWELsllcGr2M6nm3tV2piAWBI3tzPTt+ O+9oaooN3bg+e2o4GByYv/HOCz3/XHEvbhOB6TdgLnAjIOLbxSaykDX6SH0m n6xai/5iPe/xomBzCCBS4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEIYZ18 W3Pz+u19GzkACsk/aAggUAF1Ao6HaPYQSJr5QVBOfMjaWOe3VladmtNm4OWe sStevMm0lmmdGNxXQs941SybIqJ7l05Y4QG3tZLucInjH04AzyLdlA8kI/8/ ErmOA/T2QBuN2twP8f1kv74XLPTHAOI4jEJ6c31KsNHkXe9YO6obdFx2xoZ8 dC5aJqeFbf7Xc296Lpdw6YXPOALqSd3HoBn3O4df2KtTf8L8dxryRgJOL5bR An1WsC9R0+hcZgmxo9sFvpnBZcBemJxuVQI7AcM/fY686Kl657OLmnCnK8QY aSP9fCu1lJdY+R2Wna7LD3iOPVhYHd385xfQGgy6VDpLcJq4mKUH7zZBA2ad RFC7rJJ5oE+FyjWnmIxhmV5E3f6pn3WIjuxGXZRv16teml7EaZntmFNVDOxK laRN39tkTxciH+dKMZ7hftK91RHexDv4xuxZdvU/uPUhgIhA6UwBrII/srjd aH+GBD1dmrJBCW5Glxbt8pC34Jbp/4w9yLF5np0OfnnqfUa8I1hKqXnkL/x4 QmzG5yx9tc/s1EjO6NKfkgdwnUk84Hgu2LeEkcRYXX3ytsVnPReZDUCQ49k3 UaT6Xy09WVHNB5LIjMnlMaYfIaXuC4mWC2b01SGjkc+BvfPmQ4QQ/60aejJW sDGdo+qZDK6U/Y5uUr9Gkyv+5stuQC/yUfQsexwra4w1pZilVXO3X+BpG52l kHzdkBnjjeOwRoTCKfvtVluB9nIYwLFuhpAiC9oLmLRZLY2dB7ED+nMIFDFT KnOs2HuwNQBCrC6Bt7ilSxBhc5aV4z2iUgne92JcAnDqlTOFGGsb6wN7vvvm V5q7w4yai4X1LJZK0JjuHYLtMQVvUALpOZdrB5BNwUQ5L2FrUhGGb+A1U1mQ H5VYGUMaInj8XlsU95HQ8loDzXHZUVD4uctDiLCpYJz2WntgrQuzgsrseF/h AyW71QZpp6d+u7/J8HJ1MozY9te5e35slfesoRBkWXm09iRH3D+oQGK3rXxi 9p5H0r28Odp7ghoW/sAIeYD7U8Zrky0LRx7+AoQ1lrR+SnvOk6fvFeYGZ0WG apExk5zRQBsq+QMGGCVna6Zg0+sALzzrm4GIEP9XoYin2e6/+TrZ9RLxnUzk xqn+iaYXBNFjq18Uz3mdc3NLIT2+h0S74yuD5kI9qaJEmyBWYQq0AB3iCtqL hJAN+vFstZb5Y3qyB5fcbDspUucFEuKCURyHOCfzx9HMcdnavHAASGZiWzTb 4b9SQtapb4Mzqe1kEh1/K9mwayWukRsAZ+jQnEnsbWhV7hTtLLY1zJAhCJMZ 5I5DpTm1bbx7XCoZKCtJ8qu23rj0jS30FQ71j7TkwXrZo77PEh2CC5wNSf33 6Nsmxm3NAtNmDTEi52RtjPjof+fmbdIlG15HR9o+GRmLVW+NUk9XMQwYsjcR 43Hg3rPUiXLU1efRHNxJnG45MkUlbaXKMbhLSdZ0LK1NqWJEIR91AmuZ+Fsc WGtJAiJePXBZJTCwOYzMnkPVb5jTjQt0IwBpLzoj6SmCisihKOd+kjaa9AXa JGdoooD5tZ/gVsvCDtuErNfq8APmYiA6kLnHGsU+sDERSiO7a9XTHgIaAwf4 9osZNPybZMea6pN2LIVWnnsIT3/l+3sGwvbENK2wQlzNRMVNeqPxN9Q3JPd3 X3SZurB/XDOgbP0dCujXZ5EAIp2SJLVe8DVmvCVlRVqo2YaZY=]
+          ENC[PKCS7,MIIGbQYJKoZIhvcNAQcDoIIGXjCCBloCAQAxggEhMIIBHQIBAD
+          AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAcFUGHAIS1cpW02YiIr2tRulEaU
+          v995kpm6nnpadSQ31RABPU/0mTfU2VOgDUp2Grp7rma9LeB99js026jWXE+w
+          RXcHBqZ3RNNvGwkB+KfWSU1Hh5EjEHf6eidRF19p4cslUsgzpIOOhcVL38yQ
+          yI8i34MWK86SqPSgKhLR8uQCVLP1KrE4bGmFpmCcr9tcz3Dx/H6AwdtBB+WD
+          GNtwDzMull6hhbG3nYsOLR0TubrlhWELsllcGr2M6nm3tV2piAWBI3tzPTt+
+          O+9oaooN3bg+e2o4GByYv/HOCz3/XHEvbhOB6TdgLnAjIOLbxSaykDX6SH0m
+          n6xai/5iPe/xomBzCCBS4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEIYZ18
+          W3Pz+u19GzkACsk/aAggUAF1Ao6HaPYQSJr5QVBOfMjaWOe3VladmtNm4OWe
+          sStevMm0lmmdGNxXQs941SybIqJ7l05Y4QG3tZLucInjH04AzyLdlA8kI/8/
+          ErmOA/T2QBuN2twP8f1kv74XLPTHAOI4jEJ6c31KsNHkXe9YO6obdFx2xoZ8
+          dC5aJqeFbf7Xc296Lpdw6YXPOALqSd3HoBn3O4df2KtTf8L8dxryRgJOL5bR
+          An1WsC9R0+hcZgmxo9sFvpnBZcBemJxuVQI7AcM/fY686Kl657OLmnCnK8QY
+          aSP9fCu1lJdY+R2Wna7LD3iOPVhYHd385xfQGgy6VDpLcJq4mKUH7zZBA2ad
+          RFC7rJJ5oE+FyjWnmIxhmV5E3f6pn3WIjuxGXZRv16teml7EaZntmFNVDOxK
+          laRN39tkTxciH+dKMZ7hftK91RHexDv4xuxZdvU/uPUhgIhA6UwBrII/srjd
+          aH+GBD1dmrJBCW5Glxbt8pC34Jbp/4w9yLF5np0OfnnqfUa8I1hKqXnkL/x4
+          QmzG5yx9tc/s1EjO6NKfkgdwnUk84Hgu2LeEkcRYXX3ytsVnPReZDUCQ49k3
+          UaT6Xy09WVHNB5LIjMnlMaYfIaXuC4mWC2b01SGjkc+BvfPmQ4QQ/60aejJW
+          sDGdo+qZDK6U/Y5uUr9Gkyv+5stuQC/yUfQsexwra4w1pZilVXO3X+BpG52l
+          kHzdkBnjjeOwRoTCKfvtVluB9nIYwLFuhpAiC9oLmLRZLY2dB7ED+nMIFDFT
+          KnOs2HuwNQBCrC6Bt7ilSxBhc5aV4z2iUgne92JcAnDqlTOFGGsb6wN7vvvm
+          V5q7w4yai4X1LJZK0JjuHYLtMQVvUALpOZdrB5BNwUQ5L2FrUhGGb+A1U1mQ
+          H5VYGUMaInj8XlsU95HQ8loDzXHZUVD4uctDiLCpYJz2WntgrQuzgsrseF/h
+          AyW71QZpp6d+u7/J8HJ1MozY9te5e35slfesoRBkWXm09iRH3D+oQGK3rXxi
+          9p5H0r28Odp7ghoW/sAIeYD7U8Zrky0LRx7+AoQ1lrR+SnvOk6fvFeYGZ0WG
+          apExk5zRQBsq+QMGGCVna6Zg0+sALzzrm4GIEP9XoYin2e6/+TrZ9RLxnUzk
+          xqn+iaYXBNFjq18Uz3mdc3NLIT2+h0S74yuD5kI9qaJEmyBWYQq0AB3iCtqL
+          hJAN+vFstZb5Y3qyB5fcbDspUucFEuKCURyHOCfzx9HMcdnavHAASGZiWzTb
+          4b9SQtapb4Mzqe1kEh1/K9mwayWukRsAZ+jQnEnsbWhV7hTtLLY1zJAhCJMZ
+          5I5DpTm1bbx7XCoZKCtJ8qu23rj0jS30FQ71j7TkwXrZo77PEh2CC5wNSf33
+          6Nsmxm3NAtNmDTEi52RtjPjof+fmbdIlG15HR9o+GRmLVW+NUk9XMQwYsjcR
+          43Hg3rPUiXLU1efRHNxJnG45MkUlbaXKMbhLSdZ0LK1NqWJEIR91AmuZ+Fsc
+          WGtJAiJePXBZJTCwOYzMnkPVb5jTjQt0IwBpLzoj6SmCisihKOd+kjaa9AXa
+          JGdoooD5tZ/gVsvCDtuErNfq8APmYiA6kLnHGsU+sDERSiO7a9XTHgIaAwf4
+          9osZNPybZMea6pN2LIVWnnsIT3/l+3sGwvbENK2wQlzNRMVNeqPxN9Q3JPd3
+          X3SZurB/XDOgbP0dCujXZ5EAIp2SJLVe8DVmvCVlRVqo2YaZY=]
         defaultNamespace: jenkins-agents
         max_capacity: 150 # Max 50 workers (16 CPU / 32 G) with 3 pods (4 CPU / 8G) each
         url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAtfHDatuvM+I0uDN/DYUoTelys7UPpAaoGrKYoAY9Esziae/jmhZXsR+RSleBdZPvd2UTDeQbSLxiHXffBJe9xyHYlTZOfwxx1gucSXu+QN6cdjM0b3HPkPcIJBx7Pznzub7mP13chnQJ7Z/PUv8iergEwiAtvRnnPAvDue896jtvdLkscDaE3oNu83FXP0zH0jVrdHbSI03AtT08kG1b5JMvtUUFanifixF4t4wZ/Pm4+F9nkc48/JBHtaaA5SaZl4UN7nVC3RE2gH+8/tVY9GIUZ2i2N4DlpM1jvUhJVcMzuv+r1anikpYt/EZzGcPlI0tOB+KHzaGFDYZmkeeDXzB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBPA1ILnz07T+NNUoKXWFfPgFCaTM9MFT8H37nkTIoVzhsYSakmW1/8kih425IBSQj7TGdp4fd32/vuv4MAh0l9UUlWG9b6pPg92ATbfIRqKj3leynNNxopVRfT+QkNLnjc9g==]
@@ -230,7 +383,45 @@ profile::jenkinscontroller::jcasc:
         provider: do
         credentialsId: "doks-jenkins-agent-sa-token"
         serverCertificate: >
-          ENC[PKCS7,MIIGrQYJKoZIhvcNAQcDoIIGnjCCBpoCAQAxggEhMIIBHQIBAD AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAr6k+sP7eKtXnjfgLky6TfIcFJs vgfo4wu82beaRViAIb+stBS52yhKiE0YXCH/LVbIQg8ZWWABGKlNlGM/Ow6G miEGKOlmF9SWZF+XfTqqBC5xO/wjD0lfvDacmi/nUuHsfhpQxxibMlnVSJ+p 0hcHLlkUYErg3pJj+UPf3R8ETyUh37W+dzcHlc3VRv2IYoD6Rv0zUkOGGUOt 3WVCwDDzaUQP/LRm2YTrbCXL7PZCA5+BeLnd1NxexyU0uK9EdKudYY4w8GXV oxu0QT6PClTdOPLa23mVmjfDNRXuOsJ7Y5RV+V+zV51Ut/Mb88bUNhrnBg5R 7mEjSLj2aZEFfXgzCCBW4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEJiWIA mCfHYQfHn/Lp6aQXuAggVAoecyPSgMXtEL/JYKXc2ZTg3veMFcQzuY3iBqTd liBnEN8V7/3P8E1w5rv7lgWUlzb8ccm87S7LTMho8OInEZ04TfwA92AU9MoL BO5Zue9+ZLlTa+Kk6hYtf16bX4p5nqgOxGSZVDSWqUkSFDJaIxPJEUN9fntm 9qDcYLV7IaSSj1uoki/tkhdJukOdx0raoH4iXu3EWHPwH3aMy74hbbBNCrJc w71/Y1E88xT1N9GzCPj/SkFReS3k8r5O2IQtqlg0DtcQkTvV0D6LCT6fgGgQ EiqdrAgl6MF4o7VDtiBAyrJjLQrUpCPOihLm63Tzr4HbNhp2TiWTjs1sbrNv m3qZJtDvNF+hHbEMflobZb5PYK0TkbPr6Lgc5LTLKTlpnvT3UkuG0gjxUI27 8OwO3Czgu3GKQL8qfKQf7AVHy0X5tztCjYbxgdieDia/35xxB7Yrhn5EZLSY mrA18mFArgT/Niq8GB1jb0d0tGdbqEate78c8694Yl9qWjg+2rCx9dyG1JCo uxiWYCPsQKf2xTMDf8Ib3k7VfEGy1cw/HhjDLqTyCAvRYRFPWGPuOLtHBqU4 Yfujtd0znDm6xTCX3wK3t/zmbpUA6EBI15XCEi4DzkQw6MYcn9mfCcydVAok 00muCSvu9DlSlmAH5JGDsfSnG7YAogVg4sEd7n1hX0Mdc0OTZxsf3gwQgyAK 6U84g1RYYu5add51ikIiY9MBYlUaUIE4ET43BrHxy/mj+9Y4n4WDoOS/h9OM CkpvWRW/kYp5mUllCsyvG75HpfK8lbyO5+Xue1ZrqZWF2BgIkWtc6TIeSn9B H1kRLw4DomKYobwuIrb5jugfR2ylv9YXs8Ao3YW/z2Wuits+0QLr9nzgc9s9 aLRdjazSIVC7lc89nPPkhc4ufEjyeBmNU3U1iUz9BE6c79zdA4SB7PBEpuPv oKzylyJoQDOQ9hfD5fZC3Og6bblc5+z/5qDCWSbqqLhRuuJr/NgqNppOSKnx dcc9yioyJnkjr5XbaH/bAPqqqALB6/6mWlrDC3jEkvyF7JaunfDy2O3P+9x8 Kxt+xDsfPuoA6fd3WDuzDlK1QSLhWNZ4JPgx9LbhewcVWL8SxwxpMbxoP325 QqMbKXIBz+WS7f55wWmmzSx+p/FdxBeSNeerFPpKpKNe9cM2wzyRJY7LffL3 IvB8FG0hHLFpYEFL1LPjTvdhTBfNpNUW6+nYVO4qvLdEZKOedBVUTfOaB9eK 8y/I1yGzr832E23r+KSnRCr1fpoer1mR5bPFU4Tz/pKaeaSQmov/vPq1WS/w 53bDmMcAbuNnnaLdacIPM3pomwB5/se0j/VwChAd6Tbdm4Q0tTUtFNYvnoQm twVXrc0wlh3m+5l2SwHNb/2eEr2n5C6D3S9Nkc2bEr9P8vd2fWSk5k2xpYqZ IhCgEYUVPaw6sC8LtNKcwVGxCx2mcOtPzLpaThm/sMUvu5sXN0BEfDtive/k QWmWGg4VElPOQbcTAQkXDuqXdq47FncE6JVNgCcDm+/z3442kV06IYQgt0or Tmi3+UPvTsznMvdfiUsxBbu36GQ2UpbzokBwRl+34qY9Jyk9SovHPsd+SV6Q CCiuaCDLybTilrLGeMBcBkYJ0L6H193cM3n1mF++VtYZ85nFztuqdzub4acn 96xw/pJ0oAMBH7Tt2wUpZozZ+XVF4urj6oh3WkggSHH3vbo2ooPYfcTWkqh0 sDd6xAYpzxtCpXKnBDv1W5cMXyjdxMf2knvSO9UEVLhpT3FUtL5apoYAgbqo jbvFaVW+RV5IW/]
+          ENC[PKCS7,MIIGrQYJKoZIhvcNAQcDoIIGnjCCBpoCAQAxggEhMIIBHQIBAD
+          AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAr6k+sP7eKtXnjfgLky6TfIcFJs
+          vgfo4wu82beaRViAIb+stBS52yhKiE0YXCH/LVbIQg8ZWWABGKlNlGM/Ow6G
+          miEGKOlmF9SWZF+XfTqqBC5xO/wjD0lfvDacmi/nUuHsfhpQxxibMlnVSJ+p
+          0hcHLlkUYErg3pJj+UPf3R8ETyUh37W+dzcHlc3VRv2IYoD6Rv0zUkOGGUOt
+          3WVCwDDzaUQP/LRm2YTrbCXL7PZCA5+BeLnd1NxexyU0uK9EdKudYY4w8GXV
+          oxu0QT6PClTdOPLa23mVmjfDNRXuOsJ7Y5RV+V+zV51Ut/Mb88bUNhrnBg5R
+          7mEjSLj2aZEFfXgzCCBW4GCSqGSIb3DQEHATAdBglghkgBZQMEASoEEJiWIA
+          mCfHYQfHn/Lp6aQXuAggVAoecyPSgMXtEL/JYKXc2ZTg3veMFcQzuY3iBqTd
+          liBnEN8V7/3P8E1w5rv7lgWUlzb8ccm87S7LTMho8OInEZ04TfwA92AU9MoL
+          BO5Zue9+ZLlTa+Kk6hYtf16bX4p5nqgOxGSZVDSWqUkSFDJaIxPJEUN9fntm
+          9qDcYLV7IaSSj1uoki/tkhdJukOdx0raoH4iXu3EWHPwH3aMy74hbbBNCrJc
+          w71/Y1E88xT1N9GzCPj/SkFReS3k8r5O2IQtqlg0DtcQkTvV0D6LCT6fgGgQ
+          EiqdrAgl6MF4o7VDtiBAyrJjLQrUpCPOihLm63Tzr4HbNhp2TiWTjs1sbrNv
+          m3qZJtDvNF+hHbEMflobZb5PYK0TkbPr6Lgc5LTLKTlpnvT3UkuG0gjxUI27
+          8OwO3Czgu3GKQL8qfKQf7AVHy0X5tztCjYbxgdieDia/35xxB7Yrhn5EZLSY
+          mrA18mFArgT/Niq8GB1jb0d0tGdbqEate78c8694Yl9qWjg+2rCx9dyG1JCo
+          uxiWYCPsQKf2xTMDf8Ib3k7VfEGy1cw/HhjDLqTyCAvRYRFPWGPuOLtHBqU4
+          Yfujtd0znDm6xTCX3wK3t/zmbpUA6EBI15XCEi4DzkQw6MYcn9mfCcydVAok
+          00muCSvu9DlSlmAH5JGDsfSnG7YAogVg4sEd7n1hX0Mdc0OTZxsf3gwQgyAK
+          6U84g1RYYu5add51ikIiY9MBYlUaUIE4ET43BrHxy/mj+9Y4n4WDoOS/h9OM
+          CkpvWRW/kYp5mUllCsyvG75HpfK8lbyO5+Xue1ZrqZWF2BgIkWtc6TIeSn9B
+          H1kRLw4DomKYobwuIrb5jugfR2ylv9YXs8Ao3YW/z2Wuits+0QLr9nzgc9s9
+          aLRdjazSIVC7lc89nPPkhc4ufEjyeBmNU3U1iUz9BE6c79zdA4SB7PBEpuPv
+          oKzylyJoQDOQ9hfD5fZC3Og6bblc5+z/5qDCWSbqqLhRuuJr/NgqNppOSKnx
+          dcc9yioyJnkjr5XbaH/bAPqqqALB6/6mWlrDC3jEkvyF7JaunfDy2O3P+9x8
+          Kxt+xDsfPuoA6fd3WDuzDlK1QSLhWNZ4JPgx9LbhewcVWL8SxwxpMbxoP325
+          QqMbKXIBz+WS7f55wWmmzSx+p/FdxBeSNeerFPpKpKNe9cM2wzyRJY7LffL3
+          IvB8FG0hHLFpYEFL1LPjTvdhTBfNpNUW6+nYVO4qvLdEZKOedBVUTfOaB9eK
+          8y/I1yGzr832E23r+KSnRCr1fpoer1mR5bPFU4Tz/pKaeaSQmov/vPq1WS/w
+          53bDmMcAbuNnnaLdacIPM3pomwB5/se0j/VwChAd6Tbdm4Q0tTUtFNYvnoQm
+          twVXrc0wlh3m+5l2SwHNb/2eEr2n5C6D3S9Nkc2bEr9P8vd2fWSk5k2xpYqZ
+          IhCgEYUVPaw6sC8LtNKcwVGxCx2mcOtPzLpaThm/sMUvu5sXN0BEfDtive/k
+          QWmWGg4VElPOQbcTAQkXDuqXdq47FncE6JVNgCcDm+/z3442kV06IYQgt0or
+          Tmi3+UPvTsznMvdfiUsxBbu36GQ2UpbzokBwRl+34qY9Jyk9SovHPsd+SV6Q
+          CCiuaCDLybTilrLGeMBcBkYJ0L6H193cM3n1mF++VtYZ85nFztuqdzub4acn
+          96xw/pJ0oAMBH7Tt2wUpZozZ+XVF4urj6oh3WkggSHH3vbo2ooPYfcTWkqh0
+          sDd6xAYpzxtCpXKnBDv1W5cMXyjdxMf2knvSO9UEVLhpT3FUtL5apoYAgbqo
+          jbvFaVW+RV5IW/]
         defaultNamespace: jenkins-agents
         max_capacity: 48 # Max 16 workers (16 CPU / 32 G) with 3 pods (4 CPU / 8G) each
         url: ENC[PKCS7,MIIBuQYJKoZIhvcNAQcDoIIBqjCCAaYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAc6NOxZbHKCrW0RtsyuKr+nWLkQe5373QWJyENhn2potG95WHOAMXIvptK4TVmj5+AUz05uv7rnji01I+c8RYFpdu7J3dEczLsUdCY9QMTtFngz7Z/GpXAszorvEobocOQdVWzw4Rg7jncJuNI1JfiMIA9KcVYOISuyF6VEQajb/ACcyDBeYoLD7K3V6uTDIDrChCvW0FvmYDFPhxt0TheX6AxWI/9/1DzCYdz8yvOtxiSAdXOvZ87yM58OdyRotzjRCX+5E2VhxyyJdI+myfoU3DKP1H1tAuOIBdubq8OZJaZv2SQTC/BVLTIl0Wr43kKhE3kg2UOcMUypIuGcmzvDB8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCLrMYKsCzYfbJk8jdLB+5WgFBuB88xQ38Pl6SjAdHgCJxgwm0Ty9pFtJ/5OubJ9UaKrZfQtI9HmGkzIr8wq5CWPjPQ3ZZ9r7TIJBWITnOnFQWiUODb+x79K1SXa5US343uKg==]
@@ -299,7 +490,7 @@ profile::jenkinscontroller::jcasc:
               - arm64linux
             useAsMuchAsPossible: false
             spot: true
-            userData: &BootstrapDatadogScript
+            userData:
               - "#!/bin/bash"
               - "set -eux"
               - echo "START CLOUDINIT"
@@ -316,7 +507,7 @@ profile::jenkinscontroller::jcasc:
               - echo "END CLOUDINIT"
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
-      resource_group: eastus-cijenkinsio
+      resource_group: ci-jenkins-io-ephemeral-agents
       maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
       agent_definitions:
         - name: "ubuntu-22"
@@ -324,7 +515,7 @@ profile::jenkinscontroller::jcasc:
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
           os_version: "22.04"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXcLW9OnUwAhARiFS6P8vg8YrfYj9DHXTJmXqp+U/Ytjeova0bH/C8bhEbOykV4nJLMReHrrfEu5Jx+Eg+wjfq7LGD4bkAsp3covik/lkxAEDiMACIU3mWGlgeQ+0Tf4tpEHDOlWXNiA33T+3Knr1/v4H4vQOWC63tASAUUIPys2sesrv4RilEqKTd39oT9ugsQDVhftEHbp4eaqmI9zTXpU5hvy2fpJp5F2b5o7ohNvdRsovrsbN7XWJvMxvRbg/YMK/yq3zdowBzUFqXRcmiNC7T2iV0/lNjKKJOV1j4y0VDQoMomOZ5+zrozDq44FhwtAXRHJMyHr8lhtYZth0PTBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBVFqN/yr2UmCADos0nCHO7gCC7w2deUgakcUIXAZ7Y1M+Y3+dGENY/F2cNkceceJpQhw==]
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEA1Nsg1Pm61jyGb87jWWKChYAFr5V6N3gPm3kzp9DfdL7ntn2eN+ZWUH3Q2IjfKVqM2AIubG8yopiG7fC6/6/hjkGl9HvQCEmnL6pYtxCr5c3aa/E5HUWV4NdhBS0aphW3BGK4eMuEZVtAwOsyjM2VrUQyX5j653l0TX9DSzWbRpg1b8L07yfIxyRHIwn3Os+CFRIiIEjH5/9hHLhVaX47RmoQAo4tqaVM63Jzwgwac0QYmXFjfJ9Nr0vptL9bb8mahcrlVplRgrLYJgRfyVU/5ACRLuRPphlrIubTxAZedII1hSzwPVZCc3hbRsvZT0/fUBTJNrwTKj6vtKwTIoMJszBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBC4aAckaWcMKMpLzJP6QsTGgCB22xvs2eN/1mbe8eTwtnyyIuUElyAHsmGO+z7Hycat4g==]
           location: "East US 2"
           instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
@@ -339,17 +530,17 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
-          initScript: *BootstrapDatadogScript
+          initScript: *InboundAgentInitShellScript
         - name: "ubuntu-22-arm64"
           description: "Ubuntu 22.04 LTS ARM64"
           imageDefinition: jenkins-agent-ubuntu-22.04-arm64
           os: "ubuntu"
           os_version: "22.04"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXcLW9OnUwAhARiFS6P8vg8YrfYj9DHXTJmXqp+U/Ytjeova0bH/C8bhEbOykV4nJLMReHrrfEu5Jx+Eg+wjfq7LGD4bkAsp3covik/lkxAEDiMACIU3mWGlgeQ+0Tf4tpEHDOlWXNiA33T+3Knr1/v4H4vQOWC63tASAUUIPys2sesrv4RilEqKTd39oT9ugsQDVhftEHbp4eaqmI9zTXpU5hvy2fpJp5F2b5o7ohNvdRsovrsbN7XWJvMxvRbg/YMK/yq3zdowBzUFqXRcmiNC7T2iV0/lNjKKJOV1j4y0VDQoMomOZ5+zrozDq44FhwtAXRHJMyHr8lhtYZth0PTBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBVFqN/yr2UmCADos0nCHO7gCC7w2deUgakcUIXAZ7Y1M+Y3+dGENY/F2cNkceceJpQhw==]
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXUzOSOWZy2EI9QzQS/rHOuDVVykF9iKin47MtO85BsRdLIncooCcdD/WWJizYLnTXg7SzcS6E/rHP/QML+ymHfQYYTcbnbjYQQbI5t9kLlQB49QOSKrP3elsg9j/r24sUh7fGsV354j281ADD1meMwZ4nj5aYWLVN4KIAGzqYx113PkS1I/B+5Gtl06P9Mrt9myf7SXxuya7X9M3OZR/USuGXM47nDpQN57zmpgtSrZoaQ+9h+67prX1wq1hRsWwwt6Ve9j3JHwYGnVRPaU5zUbfRMHYW0exbnl/6KJn6pLVcRwiI4l740nUgJgzWfeASk7qAEGM6eVo3BZBW2A+VzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDdbrT/4ubtoeKc07/uQk14gCCdGGZJAjSgpN30zDmrfVQkXBtIoYQ2+lr/vFStxH4VBw==]
           location: "East US 2"
           instanceType: Standard_D4pds_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
@@ -362,17 +553,17 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
-          initScript: *BootstrapDatadogScript
+          initScript: *InboundAgentInitShellScript
         - name: "ubuntu-22-highmem"
           description: "Ubuntu 22.04 LTS Highmem"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
           os_version: "22.04"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAG/Diw4+KrBubbNNGJxe7yGXyJJUSSbhWIRXcLBYGPxo14g/jsZLqyoO7yW7mN36IUnByMnBhQemcp2gGXj7x4GXBwbrABRd4UhIJMfMoAaKjFktl2FQk1YRdgBFDmCd7+FeOSn4GsCG1w/IVSpN1ezlqBdVqiMuG3RSyEByVBHvLXBQLulGp/ZsKGoJkW2gFTLnjxSbpu3fB8Y2KtiZ6RT3IlfnGS5Yfhl9vBxTcxgzvRrjK2h6QjVFSz/r+unAhpPKZ8BPlFCQta7/HF1bzWE4G7fX+rYiNtTAH3aWdOlD/okMUlhzsByIzi74VFvHREFVOkD908Gds7kzMh3qptjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDg3jrltbTU6EQUsnrJ7+VRgCCtEzUFqD1vyGyzqY4dHdJpD1CrMKnVM/JW0AT+y6573g==]
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAu0efEH9NzGrhuJpSxNZWuWwGOIeGBpsvNfNlxezGgbDjT7JFihJcHTCue/I3jG5afzT7LM+2sOlzx3X02gEAYyfIF6f87lWkyU8JwgAawBSQv4RZe9F/xPb5EIZUC1aTsV6c4i9IUbDsXnN6riJe5Cad/jhl0eE9C9s3kxugP9GHSgRsLrdBVon+VEm2VRRtdspEU3k249KY7kzUEjbxSCYFSCPW3Bq4naFRIab/DwcJcx7yYjboAaDeGwuPxCDxsSBfkz4Mv5c3xALlyIcEtjzucRVnXkX0mqpOTc4CzRJ4+2sL6GApK5CuSuU4xUdKsNzzZx5ZxfQcnBJhtLB6ejBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDAK7JsGHPsFqAY/Hjj7OEtgCDRSLKM6BQQHHKQl2PHZmx/AxHdWav7GE5z/vVyVmG8OQ==]
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
@@ -387,17 +578,17 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: false
           usePrivateIP: true
           credentialsId: "jenkinsvmagents-userpass"
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
-          initScript: *BootstrapDatadogScript
+          initScript: *InboundAgentInitShellScript
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64
           os: "windows"
           os_version: "2019"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAa3oGTsMY7PLE9o717wXQutJn5erhOYg2JV0KX1wR4JrAOBQ3d8DIdy7Uz60N/ANgEDZyrEgt2PYs51RYhtJV5OY5r7GxHecYj0fClGCkGVn+Zkz7SWLQlppK5QX3HaXFXwEXMvsn3CRZai8r2y6f0xxoVuEudih2eCxZ9ayq5CdOQYE3hXmGa6lXvpjpQTJpx1qwcyQRy/eieps4i3571pY8GYDQRkTdGKWrNpO7j59EgnEp64s+VRrSJuYHq+AqOPzA3DY8onnHCGg+uFFJ5W0ZtKDwj8hBHW8nKt7U0hURivHKbfr0S1mb9SDO5G5i/4OB6cIio6COS1pTsHbfSjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAKIIdotZJv1Gi79wx+4nFBgCCJXHclsURJelhh4ZScsLY7s1rrE+6qCUIDMOkDz7kaBw==]
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAEDWY4jm5b9+cuyyygyxro0ei9gdjlctC/r7ArLUs8poPS/TtPRjC+HToOF52ZDp9cueq1qnFFbEkh5Y0IxFwC9FMRKkdCKmst7OnjcWCd2DOfgkau8SX0Y9UwVXKswv3xHGfAVDge6KmsXo0uVemafWgflhWKOlnQ8/EZyRQiq7GdGQEYAvN8RgSH+AhqTZgYYKdMdjHeMSw8AIKsBZgVkc/mKUZDicxbAwAw290jx5SgAGw4CGvzWe4SO57LxWhst1Y80KXY3NRcfNrqFUa+t4mIFCHfNk9c+eap+cSwVTvN20Y+0ClFccFqevQP5IOrRYPwsaYfdWoiUbDTh5zJDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAtlI9ee6IQCNrI7sv/L5ungCDnUJfb1bXoY0Vf45rbG2bujlYXAIuu5I+SR/5tmAqtFg==]
           location: "East US 2"
           instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
@@ -410,18 +601,17 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
-          initScript:
-            - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAwauZAjJ4q+FlbVZP/oph6SieLs4uV84UsFXGSTZ6Jqss1+54QUo5CE0yewkAWdS7NPieofhFVLGZ80ctY1hMJKFyEm1I28tfTSO+sTl8y/viw9Osw7SjlkoJnSyjyC6Zz1y1Zcvt0hRvTYhrx1e/4xvQT8hyvS/l1YpPTwZeMIlZfcE/kwbQb//t5sOOQN/t16gIczUIs1GoCl/AxqPDugUDp4ywQpowqDdn66PjISyvdzSoFq+K9jKn77cQmO6mR6X1taQL7LG7/SZSjR971wUFJzB0AA+gOgTlsC6meoEOuufDDaO+GKNZkY5ECnFh5/WMwdUSyZ8eLN6EyHIegzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA37mrATOdrzzAq7YzIvTiogDAQ9lBBTveYMxpwbfdP9rY2qom/AIqvgraMdmde8zJ2w4ilVeR1aj0IHF80Kh++jNg=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+          initScript: *InboundAgentInitPowershellScript
         - name: "win-2022" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2022"
           imageDefinition: jenkins-agent-windows-2022-amd64
           os: "windows"
           os_version: "2022"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAa3oGTsMY7PLE9o717wXQutJn5erhOYg2JV0KX1wR4JrAOBQ3d8DIdy7Uz60N/ANgEDZyrEgt2PYs51RYhtJV5OY5r7GxHecYj0fClGCkGVn+Zkz7SWLQlppK5QX3HaXFXwEXMvsn3CRZai8r2y6f0xxoVuEudih2eCxZ9ayq5CdOQYE3hXmGa6lXvpjpQTJpx1qwcyQRy/eieps4i3571pY8GYDQRkTdGKWrNpO7j59EgnEp64s+VRrSJuYHq+AqOPzA3DY8onnHCGg+uFFJ5W0ZtKDwj8hBHW8nKt7U0hURivHKbfr0S1mb9SDO5G5i/4OB6cIio6COS1pTsHbfSjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAKIIdotZJv1Gi79wx+4nFBgCCJXHclsURJelhh4ZScsLY7s1rrE+6qCUIDMOkDz7kaBw==]
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAxqeuJ/JuJ8Z1sdTo3G/NLrcP7cYSC/m8w7+UE6Hdx3eH1aywUKjk+9nOIix9ccLvfhMNcPAqecLbkQBx2whqry/soSEMdK43Pk4yZluCtWGpfbAC3CH9CGSwMuf98T4azupZHYcttdo9ZSi1LD031G1fG7UTPFj74jMc9c+xnpF4h8zWmZLu7B4AA33bCQQfsjgcWn2vjRCL+8AcM70DH9SdPLb36RxCb1OGz4lTMhyFGMZe0cUcc8VOsg7XGUURX/m7apHghO5GN7KX02bb0tsLODbc2gJqi0YJPV17S3yijwadMGViaTCBS2cAGMKjmUO84dEUHqhMjuuARQ8JCjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAlsml6TC3ewPAJ5STsIHoggCAb2sm1Y7aJeaHEYPtIXKXlsktj2MjVoXuexTDgYPUx0w==]
           location: "East US 2"
           instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
@@ -432,12 +622,11 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
-          initScript:
-            - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAgpgVYZ4sEtsRHFfQ/08BnGI0W94lNVS0IuzpyDq9NC1vtb8uJqF3H3pm2B9nKik+cu0z8XAQfbgED+sbz9Aia5PmEibBfAcufblETKPEoQMwYtkCLUjkHGmQZXxSTfmFRumgRWWjm4tguG/3ouVoUEcZIJVviPkacejwgcXBC543AmEFvLmLxmX1m8mNGIi9yl9S6SGyAC+1VuW3E+oN36sXm1jzL0b5NHuJFF/Iso3lYa9EhYBfudyn7OwJN26CrNcQcOY9jilu1zwHAzIUDXGmCyhpfdU2AFUVDnEKpJ9blA78AWjm3w9u/SLtdgV0qsfSG47lY5nsMs9q1EqyZzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBnnHwSeC2exXv3gY4Zm2VRgDC3wSNm8xRReG3fcUMBFdX2HYo2HD8yUWXzSTq9yTZg9yGFEAfp0YDAhyWQK0LdkHY=]' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+          initScript: *InboundAgentInitPowershellScript
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -56,7 +56,7 @@ x-inbound-agent-init-shell-script: &InboundAgentInitShellScript
 # Non functionnal key used to factorize code with a YAML anchor
 x-inbound-agent-init-powershell-script: &InboundAgentInitPowershellScript
   - "# Setup datadog"
-  - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: 15c1d29da910e04b4673eda9f0607316' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+  - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
   - "& \"$env:ProgramFiles\\Datadog\\Datadog Agent\\bin\\agent.exe\" restart"
   - "# Setup inbound agent"
   - "$jenkinsserverurl = $args[0]"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -25,17 +25,65 @@ profile::jenkinscontroller::memory_limit: '14g'
 # Non functional key used to factorize code with a YAML anchor
 x-inbound-agent-init-shell-script: &InboundAgentInitShellScript
   - "#!/bin/bash"
-  - set -eux
-  - systemctl stop datadog-agent.service
-  - sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAhoDM4a7hdCAgZikQ/SE3mE3jO4zQkYkDCiDRR1zF6dOMEagx2ztsVT+Rr4c5W9mpyor4K0O5GriZVmh+zlR7icucFf9o59w/PS8ryDMNYIRMMW2wfvMKj+xz8YEeNGbNEWyg8lempPmt+zXq5zSxon/Mz8gcC8rLbxugPVawxEO48x3wL46qpA0TzilaiHPFG90/WiEmu5HCme4kDqPhg+ArYiH5n7KGZUEqv3iYYRF5GzsLe+MCCINz3Q9AKHADAOG3kcf4SWsl+mDsq+iA9GIsk1ouRdX9iiRAstPzxrDv2NJYPZRpRNgG3L9dmruAIeqtvZCf1xGGRgFSEmws7zBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBscnDbb0G00Fk3iaK2BNkZgDB7S/qP+jE2P88vv/pieLchcEROoUgd/OG2WGZm5e0p7MMi3n3EOun4Eh9sVEPCy30=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-  - sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
-  - mkdir -p /var/log/datadog /etc/datadog-agent
-  - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-  - chmod 640 /etc/datadog-agent/datadog.yaml
-  - chown dd-agent:dd-agent /var/log/datadog
-  - chmod 770 /var/log/datadog
-  - systemctl start datadog-agent.service
-  - rm -f /etc/sudoers.d/90-cloud-init-users # Remove jenkins user from admins
+  - "set -eux"
+  - "JENKINS_URL=$1"
+  - "AGENT_NAME=$2"
+  - "SECRET=$3"
+  - "export USER=jenkins"
+  - "systemctl stop datadog-agent.service"
+  - "mkdir -p /home/$USER/inbound-agent /var/log/datadog /etc/datadog-agent"
+  - "chown $USER:$USER /home/$USER/inbound-agent"
+  - "("
+  - "  cd /home/$USER/inbound-agent || exit"
+  - "  curl -O \"$JENKINS_URL/jnlpJars/agent.jar\""
+  - "  echo \"^${SECRET}\" > agent-secret"
+  - "  curl -O https://raw.githubusercontent.com/jenkinsci/azure-vm-agents-plugin/HEAD/docs/init-scripts/systemd-unit.service"
+  - "  export AGENT_URL=\"$JENKINS_URL/computer/$AGENT_NAME/jenkins-agent.jnlp\""
+  - "  envsubst < systemd-unit.service > /etc/systemd/system/jenkins-agent.service"
+  - "  rm -f systemd-unit.service"
+  - "  sudo systemctl daemon-reload"
+  - "  sudo systemctl enable jenkins-agent"
+  - "  sudo systemctl start jenkins-agent || sudo systemctl status jenkins-agent"
+  - ") |& tee /home/$USER/inbound-agent/agent-init-script.log"
+  - "sed 's/api_key:.*/api_key: SuperSecretEncryptedInProduction/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+  - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+  - "chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml"
+  - "chmod 640 /etc/datadog-agent/datadog.yaml"
+  - "chown dd-agent:dd-agent /var/log/datadog"
+  - "chmod 770 /var/log/datadog"
+  - "systemctl start datadog-agent.service"
+  - "rm -f /etc/sudoers.d/90-cloud-init-users" # Remove jenkins user from admins
+# Non functionnal key used to factorize code with a YAML anchor
+x-inbound-agent-init-powershell-script: &InboundAgentInitPowershellScript
+  - "# Setup datadog"
+  - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: 15c1d29da910e04b4673eda9f0607316' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+  - "& \"$env:ProgramFiles\\Datadog\\Datadog Agent\\bin\\agent.exe\" restart"
+  - "# Setup inbound agent"
+  - "$jenkinsserverurl = $args[0]"
+  - "$vmname = $args[1]"
+  - "$secret = $args[2]"
+  - "# Download the service wrapper"
+  - "$wrapperExec = 'c:\\jenkins\\jenkins-agent.exe'"
+  - "$configFile = 'c:\\jenkins\\jenkins-agent.xml'"
+  - "$agentSource = $jenkinsserverurl + 'jnlpJars/agent.jar'"
+  - "mkdir C:\\jenkins"
+  - "$wc = New-Object System.Net.WebClient"
+  - "$wc.DownloadFile('https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW.NET461.exe', $wrapperExec)"
+  - "$wc.DownloadFile('https://raw.githubusercontent.com/Azure/jenkins/master/agents_scripts/jenkins-slave.exe.config', 'c:\\jenkins\\jenkins-agent.exe.config')"
+  - "$wc.DownloadFile('https://raw.githubusercontent.com/Azure/jenkins/master/agents_scripts/jenkins-slave.xml', $configFile)"
+  - "# Prepare config"
+  - "Write-Output 'Executing agent process...'"
+  - "$configExec = 'C:\\tools\\jdk-11\\bin\\java'"
+  - "$configArgs = '-jnlpUrl \"{0}/computer/{1}/jenkins-agent.jnlp\" -workDir C:\\jenkins\\workDir' -f $jenkinsserverurl, $vmname"
+  - "if ($secret) {"
+  - "    $configArgs += \" -secret `\"$secret`\"\""
+  - "}"
+  - "(Get-Content $configFile).replace('@JAVA@', $configExec) | Set-Content $configFile"
+  - "(Get-Content $configFile).replace('@ARGS@', $configArgs) | Set-Content $configFile"
+  - "(Get-Content $configFile).replace('@SLAVE_JAR_URL', $agentSource) | Set-Content $configFile"
+  - "# Install the service"
+  - "& $wrapperExec install"
+  - "& $wrapperExec start"
 profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: SuperSecretThatShouldBeEncryptedInProduction
@@ -202,28 +250,32 @@ profile::jenkinscontroller::jcasc:
         # No agent definitions (to test an empty cloud)
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
-      resource_group: eastus-cijenkinsio
+      resource_group: ci-jenkins-io-ephemeral-agents
+      maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
       agent_definitions:
-        - name: "ubuntu-20"
-          description: "Ubuntu 20.04 LTS"
-          imageDefinition: jenkins-agent-ubuntu-20.04-amd64
+        - name: "ubuntu-22"
+          description: "Ubuntu 22.04 LTS"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
-          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
+          os_version: "22.04"
+          storageAccount: SuperSecretEncryptedInProduction
           location: "East US 2"
-          instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
+          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          ephemeralOSDisk: true
           architecture: amd64
           labels:
+            - ubuntu
             - java
             - linux
             - docker
             - linux-amd64
-          maxInstances: 10
+          maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
           initScript: *InboundAgentInitShellScript
         - name: "ubuntu-22-arm64"
@@ -231,87 +283,93 @@ profile::jenkinscontroller::jcasc:
           imageDefinition: jenkins-agent-ubuntu-22.04-arm64
           os: "ubuntu"
           os_version: "22.04"
-          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
+          storageAccount: SuperSecretEncryptedInProduction
           location: "East US 2"
-          instanceType: Standard_D4ps_v5 # 4 vCPUS / 16 Gb
+          instanceType: Standard_D4pds_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          ephemeralOSDisk: true
           architecture: arm64
           labels:
             - ubuntu
             - arm64docker
             - arm64linux
-          maxInstances: 80
+          maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
           initScript: *InboundAgentInitShellScript
-        - name: "ubuntu-20-highmem"
-          description: "Ubuntu 20.04 LTS Highmem"
-          imageDefinition: jenkins-agent-ubuntu-20.04-amd64
+        - name: "ubuntu-22-highmem"
+          description: "Ubuntu 22.04 LTS Highmem"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
-          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
+          os_version: "22.04"
+          storageAccount: SuperSecretEncryptedInProduction
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
           architecture: amd64
-          ephemeralOSDisk: true # Should set osDiskStorageAccountType to Standard_LRS
           labels:
+            - ubuntu
             - highmem
             - highram
             - docker-highmem
             - linux-amd64-big
-          maxInstances: 20
+          maxInstances: 50
           useAsMuchAsPossible: false
           usePrivateIP: true
           credentialsId: "jenkinsvmagents-userpass"
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
           initScript: *InboundAgentInitShellScript
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64
           os: "windows"
-          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
+          os_version: "2019"
+          storageAccount: SuperSecretEncryptedInProduction
           location: "East US 2"
-          instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
+          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          ephemeralOSDisk: true
           architecture: amd64
           labels:
             - docker-windows
-          maxInstances: 20
+            - docker-windows-2019
+            - windows
+          maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
-          spot: false
-          initScript:
-            - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretThatShouldBeEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
+          spot: true
+          initScript: *InboundAgentInitPowershellScript
         - name: "win-2022" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2022"
           imageDefinition: jenkins-agent-windows-2022-amd64
           os: "windows"
           os_version: "2022"
-          storageAccount: SuperSecretThatShouldBeEncryptedInProduction
+          storageAccount: SuperSecretEncryptedInProduction
           location: "East US 2"
-          instanceType: Standard_D4s_v3 # 4 vCPUS / 16 Gb
+          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          ephemeralOSDisk: true
           architecture: amd64
           labels:
             - docker-windows-2022
-          maxInstances: 20
-          useAsMuchAsPossible: false
+          maxInstances: 50
+          useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
-          spot: false
-          initScript:
-            - "(Get-Content C:\\ProgramData\\Datadog\\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: SuperSecretThatShouldBeEncryptedInProduction' | Set-Content C:\\ProgramData\\Datadog\\datadog.yaml"
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
+          spot: true
+          initScript: *InboundAgentInitPowershellScript
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3535 and https://github.com/jenkins-infra/helpdesk/issues/3481#issuecomment-1497021548


This PR switches ci.jenkins.io's Azure VM agents templates to inbound agent mode in the public-vnet network.

- Both changes (inbound mode + new vnet) are coupled but it's required: the inbound connection in the current (legacy network) results in "TCP connection errors" due to the network overlaps :( 
- Cleaned up the init script to:
  - Ensure it's defined before the JCasc definition, to avoid breaking anchor references when reordering JCasc agent templates (was done last month on trusted.ci, using the same trick here)
  - Made the script instructions safe: using double quotes (to avoid YAML parsing errors) and escaping of "double quote" and "back slashes" (on Windows)
  - Note that the AWS EC2 init script is kept aside. Not only we ought to remove it in another PR, but it also is NOT ready for inbound mode

- Tested the scripts on ci.jenkins.io with a test azure vm cloud manually first, both Linux and Windows
  - Then transplanted the settings to the local vagrant testing
  - Cleaned up and checked the result on the local vagrant
  - But I did NOT closed the loop due to the risks of exposing encrypted credentials
  - Hence the puppet agent is kept disabled on ci.jenkins.io: I'll run a noop first once merged + I'll check all agents and report back here