### PR TITLE
chore(updatecli) fix manifests for the docker digest breaking change (docker tag added by default)

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -245,11 +245,10 @@ profile::jenkinscontroller::jcasc:
       jnlp-maven-17-windows: jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver@sha256:31382d3719a6320cd5bc32ed0e07e6a8bc4fd231f7a565132b3ad7639959ff85
       jnlp-maven-19-windows: jenkinsciinfra/inbound-agent-maven:jdk19-nanoserver@sha256:5b84e973e215489cf2665ebeebdb75244fe20f60debf39c7128c6878c9c6ec8b
       jnlp-maven-21-windows: jenkinsciinfra/inbound-agent-maven:jdk21-nanoserver@sha256:35ad7de91308b0e5160a165b61dac5b57ce1a78b790488cc42e9afeabab229c2
-      jnlp-ruby: jenkinsciinfra/inbound-agent-ruby@sha256:221f96baa1957742728eb6d2769a691aea5721fc11ed9b05da810c5debe92115
-      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04@sha256:1ab7c68c81ed9ec123172ab889e4ac461a784201eb27caff25505d47d9cbf30a
-      jnlp-webbuilder: jenkinsciinfra/builder@sha256:b3202fb5c0b8a65ad0fdbb6278b24831039fcaf3135c78952a5b70884f07b00c
+      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.23.0@sha256:1ab7c68c81ed9ec123172ab889e4ac461a784201eb27caff25505d47d9cbf30a
+      jnlp-webbuilder: jenkinsciinfra/builder:latest@sha256:b3202fb5c0b8a65ad0fdbb6278b24831039fcaf3135c78952a5b70884f07b00c
       # default template from the official inbound-agent image here to provide a default agent (`node()` pipeline step)
-      jnlp: jenkins/inbound-agent@sha256:1b227a7c360ffa86bf7bbde4a4de3d5eb6a8bf8b2ba5f8f5a22e65b591d0ca73
+      jnlp: jenkins/inbound-agent:latest-jdk17@sha256:1b227a7c360ffa86bf7bbde4a4de3d5eb6a8bf8b2ba5f8f5a22e65b591d0ca73
   tools_default_versions:
     jdk8: 8u382-b05
     jdk11: 11.0.20+8

--- a/updatecli/weekly.d/jenkins-lts.yaml
+++ b/updatecli/weekly.d/jenkins-lts.yaml
@@ -41,7 +41,7 @@ conditions:
 
 targets:
   imageTag:
-    name: "Update Docker Image Digest for jenkins/jenkins:lts"
+    name: "Update Docker Image tag for jenkins/jenkins:lts"
     sourceid: jenkinsLatestLTS
     kind: yaml
     spec:

--- a/updatecli/weekly.d/jenkinscontroller-agents-non-packer.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents-non-packer.yaml
@@ -60,7 +60,7 @@ targets:
       file: hieradata/common.yaml
       key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-webbuilder
     transformers:
-      - addprefix: "jenkinsciinfra/builder@"
+      - addprefix: "jenkinsciinfra/builder:"
     scmid: default
   setInboundJDK8WindowsContainerImage:
     sourceid: getLatestInboundMaven8WindowsContainerImage
@@ -70,7 +70,7 @@ targets:
       file: hieradata/common.yaml
       key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-8-windows
     transformers:
-      - addprefix: "jenkinsciinfra/inbound-agent-maven:jdk8-nanoserver@"
+      - addprefix: "jenkinsciinfra/inbound-agent-maven:"
     scmid: default
   setInboundJDK11WindowsContainerImage:
     sourceid: getLatestInboundMaven11WindowsContainerImage
@@ -80,7 +80,7 @@ targets:
       file: hieradata/common.yaml
       key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-11-windows
     transformers:
-      - addprefix: "jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver@"
+      - addprefix: "jenkinsciinfra/inbound-agent-maven:"
     scmid: default
   setInboundJDK17WindowsContainerImage:
     sourceid: getLatestInboundMaven17WindowsContainerImage
@@ -90,7 +90,7 @@ targets:
       file: hieradata/common.yaml
       key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-17-windows
     transformers:
-      - addprefix: "jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver@"
+      - addprefix: "jenkinsciinfra/inbound-agent-maven:"
     scmid: default
   setInboundJDK19WindowsContainerImage:
     sourceid: getLatestInboundMaven19WindowsContainerImage
@@ -100,7 +100,7 @@ targets:
       file: hieradata/common.yaml
       key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-19-windows
     transformers:
-      - addprefix: "jenkinsciinfra/inbound-agent-maven:jdk19-nanoserver@"
+      - addprefix: "jenkinsciinfra/inbound-agent-maven:"
     scmid: default
   setInboundJDK21WindowsContainerImage:
     sourceid: getLatestInboundMaven21WindowsContainerImage
@@ -110,7 +110,7 @@ targets:
       file: hieradata/common.yaml
       key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-21-windows
     transformers:
-      - addprefix: "jenkinsciinfra/inbound-agent-maven:jdk21-nanoserver@"
+      - addprefix: "jenkinsciinfra/inbound-agent-maven:"
     scmid: default
 
 actions:

--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -92,7 +92,7 @@ targets:
       file: hieradata/common.yaml
       key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-all-in-one
     transformers:
-      - addprefix: "jenkinsciinfra/jenkins-agent-ubuntu-22.04@"
+      - addprefix: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:"
     scmid: default
   setInboundJDK17ContainerImage:
     sourceid: getLatestInboundJDK17ContainerImage
@@ -102,7 +102,7 @@ targets:
       file: hieradata/common.yaml
       key: $.profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp
     transformers:
-      - addprefix: "jenkins/inbound-agent@"
+      - addprefix: "jenkins/inbound-agent:"
     scmid: default
 
 actions:


### PR DESCRIPTION
Closes #3028 and #3029

This PR fixes the `updatecli` manifests using a Docker digest source as the version [0.57.0](https://github.com/updatecli/updatecli/releases/tag/v0.57.0) introdueced a breaking change.

This PR also removes a hieradata configuration line not used since 5 months at least (ref. https://github.com/jenkins-infra/jenkins-infra/blame/2a88bbcacb794aaf6316fd936f91b7473dbd1d33/hieradata/common.yaml#L248)