### PR TITLE
fixup: disable spot instance for `highmem` agents, not `win-2019`

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -507,7 +507,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: "public-vnet"
           virtualNetworkResourceGroupName: "public"
           subnetName: "public-vnet-ci_jenkins_io_agents"
-          spot: true
+          spot: false
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64
@@ -530,7 +530,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: "public-vnet"
           virtualNetworkResourceGroupName: "public"
           subnetName: "public-vnet-ci_jenkins_io_agents"
-          spot: false
+          spot: true
         - name: "win-2022" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2022"
           imageDefinition: jenkins-agent-windows-2022-amd64


### PR DESCRIPTION
Fixup of #2983 

Ref: https://github.com/jenkins-infra/helpdesk/issues/3673