### PR TITLE
breaking: switch to JDK17

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -19,7 +19,7 @@ class profile::jenkinscontroller (
   Stdlib::Fqdn $ci_fqdn                        = '',
   String $ci_resource_domain                   = '',
   String $docker_image                         = 'jenkins/jenkins',
-  String $docker_tag                           = 'lts-jdk11',
+  String $docker_tag                           = 'lts-jdk17',
   String $docker_container_name                = 'jenkins',
   Boolean $letsencrypt                         = true,
   Optional[Array] $plugins                     = undef,

--- a/dist/profile/templates/jenkinscontroller/casc/permanent-agents.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/permanent-agents.yaml.erb
@@ -14,7 +14,7 @@ jenkins:
         ssh:
           credentialsId: "<%= agent['ssh']['credentialsId'] %>"
           host: "<%= agent['ssh']['host'] %>"
-          javaPath: "<%= agent['ssh']['javaPath'] ? agent['ssh']['javaPath'] : '/opt/jdk-11/bin/java' %>"
+          javaPath: "<%= agent['ssh']['javaPath'] ? agent['ssh']['javaPath'] : '/opt/jdk-17/bin/java' %>"
           launchTimeoutSeconds: "<%= agent['ssh']['timeout'] ? agent['ssh']['timeout'] : '60' %>"
           port: "<%= agent['ssh']['port'] ? agent['ssh']['port'] : '22' %>"
           retryWaitTime: "<%= agent['ssh']['retryWaitTime'] ? agent['ssh']['retryWaitTime'] : '60' %>"

--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -32,7 +32,7 @@ profile::jenkinscontroller::ci_fqdn: 'ci.jenkins.io'
 profile::jenkinscontroller::ci_resource_domain: 'assets.ci.jenkins.io'
 profile::jenkinscontroller::letsencrypt: true
 profile::jenkinscontroller::docker_image: 'jenkins/jenkins'
-profile::jenkinscontroller::docker_tag: 'lts-jdk11'
+profile::jenkinscontroller::docker_tag: 'lts-jdk17'
 profile::jenkinscontroller::groovy_init_enabled: true
 profile::jenkinscontroller::block_remote_access_api: true
 profile::jenkinscontroller::groovy_d_lock_down_jenkins: 'present'
@@ -137,7 +137,7 @@ profile::jenkinscontroller::jcasc:
         hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIaGnnWz9Q/MvlscCUZslFxH8JJ01OQ6FXyuQMQWVuNe"
       envVars:
         PATH+MAVEN: /home/jenkins/tools/apache-maven-3.9.4/bin
-        JAVA_HOME: "/opt/jdk-11"
+        JAVA_HOME: "/opt/jdk-17"
         # For the permanent agents, we're using the artifact caching proxy on DigitalOcean (bandwith available)
         ARTIFACT_CACHING_PROXY_PROVIDER: "do"
       toolLocation:
@@ -307,7 +307,7 @@ profile::jenkinscontroller::jcasc:
             memory: 8
           - name: jnlp-maven-11
             imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-11
+            javaHome: /opt/jdk-17
             labels:
               - maven-11
               - jdk11
@@ -610,7 +610,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
             labels:
               - maven-windows
           - name: maven-11-windows
@@ -618,7 +618,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
             labels:
               - maven-11-windows
           - name: maven-17-windows
@@ -626,7 +626,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
             labels:
               - maven-17-windows
           - name: maven-19-windows
@@ -634,7 +634,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
             labels:
               - maven-19-windows
           - name: maven-21-windows
@@ -642,7 +642,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
             labels:
               - maven-21-windows
   artifact_caching_proxy:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -155,7 +155,7 @@ datadog_agent::integrations:
 docker_hub_key: |
   ENC[PKCS7,MIICCwYJKoZIhvcNAQcDoIIB/DCCAfgCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAOkIizRCPVrwnvnwibEmMCIfXFsYJQCZKqIVujP0N8IbVhVeieb41055u/MFYSmbqBXb0ummeMiZ7y9NAymAROfz32wY8IM/d005oBMp8JCbSbEGBEApDY22SL4osIk7JNJe2Ru0mhVqIP0sm412frklI1acP3575GvfCvU+JY8xszi9wT28WKT0aIO1nj8WwEET6c0xw4s3XhE99EuakWtvlqhcS+ViXc7LT/iMdWZDeObw12K+B3usOzJsX/u7eG6jr1AR/UKwIjS71qPhO59MKayAs8RoD/L5BtTWIavLSvrbIx2qn5yjQn/U1c6FSdMGAyL7SjPTYEflmvsGvkDCBzQYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQ7Foo3dyKQiNVrsMCbnYXO4CBoMjaW4RIBAkNA8Mv/ngH1vzf/dImaPkVpWVomYJ0CSktOjLt6qSPAHLIcL2pU0FAtNF/Css0kll7uhV3oUtwoIsUbz21CYVZPJs88HsZChNl6mE5Awg3MooX3OLcQHn4293rRFZOaRNGL+iA35m0fT1LUWvP/sYjrdOABVmRdFQ+J/tCBsECaqh+CMP4FztPIS8+0ZeNBbC7xxs2MvKVF18=]
 profile::jenkinscontroller::docker_image: jenkins/jenkins
-profile::jenkinscontroller::docker_tag: 2.401.3-jdk11
+profile::jenkinscontroller::docker_tag: 2.401.3-jdk17
 # WARNING: this list is not deep merged by hieradata (will be overwritten!)
 profile::jenkinscontroller::plugins:
   - workflow-aggregator
@@ -222,18 +222,18 @@ profile::jenkinscontroller::jcasc:
       remoteAdmin: Administrator
       osDiskSize: 150
       osDiskStorageAccountType: 'Premium_LRS'
-      agentJavaBin: 'C:/tools/jdk-11/bin/java'
+      agentJavaBin: 'C:/tools/jdk-17/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
-      javaHome: 'C:/tools/jdk-11' # Default JDK provided for builds when no pipeline setup exists
+      javaHome: 'C:/tools/jdk-17' # Default JDK provided for builds when no pipeline setup exists
     ubuntu:
       agentDir: "/home/jenkins/agent"
       remoteAdmin: jenkins
       tempDir: "/tmp"
       osDiskSize: 150
       osDiskStorageAccountType: 'Premium_LRS'
-      agentJavaBin: '/opt/jdk-11/bin/java'
+      agentJavaBin: '/opt/jdk-17/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
-      javaHome: '/opt/jdk-11' # Default JDK provided for builds when no pipeline setup exists
+      javaHome: '/opt/jdk-17' # Default JDK provided for builds when no pipeline setup exists
       path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
   agent_images:
     azure_vms_gallery_image:
@@ -249,7 +249,7 @@ profile::jenkinscontroller::jcasc:
       jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04@sha256:d2a76a445d5197d4579f51a1c24b69e97a7942a33f9fd064770c419ea2568572
       jnlp-webbuilder: jenkinsciinfra/builder@sha256:8b59fae6e558ab5da8b8c7d1b63e3ef259e0c8d5d7809ae179fe2d55584aee16
       # default template from the official inbound-agent image here to provide a default agent (`node()` pipeline step)
-      jnlp: jenkins/inbound-agent@sha256:ffcee0b47c65c14a8347a4af916c81e3fcf3b9fd35b64a5ae627f358265c32d8
+      jnlp: jenkins/inbound-agent@sha256:51b36a5ac5078996504ecc271aab884bbd12d44ddc33f3ecb62ca54e4c97636c # :latest-jdk17
   tools_default_versions:
     jdk8: 8u382-b05
     jdk11: 11.0.20+8

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -240,14 +240,14 @@ profile::jenkinscontroller::jcasc:
       version: 1.20.0
       subscription_id: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAluBQmOHo1MWoOCMVOCcgVUs9gOzFVEZMT7RA3V33KeolyRKh0lm5Ta5+C9aKJe9myuVGaDQsd99XsW40d7NdygJcnBxUV+VTnnLphjplPtCX5JIS4ww/S8JGOpOIE2zejy5bL2CpnZhgSFh+aD1FLD91ozNS5lgNOq9hNKqo+mSfUnX5wrUFvlCaadTWp3yxG7l7VluxP1Wh4BlsRmphmbUmmgFo56CjDUVz9dMwxT/p/uE1S/SPuEirJOAPtPCl7x2NQWg+Qlv5j1tC5ASgh9beD3SjUVPd6VYM+K+u07aw8jOj/meARXgghtUPgqHqWC44JGHPzWkZ4dQFhe6jyzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDc6VPQnQTEmwF9aAh/uK9IgDDXAM9S6QNxRH8cFSOAESeqOlLFBKVAlJc3Mnby3Pc/6H21BsehZbQLUd+1MfcoPI0=]
     container_images:
-      jnlp-maven-8-windows: jenkinsciinfra/inbound-agent-maven:jdk8-nanoserver@sha256:67ee372f5777c0bb3b01ef1f04acde15379952b3da41e83ff050c0cd63266af5
-      jnlp-maven-11-windows: jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver@sha256:b3334feeb6302e0d68a1667e0873903a3eb2c9c80fe2e39453575a903fb2a628
-      jnlp-maven-17-windows: jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver@sha256:7a74bc983d8eda2223e89f2b7ed05202705eab10134e63bb0832e39557ee4205
-      jnlp-maven-19-windows: jenkinsciinfra/inbound-agent-maven:jdk19-nanoserver@sha256:1f8dcbb7bc2832bf7cc2a905142e0b049fe6ce2e4a7b8d9e29643a90c00a3b9f
-      jnlp-maven-21-windows: jenkinsciinfra/inbound-agent-maven:jdk21-nanoserver@sha256:3f1616ec8a9319fdeacb8996f717ea754a25bd73b3e23c5524b92a995ca53885
+      jnlp-maven-8-windows: jenkinsciinfra/inbound-agent-maven:jdk8-nanoserver@sha256:5035b345fe6d772e08a913693cfc49d3abd4c6f0d8dc2a7e100fcf2d990412a8
+      jnlp-maven-11-windows: jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver@sha256:8cd89c33bfdad5402c7c965beb036fdc2b75d1582d0cdc76ab719515a6b30abf
+      jnlp-maven-17-windows: jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver@sha256:5a1b6230ed17c082ee076d20287f7979b90927d4edac8f44117fb4582e47666d
+      jnlp-maven-19-windows: jenkinsciinfra/inbound-agent-maven:jdk19-nanoserver@sha256:f802888c3ca5a58dd45e07eee8a25fdfaf3c46b83f4fabe33b2e4d03a9cf24c8
+      jnlp-maven-21-windows: jenkinsciinfra/inbound-agent-maven:jdk21-nanoserver@sha256:9c72aaf61bc5234305835333a38da1dec3ce2838a85ee8a04f42367804a9bb71
       jnlp-ruby: jenkinsciinfra/inbound-agent-ruby@sha256:221f96baa1957742728eb6d2769a691aea5721fc11ed9b05da810c5debe92115
       jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04@sha256:d2a76a445d5197d4579f51a1c24b69e97a7942a33f9fd064770c419ea2568572
-      jnlp-webbuilder: jenkinsciinfra/builder@sha256:8b59fae6e558ab5da8b8c7d1b63e3ef259e0c8d5d7809ae179fe2d55584aee16
+      jnlp-webbuilder: jenkinsciinfra/builder@sha256:b3202fb5c0b8a65ad0fdbb6278b24831039fcaf3135c78952a5b70884f07b00c
       # default template from the official inbound-agent image here to provide a default agent (`node()` pipeline step)
       jnlp: jenkins/inbound-agent@sha256:51b36a5ac5078996504ecc271aab884bbd12d44ddc33f3ecb62ca54e4c97636c # :latest-jdk17
   tools_default_versions:

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -53,7 +53,7 @@ profile::jenkinscontroller::jcasc:
         agent_definitions:
           - name: jnlp-webbuilder
             agentJavaBin: java
-            javaHome: /opt/jdk-11
+            javaHome: /opt/jdk-17
             cpus: 2
             memory: 4
             labels:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -114,7 +114,7 @@ profile::jenkinscontroller::jcasc:
         hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIaGnnWz9Q/MvlscCUZslFxH8JJ01OQ6FXyuQMQWVuNe"
       envVars:
         PATH+MAVEN: "/home/jenkins/tools/apache-maven-3.8.7/bin"
-        JAVA_HOME: "/opt/jdk-11"
+        JAVA_HOME: "/opt/jdk-17"
       toolLocation:
         - home: "/home/jenkins/tools/apache-maven-3.8.7"
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
@@ -303,7 +303,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
             labels:
               - maven-windows
           - name: maven-11-windows
@@ -311,7 +311,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
             labels:
               - maven-11-windows
           - name: maven-17-windows
@@ -319,7 +319,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
             labels:
               - maven-17-windows
           - name: maven-19-windows
@@ -327,7 +327,7 @@ profile::jenkinscontroller::jcasc:
             command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
             cpus: 4
             memory: 8
-            agentJavaBin: 'C:/openjdk-11/bin/java' # From image jenkins/inbound-agent:jdk11-nanoserver
+            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
             labels:
               - maven-19-windows
   artifact_caching_proxy:

--- a/updatecli/weekly.d/jenkins-lts.yaml
+++ b/updatecli/weekly.d/jenkins-lts.yaml
@@ -20,7 +20,7 @@ sources:
     spec:
       release: stable
     transformers:
-      - addsuffix: "-jdk11"
+      - addsuffix: "-jdk17"
 
 conditions:
   defaultCidockerimage:

--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -39,11 +39,11 @@ sources:
       image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04"
       tag: '{{ source "packerImageVersion"}}'
       architecture: arm64
-  getLatestInboundJDK11ContainerImage:
+  getLatestInboundJDK17ContainerImage:
     kind: dockerdigest
     spec:
       image: "jenkins/inbound-agent"
-      tag: "latest-jdk11"
+      tag: "latest-jdk17"
       architecture: amd64
   getWindowsVMAgentsDiskSize:
     kind: file
@@ -94,9 +94,9 @@ targets:
     transformers:
       - addprefix: "jenkinsciinfra/jenkins-agent-ubuntu-22.04@"
     scmid: default
-  setInboundJDK11ContainerImage:
-    sourceid: getLatestInboundJDK11ContainerImage
-    name: "Bump container agent image jenkins/inbound-agent (JDK11)"
+  setInboundJDK17ContainerImage:
+    sourceid: getLatestInboundJDK17ContainerImage
+    name: "Bump container agent image jenkins/inbound-agent (JDK17)"
     kind: yaml
     spec:
       file: hieradata/common.yaml


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3072, this PR bumps the 3 Jenkins controllers managed in this repository (ci.jenkins.io, trusted.ci.jenkins.io and cert.ci.jenkins.io) to use JDK17 for controller (and agent JVMs) instead of JDK11