### PR TITLE
fix(ci.jenkins.io) exclude all externals Maven repositories from ACP mirroring

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id><%= providerId %>-proxy</id>
                   <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>*,!central,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local,!jitpack.io</mirrorOf>
+                  <mirrorOf>external:*,!central,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io</mirrorOf>
               </mirror>
               <mirror>
                   <id><%= providerId %>-proxy-incrementals</id>


### PR DESCRIPTION
- https://maven.apache.org/guides/mini/guide-mirror-settings.html#AdvancedMirrorSpecification mentions that `external:*` is a pattern matching "all repositories" except URLs to localhost or file based.
- Found in https://github.com/jenkinsci/maven-hpi-plugin/pull/537 which pointed to https://maven.apache.org/plugins/maven-invoker-plugin/examples/fast-use.html#fast-build-configuration-mergeusersettings-and-mirrors
- Remove the `!local` exception added as part of https://github.com/jenkins-infra/helpdesk/issues/3567 (replaced by the `external:` pattern)