### PR TITLE
feat(*.ci.jenkins.io): activate ANSI color globally

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -185,6 +185,8 @@ class profile::jenkinscontroller (
       'jenkinscontroller/casc/artifact-manager.yaml.erb',
       # Opt-in with `profile::jenkinscontroller::jcasc.datadog
       'jenkinscontroller/casc/datadog.yaml.erb',
+      # Opt-out with `profile::jenkinscontroller::jcasc.ansi_color: false`
+      'jenkinscontroller/casc/ansi-color.yaml.erb',
     ],
     config_dir => 'casc.d', # Relative to the jenkins_home
   }

--- a/dist/profile/templates/jenkinscontroller/casc/ansi-color.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/ansi-color.yaml.erb
@@ -1,0 +1,24 @@
+<%- if @jcasc['ansi_color'] && @jcasc['ansi_color']['disabled'].to_s != "true" -%>
+unclassified:
+  ansiColorBuildWrapper:
+    globalColorMapName: "xterm"
+    colorMaps:
+    - name: "xterm"
+      defaultBackground: 7 # better separation between jenkins output and pipeline output
+      black: "#000000"
+      blackB: "#4C4C4C"
+      blue: "#1E90FF"
+      blueB: "#4682B4"
+      cyan: "#00CDCD"
+      cyanB: "#00FFFF"
+      green: "#00CD00"
+      greenB: "#00FF00"
+      magenta: "#CD00CD"
+      magentaB: "#FF00FF"
+      red: "#CD0000"
+      redB: "#FF0000"
+      white: "#E5E5E5"
+      whiteB: "#FFFFFF"
+      yellow: "#CDCD00"
+      yellowB: "#FFFF00"
+<%- end -%>


### PR DESCRIPTION
This PR activates [ANSI color](https://plugins.jenkins.io/ansicolor/) globally on every *.ci.jenkins.io instance. (Opt-out for each instance possible if needed)

<details><summary>Screenshots:</summary>
(From infra.ci.jenkins.io)

### Without ANSI color:
![image](https://github.com/jenkins-infra/kubernetes-management/assets/91831478/cae06f95-2ca0-4387-a6cb-2945f4d3e372)

### With ANSI color only:
![image](https://github.com/jenkins-infra/kubernetes-management/assets/91831478/1ddafdfd-3aa6-417a-930f-cedb54ae5518)

### With ANSI color and default background set to "White":
![image](https://github.com/jenkins-infra/kubernetes-management/assets/91831478/001eee44-3af0-4aee-9908-cdcf7b3cf949)

</details>

Follow-up of https://github.com/jenkins-infra/kubernetes-management/pull/4238