### PR TITLE
feat(ci.jenkins.io) initial support of JDK21 ACI Windows 2019 agent

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -637,6 +637,14 @@ profile::jenkinscontroller::jcasc:
             agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
             labels:
               - maven-19-windows
+          - name: maven-21-windows
+            os: windows
+            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+            cpus: 4
+            memory: 8
+            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            labels:
+              - maven-21-windows
   artifact_caching_proxy:
     disabled: false
   datadog:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -244,6 +244,7 @@ profile::jenkinscontroller::jcasc:
       jnlp-maven-11-windows: jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver@sha256:02cc8013309495531eef7575a25205749da9460395224267f65b43180607cd0a
       jnlp-maven-17-windows: jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver@sha256:b3312c29f18d36341d029db9af3bb43078e13eb890d75bdd80a683443ec8394a
       jnlp-maven-19-windows: jenkinsciinfra/inbound-agent-maven:jdk19-nanoserver@sha256:5dee25723f70f77de719d24fabe27410ce9d5cba30ecd0b0da802bfa0a35107e
+      jnlp-maven-21-windows: jenkinsciinfra/inbound-agent-maven:jdk21-nanoserver # :latest (until updatecli tracks this image)
       jnlp-ruby: jenkinsciinfra/inbound-agent-ruby@sha256:221f96baa1957742728eb6d2769a691aea5721fc11ed9b05da810c5debe92115
       jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04@sha256:d2a76a445d5197d4579f51a1c24b69e97a7942a33f9fd064770c419ea2568572
       jnlp-webbuilder: jenkinsciinfra/builder@sha256:8b59fae6e558ab5da8b8c7d1b63e3ef259e0c8d5d7809ae179fe2d55584aee16


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3709, this PR adds the initial support for ACI agents (e.g. Windows containers) with Maven and JDK21 

Please note that it defines the `:latest` container image  tag (implicitly) until updatecli tracks the image (which will stick it to an `sha` digest)