### PR TITLE
chore(datadog): don't collect container logs from `ci.jenkins.io`

### DIFF
--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -30,6 +30,7 @@ datadog_agent::apm_enabled: true
 datadog_agent::apm_non_local_traffic: true # Allow jenkins container to contact the agent for traces and logs
 datadog_agent::agent_extra_options:
   bind_host: "0.0.0.0" # All hosts interfaces to allow container access
+datadog_agent::container_collect_all: true # Don't collect Jenkins container logs (the only container running) as we're already collecting these logs via the Datadog plugin
 profile::jenkinscontroller::anonymous_access: true
 profile::jenkinscontroller::admin_ldap_groups:
   - admins

--- a/hieradata/clients/azure.ci.jenkins.io.yaml
+++ b/hieradata/clients/azure.ci.jenkins.io.yaml
@@ -30,7 +30,7 @@ datadog_agent::apm_enabled: true
 datadog_agent::apm_non_local_traffic: true # Allow jenkins container to contact the agent for traces and logs
 datadog_agent::agent_extra_options:
   bind_host: "0.0.0.0" # All hosts interfaces to allow container access
-datadog_agent::container_collect_all: true # Don't collect Jenkins container logs (the only container running) as we're already collecting these logs via the Datadog plugin
+datadog_agent::container_collect_all: false # Don't collect Jenkins container logs (the only container running) as we're already collecting these logs via the Datadog plugin
 profile::jenkinscontroller::anonymous_access: true
 profile::jenkinscontroller::admin_ldap_groups:
   - admins


### PR DESCRIPTION
As Jenkins logs are now collected by the Datadog agent, we don't need anymore to collect them as container logs.
Since Jenkins is the only container running on ci.jenkins.io machine, this PR disable the container logs collection.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3573