### PR TITLE
chore: disable spot for `highmem` Azure VM agents of `ci.jenkins.io`

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -530,7 +530,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: "public-vnet"
           virtualNetworkResourceGroupName: "public"
           subnetName: "public-vnet-ci_jenkins_io_agents"
-          spot: true
+          spot: false
         - name: "win-2022" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2022"
           imageDefinition: jenkins-agent-windows-2022-amd64


### PR DESCRIPTION
Disabling spot instances for these agents mainly used for ATH and BOM builds in order to check if it changes the fact that related agents are frequently disappearing after a while.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3673