### PR TITLE
fix: disable `artifact-manager-s3` stashes deletion on Jenkins controllers

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -47,7 +47,7 @@ class profile::jenkinscontroller (
 -Djenkins.install.runSetupWizard=false \
 -Djenkins.model.Jenkins.slaveAgentPort=50000 \
 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2 \
--Dio.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig.deleteStashes=true", # Must be Java 11 compliant!
+-Dio.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig.deleteStashes=false", # Must be Java 11 compliant!
 ) {
   include stdlib # Required to allow using stlib methods and custom datatypes
   include apache


### PR DESCRIPTION
This PR is disabling the stashes deletion by the `artifact-manager-s3` plugin, currently reporting errors for ci.jenkins.io as noted in https://github.com/jenkins-infra/helpdesk/issues/3643

As the associated storage cost is low, there is no need for immediate cleanup of stashes, it can be done outside ci.jenkins.io.
