### PR TITLE
feat(cert.ci.jenkins.io) manage new VM setup with Puppet

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -1,0 +1,159 @@
+---
+lookup_options:
+  "^profile::jenkinscontroller::jcasc$":
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+  "^letsencrypt":
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+profile::jenkinscontroller::ci_fqdn: 'cert.ci.jenkins.io'
+profile::jenkinscontroller::proxy_port: 443
+docker::log_opt::max-size: "100m"
+docker::log_opt::max-file: 2
+# Per-host Datadog configuration
+datadog_agent::host: "cert.ci.jenkins.io"
+profile::jenkinscontroller::letsencrypt: true
+## TODO: should we uncomment?
+# profile::jenkinscontroller::anonymous_access: false
+## TODO: should we uncomment?
+# profile::jenkinscontroller::admin_ldap_groups:
+#   - admins
+#   - cert-admins
+profile::letsencrypt::plugin: dns-azure
+profile::letsencrypt::dns_azure:
+  sp_client_id: "ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAkpN6sYhMR1TjgwqpS84p/1x4LBKdOmMvr7Y4msG7eWmejWKUkTnmPo081r9CG7fZmOLU2WnvjZmdSCpYptOYuBFGqj7G523wp0n8gPgif7XlrESb3LiO6+pgklQ45YvI6+sob7wmxdlHMCyuq4nEywzC73OJhPeIRLKZ+f+Sq/ELsvnv4ZpQKTK9pnondc4uLmWGa8mYS7RISDYvQUlEJ1jqDpltAz9GciRav72NBVe2ZMqBPQdLiN1ZxDB6Xi0zK64b9tTbqfyUc+iPdbHlHMX+xPeOHhO2wqSTVbHMxvbHOcqOafMxVZJwg26+3L5YEU9O/g5Cqkw3U1IFaOwWpTBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDaPnKpm49eujEGENbjOzojgDA/WZMkInqdfOdfMMfC/MXcO9eUsNdcV+vqZZMkvHUDWGgDn/YX8hXNWuzt7po3q84=]" # application_id
+  sp_client_secret: "ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAJ2fdGgr4AqC0NsuFsi+G5TV8R8oZiA7MMU3FNW5QiuO0i4pKmzJaISHYDEjDf2MY/6/vgwc4RJ5u0tH6EV7k33xrE0GBikZzlxkl/TKm2rbOTNCsDpcx+oXQ+I7DqFhn/7fSWvsHGzHf/YvOii8mWx/P3Yq23C5D1rZVHzdtg5HnN1cp6j6tvdJzd/i/nu681oO/rIHeWijELvp16XT7Sl8iKUM4ve6xAP6BbpTxSjZ320Hofq0INIf/dQz0EBE981mzd4wjNI/lY/nVpSyuTpayhKd9zMgINK6BU3A9OPeBfV+vvWHEVpMNWp4aPXpB10pYsgPD4xBAThH7nRy7XTBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDYzwuKdG/rn9LJUvUTzVYTgDBcrMkKVsJknWGWbZuTSvM86mwlzU0qqe62Epq9j+9ubtjohhT91PpQxREVDyK9Ls0=]" # application_password.
+  tenant_id: "ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAkgR5pF4ipEnUpbYCk8zBlTnWsu76DjWw2Nc7lCLnu15JO0E5hp3RExxp6S+mxpFBEnAVAul+ZtuDO9/zuIm7Evqg28yAfRMT1nIe3CcZhr1RBz/aSfoirE9qRSX87iGKGlkt9Xe6fFtNhBJ+HZmHSBCv9gHQAA7UYlJ85wp0Jhioj6Jsq0QRAPxKbkoRQ4tUGy7g6kYVMrS5gTuJzfF6eSTisJ8v+y+AqDDxh/ImUEtt5Ci+Cfizk5qrvtNopM+d9EFp7hggxZHp+pwmUIiGMa6zKw5zK+yv5O+D7u28XzsMof/2CRAlVZddph8QyZJzPJdN4HhrGtTFvCjt4QxZmzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBD+pYc/BGBpdj/nG0PmzYkgDDeOpYnPPb669742yPihHnDvpBJFyhENejHd3fEGumuo8v4fDQW5GbJBLLWNOj1wuk=]" # subscription id
+  zones:
+    cert.ci.jenkins.io: "ENC[PKCS7,MIIB+wYJKoZIhvcNAQcDoIIB7DCCAegCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXd58sZ32pzljKO60kMLEEKkEkrDvc+bn+pIE5pQuTc2DkgTBB9ANC0rYJuYzgpzmzULM8qX5eZXKKBlY664NdtdDS9W5kEknx1tqubZC8EEQiuZjgK9XIsVuW+zkfEJSwK59pK0qDxtscB1j/rz7OkQwm0x3vU7sr6Kc4oOk8Jwt9/3qagCkQNtOcW43a8Rqys/fGQB7vrepS/QTgyKe0YS3hoin2GaXd5pzaoTNf9nTCJjK4EK5ebNkZsJ2X7jMMoENdNWS3VErkzRpUckvUMCryG1tUGPN28JEUwejGgfhsoCxrqBpw2TjBmQ8nEcIFpZEBn0aS/lLdM/W2nQHBzCBvQYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQKRndXbtRhLr3JBv/IELoRICBkB6IQGtkhoRuG/60RHQYefkuKP48L9lXKU6c/b/AYuAxZLwq3IVQGv8B1fC+vumBRAz2I2MzEKPZevIG5S73VrdNcpvDhmPGw7tWYYTVUlVQDvOwmTaiUfsf99DK42psQUyex0jL9QRuwwdxPRvara4S5H01uGEyY0uREdOhakgYtb3JuTJK8K1/yrtuYfR3Tw==]"
+profile::jenkinscontroller::groovy_init_enabled: false
+profile::jenkinscontroller::memory_limit: '7g'
+profile::jenkinscontroller::jcasc:
+  enabled: true
+  reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXpmFyHEJVPfkgY2pUna5kvSxS8/O8b78GKNbCstm5loTtW6Ahgeeaqimiha9zOlr383B3/qursQHv0lYlGQrxGzonQHRblEbXM19hznGKIqtZc2JsXQ7uutgSApIB+aQkNcE7LF5AIbQbag0vfs2VtC18k8k/krqtzqFcd2ioukzdF7Dnf9YXsSbp2Q3gMUt9r1WpmrgxHTXIghZCA8lVsI1c9oo3JnQCvHYAUUxRbfXs/mAyeOKKGnCCmgujvWjNbjCNsLC0+VhVi0Hn3hnT3FTm9cyEWyDxfFfQ3/dffq9ZKbNHbRDkUg0M5sP1Kn0bQK08Nc2UScKsvP00g281TBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA+RyPMfeLE+gavSoFQen4tgCB2fTgVbu+YezSpWaedB4WQ6gX1eP5G4id2Lh7gOUYOSw==]
+  datadog_api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAPHOrzhvtHBDIx0+hew05tezK2pM+fCy1rBzC5BZIBvzeMV5rXJ9p6Ujo7O9bdYeFB1O03wemXfWAN2slD3Ycvi/NEs/2aIxDsWs/qSWhzkEucUDLqcwazcN3lHIf69zsO6fE+0srmA0sdZf+nWyJRKSDj0wDZ2Zsaa0Sz8Y5LPrDW+DMnMo84C7fdqXLJDxlzDGNMOu8kj3zv1GTH89bdNOXxFD44vzBVxX/y64FUi1VmHro1kPicLN7Gde6+X3K8oEJ2ib3Z8H5NSNC8SAGws2bYbLw+pbXyvhdDrATLS9KuVh8Huv3lolyrEyfnCtt2FCfXDvWoRgM50hQ/GElFzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBX4DRxdnIckeAh69lPWonkgDDJwdm4VegnOcix+MS+AQuBFvVv+SJFTSUTt5GA+yJ+wfI6D4n0UdCqxaLSvyLZQ9U=]
+  global_libraries:
+    disabled: true
+  tools:
+    maven:
+      mvn:
+        disabled: true
+      maven-3.5:
+        version: "3.5.4"
+      maven-3.6:
+        version: "3.6.3"
+      maven-3.8:
+        version: "3.8.8"
+      maven-3.9:
+        version: "3.9.4"
+      maven:
+        home: "/usr/share/apache-maven-3.9.4"
+    jdk:
+      jdk-8: &tool_jdk8
+        installers:
+          linux-amd64:
+            type: "command"
+            label: "linux"
+            command: "echo JDK8"
+            toolHome: "/opt/jdk-8"
+          windows-amd64:
+            type: "batchFile"
+            label: "windows"
+            command: "echo JDK8"
+            toolHome: "C:/Tools/jdk-8"
+          default:
+            type: "zip"
+            version: "8u382-b05"
+      jdk-11: &tool_jdk11
+        installers:
+          linux-amd64:
+            type: "command"
+            label: "linux"
+            command: "echo JDK11"
+            toolHome: "/opt/jdk-11"
+          windows-amd64:
+            type: "batchFile"
+            label: "windows"
+            command: "echo JDK11"
+            toolHome: "C:/Tools/jdk-11"
+          default:
+            type: "zip"
+            version: "11.0.20+8"
+      # Use Yaml anchor to avoid repeating configuration
+      jdk8: *tool_jdk8
+      # Use Yaml anchor to avoid repeating configuration
+      jdk11: *tool_jdk11
+      jdk17:
+        disabled: true
+    generic:
+      groovy-3.0.6:
+        url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.6.zip"
+  cloud_agents:
+    azure-vm-agents:
+      azureCredentialsId: "azure-sp-agents" # Managed manually
+      resource_group: "cert-ci-jenkins-io-ephemeral-agents"
+      agent_definitions:
+        - name: "ubuntu"
+          description: "Ubuntu 22.04 LTS (jdk11-default)"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAeKRjv1bRcYHvDq0BDY61R8NjlYOcqQwGvQdSQGw97IocmyAHu8KWjbgG1rry1Y5AnaAuTYycrXreIYOdxvCp0bt28ZUTaVIKBj6Wj7NhrLgmT4bivEIwoceofsomGQzAVFy9d0A/ubi/BHsYE1S9ZTEvFZ3nxU1W59I7BEmERWn5W8lgMuXkiOhkRbHs2UIcbpepaXa0PCeF8pA999U49+NWZZ8Xw6D/YxNh7slDlVQs9MR7rCuoesqAaXGxvkRN+xP2r4IXHyesbb1lwaLVQUko7rAsc1c6wAPLlDN4iPoX07tfaVc5BV/RZPcHyHPVG5zbt3A7pmF/8iPQDC0dAzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCjvP3lYtLyHGNYAdelA3Y3gCBC7Yw5PHTPmzDvONYd7/onkGRLnydibBz1+Q+2oD5HCw==]
+          location: "East US 2"
+          instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
+          spotInstance: false
+          architecture: amd64
+          labels:
+            - linux
+            - docker
+          maxInstances: 10 # Quota of 80 vCPUs
+          useAsMuchAsPossible: true
+          credentialsId: "azure-login"
+          usePrivateIP: false
+        - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2019"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAE6RybUpjNDuve0SJ9CqVYByWMTuxyYGUKnIyNJQcTCkjb7Ru96Z3vUi0QQcBDmtzTa5gs8ob9Z0CnxdrEOECq2gugz5KQuLIl1sziidBv7UXtaQyZhr+tx4Vnt0lQoXBWzEr+54Y66o0tdvyypWDtAKXiyq0ZCzE0rJiV6VaKVMq+pdFvwVh95oG2ypyM56/yRVvBhi7wT70aZTsPta/HJdgxSFETsKhHtUNOPy6y1r+NdAWnbMZX8X09fhw9j0UcTAXaJqrZ1iT1fvaKAfGREv9bM1wSsB3uZCCyTrDJsGPxzQPSsNqSpcQOpz1V1+n/ImNdmXvrf/o8SIukNbLqzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA5aa632Fw04CJM5y/rCd1kgCCo6GibyePNOvdWuwHVmipYWTWtEJoXw4DgcFa3PiIhQQ==]
+          location: "East US 2"
+          instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
+          spotInstance: false
+          architecture: amd64
+          labels:
+            - windows
+            - docker-windows
+          maxInstances: 10 # Quota of 80 vCPUs
+          useAsMuchAsPossible: true
+          credentialsId: "azure-login"
+          usePrivateIP: false
+## Ensure we override the default plugins to install defined from hieradata/common.yaml
+profile::jenkinscontroller::plugins:
+  # System configuration
+  - azure-vm-agents
+  - configuration-as-code
+  - generic-tool
+  - ldap
+  - matrix-auth
+
+  # Basic Pipeline configuration
+  - github-branch-source
+  - inline-pipeline
+  - pipeline-groovy-lib
+
+  # Pipeline steps
+  - build-timeout
+  - config-file-provider
+  - junit-realtime-test-reporter
+  - pipeline-stage-step # Used in mavenBuild
+  - timestamper
+  - workflow-basic-steps
+
+  # Utility
+  - compact-columns
+
+  # (Likely unused) detached
+  - sshd # split after 2.281
+  - javax-mail-api # split after 2.330

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -49,7 +49,7 @@ profile::jenkinscontroller::jcasc:
       maven-3.9:
         version: "3.9.4"
       maven:
-        home: "/usr/share/apache-maven-3.9.4"
+        home: "/usr/share/apache-maven-3.8.8"
     jdk:
       jdk-8: &tool_jdk8
         installers:

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -88,6 +88,15 @@ node 'cert-ci' {
   sshkeyman::hostkey { ['cert.ci.jenkins.io']: }
   include role::privateci
 }
+node 'controller.cert.ci.jenkins.io' {
+  mount { '/var/lib/jenkins':
+    ensure => 'mounted',
+    atboot => 'true',
+    device => 'UUID=afa01d2f-c643-4b0f-a917-66fedaee9325',
+    fstype => 'ext4',
+  }
+  include role::privateci
+}
 
 node 'vpn.jenkins.io' {
   sshkeyman::hostkey { ['vpn.jenkins.io']: }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3688, this PR adds the new `controller.cert.ci.jenkins.io` VM under Puppet management:

Same base setup as the former `cert-ci` VM but:

- Datadisk is now mounted in the same way as trusted.ci and ci (passing UUID, after initial disk formatting). We can increase this disk's size with a single reboot so no need for addition LVM setup
- Memory management shrunk from 14 to 7 as the VM size was decreased
- Updated the Cloud agents management: 
  - New resource group (managed by the new TF module)
  - New storage account (managed by the new TF module)
  - New JCasc reload token
- Tools: bumper to latest version
  - Bumped JDK8 and JDK11 to latest available
  - Bumped Maven 3.7 and 3.8 to latest available
  - Added Maven 3.9


Note that the Cloud agent credential is still managed manually: I'll have to add it manually and restart controller