### PR TITLE
feat(cert.ci) switch VM agent type to Standard_D8ads_v5

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -103,7 +103,8 @@ profile::jenkinscontroller::jcasc:
           launcher: "ssh"
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAeKRjv1bRcYHvDq0BDY61R8NjlYOcqQwGvQdSQGw97IocmyAHu8KWjbgG1rry1Y5AnaAuTYycrXreIYOdxvCp0bt28ZUTaVIKBj6Wj7NhrLgmT4bivEIwoceofsomGQzAVFy9d0A/ubi/BHsYE1S9ZTEvFZ3nxU1W59I7BEmERWn5W8lgMuXkiOhkRbHs2UIcbpepaXa0PCeF8pA999U49+NWZZ8Xw6D/YxNh7slDlVQs9MR7rCuoesqAaXGxvkRN+xP2r4IXHyesbb1lwaLVQUko7rAsc1c6wAPLlDN4iPoX07tfaVc5BV/RZPcHyHPVG5zbt3A7pmF/8iPQDC0dAzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCjvP3lYtLyHGNYAdelA3Y3gCBC7Yw5PHTPmzDvONYd7/onkGRLnydibBz1+Q+2oD5HCw==]
           location: "East US 2"
-          instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
           spot: false
           architecture: amd64
           labels:
@@ -124,7 +125,8 @@ profile::jenkinscontroller::jcasc:
           launcher: "ssh"
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAE6RybUpjNDuve0SJ9CqVYByWMTuxyYGUKnIyNJQcTCkjb7Ru96Z3vUi0QQcBDmtzTa5gs8ob9Z0CnxdrEOECq2gugz5KQuLIl1sziidBv7UXtaQyZhr+tx4Vnt0lQoXBWzEr+54Y66o0tdvyypWDtAKXiyq0ZCzE0rJiV6VaKVMq+pdFvwVh95oG2ypyM56/yRVvBhi7wT70aZTsPta/HJdgxSFETsKhHtUNOPy6y1r+NdAWnbMZX8X09fhw9j0UcTAXaJqrZ1iT1fvaKAfGREv9bM1wSsB3uZCCyTrDJsGPxzQPSsNqSpcQOpz1V1+n/ImNdmXvrf/o8SIukNbLqzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA5aa632Fw04CJM5y/rCd1kgCCo6GibyePNOvdWuwHVmipYWTWtEJoXw4DgcFa3PiIhQQ==]
           location: "East US 2"
-          instanceType: Standard_DS4_v2 # 8 vCPUS / 28 Gb
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
           spot: false
           architecture: amd64
           labels:


### PR DESCRIPTION
Part of https://github.com/jenkins-infra/helpdesk/issues/3688

This PR switches the agent VM size to [`Standard_D8ads_v5`](https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series) and uses an ephemeral OS disk

These instance sizing is the samz as trusted.ci.jenkins.io and features:

- Same amount of vCPUs but more powerful CPU (AMD's 3rd Generation EPYCTM 7763v with clocked at 2.4Ghz / 3.5 Ghz instead of Haswell Xeon clocked at 2.3 Ghz / 3.2 Ghz)
- More memory (32 Gb  instead of 28 Gb) with faster bandwidth
- Ephemeral disk: local encrypted disk reformatted on each VM is allocation/deallocation
- Better I/Os: local disk is an NVMEs with direct access and 300 Gb size instead 128Gb
- Cheaper ($0.4120/hour instance of $0.5850/hour on demand,  $0.0412/hour instead of $0.2274/hour if we use spot)