### PR TITLE
feat(cert.ci.jenkins.io) switch agent VMs to private IPs

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -100,10 +100,11 @@ profile::jenkinscontroller::jcasc:
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
           os_version: "22.04"
+          launcher: "ssh"
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAeKRjv1bRcYHvDq0BDY61R8NjlYOcqQwGvQdSQGw97IocmyAHu8KWjbgG1rry1Y5AnaAuTYycrXreIYOdxvCp0bt28ZUTaVIKBj6Wj7NhrLgmT4bivEIwoceofsomGQzAVFy9d0A/ubi/BHsYE1S9ZTEvFZ3nxU1W59I7BEmERWn5W8lgMuXkiOhkRbHs2UIcbpepaXa0PCeF8pA999U49+NWZZ8Xw6D/YxNh7slDlVQs9MR7rCuoesqAaXGxvkRN+xP2r4IXHyesbb1lwaLVQUko7rAsc1c6wAPLlDN4iPoX07tfaVc5BV/RZPcHyHPVG5zbt3A7pmF/8iPQDC0dAzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCjvP3lYtLyHGNYAdelA3Y3gCBC7Yw5PHTPmzDvONYd7/onkGRLnydibBz1+Q+2oD5HCw==]
           location: "East US 2"
           instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
-          spotInstance: false
+          spot: false
           architecture: amd64
           labels:
             - linux
@@ -111,16 +112,20 @@ profile::jenkinscontroller::jcasc:
           maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
-          usePrivateIP: false
+          usePrivateIP: true
+          virtualNetworkName: "cert-ci-jenkins-io-vnet"
+          virtualNetworkResourceGroupName: "cert-ci-jenkins-io"
+          subnetName: "cert-ci-jenkins-io-vnet-ephemeral-agents"
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64
           os: "windows"
           os_version: "2019"
+          launcher: "ssh"
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAE6RybUpjNDuve0SJ9CqVYByWMTuxyYGUKnIyNJQcTCkjb7Ru96Z3vUi0QQcBDmtzTa5gs8ob9Z0CnxdrEOECq2gugz5KQuLIl1sziidBv7UXtaQyZhr+tx4Vnt0lQoXBWzEr+54Y66o0tdvyypWDtAKXiyq0ZCzE0rJiV6VaKVMq+pdFvwVh95oG2ypyM56/yRVvBhi7wT70aZTsPta/HJdgxSFETsKhHtUNOPy6y1r+NdAWnbMZX8X09fhw9j0UcTAXaJqrZ1iT1fvaKAfGREv9bM1wSsB3uZCCyTrDJsGPxzQPSsNqSpcQOpz1V1+n/ImNdmXvrf/o8SIukNbLqzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA5aa632Fw04CJM5y/rCd1kgCCo6GibyePNOvdWuwHVmipYWTWtEJoXw4DgcFa3PiIhQQ==]
           location: "East US 2"
           instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
-          spotInstance: false
+          spot: false
           architecture: amd64
           labels:
             - windows
@@ -128,7 +133,10 @@ profile::jenkinscontroller::jcasc:
           maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
-          usePrivateIP: false
+          usePrivateIP: true
+          virtualNetworkName: "cert-ci-jenkins-io-vnet"
+          virtualNetworkResourceGroupName: "cert-ci-jenkins-io"
+          subnetName: "cert-ci-jenkins-io-vnet-ephemeral-agents"
 ## Ensure we override the default plugins to install defined from hieradata/common.yaml
 profile::jenkinscontroller::plugins:
   # System configuration


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3688

This PR updates the agents configuration for cert.ci.jenkins.io to use private IP inside the new `ephemeral-agent` subnet.
Agent should start faster (no need to wait for public IP allocation) and should cost a bit less.