### PR TITLE
chore: remove artifact-manager-s3 `deleteStashes` parameter as its default `false` value won't change

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -46,8 +46,7 @@ class profile::jenkinscontroller (
 -Duser.home=${container_jenkins_home} \
 -Djenkins.install.runSetupWizard=false \
 -Djenkins.model.Jenkins.slaveAgentPort=50000 \
--Dhudson.model.WorkspaceCleanupThread.retainForDays=2 \
--Dio.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig.deleteStashes=false", # Must be Java 11 compliant!
+-Dhudson.model.WorkspaceCleanupThread.retainForDays=2", # Must be Java 11 compliant!
 ) {
   include stdlib # Required to allow using stlib methods and custom datatypes
   include apache


### PR DESCRIPTION
This property can only be defined as a system property in order to discourage the deletion of artifacts and stashes from Jenkins itself cf https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/31 & https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/37

This PR removes the corresponding JVM option.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3643