### PR TITLE
chore(updatecli) fix warnings for 0.54.x

### DIFF
--- a/updatecli/weekly.d/docker-ce.yaml
+++ b/updatecli/weekly.d/docker-ce.yaml
@@ -19,6 +19,8 @@ sources:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/docker-ce-updates.sh jammy
+      environments:
+        - name: PATH
 
 conditions:
   checkIfHieradataCommonHasDockerVersionKey:

--- a/updatecli/weekly.d/jenkins-lts.yaml
+++ b/updatecli/weekly.d/jenkins-lts.yaml
@@ -29,7 +29,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::docker_image"
+      key: $.profile::jenkinscontroller::docker_image
       value: "jenkins/jenkins"
   testdockerimageExist:
     kind: dockerimage
@@ -45,8 +45,8 @@ targets:
     sourceid: jenkinsLatestLTS
     kind: yaml
     spec:
-      file: "hieradata/common.yaml"
-      key: "profile::jenkinscontroller::docker_tag"
+      file: hieradata/common.yaml
+      key: $.profile::jenkinscontroller::docker_tag
     scmid: default
 
 actions:

--- a/updatecli/weekly.d/jenkinscontroller-agents-non-packer.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents-non-packer.yaml
@@ -52,7 +52,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-webbuilder"
+      key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-webbuilder
     transformers:
       - addprefix: "jenkinsciinfra/builder@"
     scmid: default
@@ -62,7 +62,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-8-windows"
+      key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-8-windows
     transformers:
       - addprefix: "jenkinsciinfra/inbound-agent-maven:jdk8-nanoserver@"
     scmid: default
@@ -72,7 +72,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-11-windows"
+      key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-11-windows
     transformers:
       - addprefix: "jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver@"
     scmid: default
@@ -82,7 +82,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-17-windows"
+      key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-17-windows
     transformers:
       - addprefix: "jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver@"
     scmid: default
@@ -92,7 +92,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-19-windows"
+      key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-19-windows
     transformers:
       - addprefix: "jenkinsciinfra/inbound-agent-maven:jdk19-nanoserver@"
     scmid: default

--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -74,7 +74,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agents_setup.windows.osDiskSize"
+      key: $.profile::jenkinscontroller::jcasc.agents_setup.windows.osDiskSize
     scmid: default
   setAzureGalleryImageVersion:
     sourceid: packerImageVersion
@@ -82,7 +82,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version"
+      key: $.profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version
     scmid: default
   setInboundAllInOneContainerImage:
     sourceid: getLatestInboundAllInOneContainerImageX86
@@ -90,7 +90,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-all-in-one"
+      key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-all-in-one
     transformers:
       - addprefix: "jenkinsciinfra/jenkins-agent-ubuntu-22.04@"
     scmid: default
@@ -100,7 +100,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp"
+      key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp
     transformers:
       - addprefix: "jenkins/inbound-agent@"
     scmid: default

--- a/updatecli/weekly.d/jenkinscontroller-tools-jdk11.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-jdk11.yaml
@@ -41,7 +41,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.tools_default_versions.jdk11"
+      key: $.profile::jenkinscontroller::jcasc.tools_default_versions.jdk11
     scmid: default
 
 actions:

--- a/updatecli/weekly.d/jenkinscontroller-tools-jdk17.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-jdk17.yaml
@@ -41,7 +41,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.tools_default_versions.jdk17"
+      key: $.profile::jenkinscontroller::jcasc.tools_default_versions.jdk17
     scmid: default
 
 actions:

--- a/updatecli/weekly.d/jenkinscontroller-tools-jdk19.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-jdk19.yaml
@@ -41,7 +41,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.tools_default_versions.jdk19"
+      key: $.profile::jenkinscontroller::jcasc.tools_default_versions.jdk19
     scmid: default
 
 actions:

--- a/updatecli/weekly.d/jenkinscontroller-tools-jdk8.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-jdk8.yaml
@@ -41,7 +41,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.tools_default_versions.jdk8"
+      key: $.profile::jenkinscontroller::jcasc.tools_default_versions.jdk8
     scmid: default
 
 actions:

--- a/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml
@@ -18,8 +18,8 @@ sources:
     kind: yaml
     name: Retrieve the current version of the Packer images used in production
     spec:
-      file: ./hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version"
+      file: hieradata/common.yaml
+      key: $.profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version
   # Retrieving Maven from packer-images to synchronize its version across our infra
   # See https://github.com/jenkins-infra/docker-inbound-agents/issues/18
   getMavenVersionFromPackerImages:
@@ -49,7 +49,7 @@ targets:
     sourceid: getMavenVersionFromPackerImages
     spec:
       file: hieradata/common.yaml
-      key: "profile::jenkinscontroller::jcasc.tools_default_versions.maven"
+      key: $.profile::jenkinscontroller::jcasc.tools_default_versions.maven
     scmid: default
   setMavenPathFors390x:
     name: "Bump Maven path on s390x permanent agent setup"
@@ -61,7 +61,7 @@ targets:
     spec:
       files:
         - hieradata/clients/azure.ci.jenkins.io.yaml
-      key: "profile::jenkinscontroller::jcasc.permanent_agents.s390x-agent.envVars.PATH+MAVEN"
+      key: $.profile::jenkinscontroller::jcasc.permanent_agents.s390x-agent.envVars.PATH+MAVEN
     scmid: default
   setMavenToolVersionFors390x:
     name: "Bump Maven path on s390x permanent agent setup"
@@ -72,7 +72,7 @@ targets:
     spec:
       files:
         - hieradata/clients/azure.ci.jenkins.io.yaml
-      key: "profile::jenkinscontroller::jcasc.permanent_agents.s390x-agent.toolLocation[0].home"
+      key: $.profile::jenkinscontroller::jcasc.permanent_agents.s390x-agent.toolLocation[0].home
     scmid: default
 
 

--- a/updatecli/weekly.d/openvpn.yaml
+++ b/updatecli/weekly.d/openvpn.yaml
@@ -45,7 +45,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: "profile::openvpn::image_tag"
+      key: $.profile::openvpn::image_tag
     scmid: default
 
 actions:


### PR DESCRIPTION
- Remove the WARNING messages about `yaml` resources missing a `$.` prefix
- Allows running the Docker-CE process on any machine