### PR TITLE
cleanup(ci.jenkins.io) remove EC2 agent template

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -489,39 +489,6 @@ profile::jenkinscontroller::jcasc:
               - default
             cpus: 1
             memory: 1
-    ec2:
-      aws-us-east-2:
-        region: us-east-2
-        credentialsId: "aws-credentials-jenkins-ci"
-        sshKeysCredentialsId: "ec2-agent-ssh"
-        agent_definitions:
-          - description: "ARM64 ubuntu 22.04"
-            maxInstances: 5
-            instanceType: A1Xlarge # 4 vCPUs / 8 Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            architecture: "arm64"
-            labels:
-              - ubuntu
-              - arm64docker
-              - arm64linux
-            useAsMuchAsPossible: false
-            spot: true
-            userData:
-              - "#!/bin/bash"
-              - "set -eux"
-              - echo "START CLOUDINIT"
-              - "sed 's/api_key:.*/api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAfLhH0PrMFmMjRbcDQVldZXt0hWOxDOv8Tk4z8HC9H2UbhDVZT+lkyoeuDzBwBZq4XyOCTjuSMINcjuZwfpHuiKnXxrFZ+G0YtivdxO2ExqeB56FBif2qMhWN0KctO2tGLyamOMgGFsLcRd+ZU8rjzSVG/BvmifHNQkWze85yYn3UMyRhuGyLvz6ZTIqFT6bWqx11VlRXrJMVU5spLQnCESj8yzzx/5XEuVaHroxY07ZxAJ8UnhSw7rgk3DzVRm5aeyJp1lGglF42dZQNcfmRG0+9YeGd7aYtp3FBAoLpAdvh5DN9T85GCODj6teqKNfwI2TYnfawd0udxS5I52EIpjBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDC7+3ivGIova6Zk3qkmlr5gDCntWs3tYo0UZLVPb9ElrROuc0sl+CoDFQyxBuwaZFs81/BeikVhjbt1dwSxfu/Kdg=]/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
-              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
-              - systemctl stop datadog-agent.service
-              - mkdir -p /var/log/datadog /etc/datadog-agent
-              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
-              - chmod 640 /etc/datadog-agent/datadog.yaml
-              - chown dd-agent:dd-agent /var/log/datadog
-              - chmod 770 /var/log/datadog
-              - systemctl start datadog-agent.service
-              - rm -f /etc/sudoers.d/90-cloud-init-users
-              - echo "END CLOUDINIT"
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
       resource_group: ci-jenkins-io-ephemeral-agents
@@ -710,7 +677,6 @@ profile::jenkinscontroller::plugins:
   - credentials-binding # Bind Jenbkins credentials to variables in jobs
   - datadog # Datadog plugin
   - docker-workflow # Provides the "withDockerContainer" pipeline keyword
-  - ec2 # AWS EC2 VM agents
   - embeddable-build-status # https://github.com/jenkins-infra/helpdesk/issues/3013
   - git # Used for... git
   - github # Provides basic GitHub integration for jobs


### PR DESCRIPTION
Since https://github.com/jenkins-infra/jenkins-infra/pull/2826, we do not need any EC2 agent at all on ci.jenkins.io as ARM64 CPUs are now handled by Azure VMs.

This PR removes last EC2 remnants managed as code.

Please note that, once applied, 2 credentials will have to be cleaned up manually from ci.jenkins.io and inside AWS console:

- `ec2-agent-ssh` 
- `aws-credentials-jenkins-ci`

Also, the EC2 plugin will have to be removed from the UI once applied
