### PR TITLE
feat(ci.jenkins.io) migrate ACI to a new resource group

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -555,7 +555,7 @@ profile::jenkinscontroller::jcasc:
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"
-        resource_group: eastus-cijenkinsio
+        resource_group: ci-jenkins-io-ephemeral-agents
         agent_definitions:
           - name: maven-8-windows
             os: windows

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -63,7 +63,7 @@ profile::jenkinscontroller::jcasc:
             imagePullSecrets: dockerhub-credentials
     azure-vm-agents:
       azureCredentialsId: "azure-credentials"
-      resource_group: eastus-cijenkinsio
+      resource_group: ci-jenkins-io-ephemeral-agents
       agent_definitions:
         - name: "ubuntu-20"
           description: "Ubuntu 20.04 LTS"
@@ -111,7 +111,7 @@ profile::jenkinscontroller::jcasc:
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"
-        resource_group: eastus-cijenkinsio
+        resource_group: ci-jenkins-io-ephemeral-agents
         agent_definitions:
           - name: maven-11-windows
             os: windows

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -289,7 +289,7 @@ profile::jenkinscontroller::jcasc:
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"
-        resource_group: eastus-cijenkinsio
+        resource_group: ci-jenkins-io-ephemeral-agents
         agent_definitions:
           - name: maven-8-windows
             os: windows


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3535#issuecomment-1629312380

Tested manually on ci.jenkins.io with success: the ACI setup uses public IP as for today and there are no setup specific to location.