### PR TITLE
feat(private.vpn.jenkins.io) enable routing to trusted-ci-jenkins-io vnet

### DIFF
--- a/hieradata/clients/private.vpn.jenkins.io.yaml
+++ b/hieradata/clients/private.vpn.jenkins.io.yaml
@@ -13,6 +13,7 @@ profile::openvpn::networks:
       - 10.244.0.0/14 # Access to the public-vnet network
       - 10.252.0.0/21 # Access to the public-db network
       - 10.252.8.0/21 # Access to the cert-ci-jenkins-io network
+      - 10.252.0.0/21 # Access to the trusted-ci-jenkins-io network
 profile::openvpn::vpn_network:
   name: private
   # Abstract network

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -307,6 +307,6 @@ limits:
     nofile:
       soft: "65536"
       hard: "65536"
-profile::openvpn::image_tag: 2.1.5
+profile::openvpn::image_tag: 2.1.6
 apt::update:frequency: 'daily'
 # vim: ft=yaml ts=2 sw=2 nowrap et


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3624

Requires https://github.com/jenkins-infra/docker-openvpn/pull/301 to be merged and deployed as https://github.com/jenkins-infra/docker-openvpn/releases/tag/2.1.6