### PR TITLE
breaking(ci.jenkins.io, trusted.ci.jenkins.io, cert.ci.jenkins.io) prepare JCasc configuration for https://github.com/jenkinsci/azure-vm-agents-plugin/releases/tag/883.v63c930b_025dc

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -4,7 +4,7 @@ jenkins:
   <%- if @jcasc['cloud_agents']['azure-vm-agents'] && !@jcasc['cloud_agents']['azure-vm-agents'].empty? -%>
   - azureVM:
       azureCredentialsId: "<%= @jcasc['cloud_agents']['azure-vm-agents']['azureCredentialsId'] %>"
-      cloudName: "azure-vms"
+      name: "azure-vms"
       deploymentTimeout: 1200
       existingResourceGroupName: "<%= @jcasc['cloud_agents']['azure-vm-agents']['resource_group'] %>"
       resourceGroupReferenceType: "existing"


### PR DESCRIPTION
Twin of https://github.com/jenkins-infra/kubernetes-management/pull/4360/files but for puppet