### PR TITLE
feat(jenkinscontroller) do not use ACP for the Maven repository which ID is `central`

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>*,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local,!jitpack.io</mirrorOf>
+                  <mirrorOf>*,!central,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local,!jitpack.io</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3599#issuecomment-1653881431