### PR TITLE
feat: initial support of the archives.do.jenkins.io VM

### DIFF
--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -73,11 +73,6 @@ class profile::archives (
     }
   }
 
-  #
-  package { 'lvm2':
-    ensure => present,
-  }
-
   package { 'libapache2-mod-bw':
     ensure => present,
   }

--- a/hieradata/clients/archives.do.jenkins.io.yaml
+++ b/hieradata/clients/archives.do.jenkins.io.yaml
@@ -1,0 +1,10 @@
+---
+profile::archives::rsync_hosts_allow:
+  - localhost
+  - archives.jenkins.io
+  - pkg.origin.jenkins.io
+  - get.jenkins.io
+  - 129.146.98.132 # archives.jenkins.io running on oracle in phoenix region
+  - 46.101.121.132 # archives.do.jenkins.io
+# Per-host Datadog configuration
+datadog_agent::host: "archives.do.jenkins.io"

--- a/hieradata/clients/archives.jenkins.io.yaml
+++ b/hieradata/clients/archives.jenkins.io.yaml
@@ -1,0 +1,6 @@
+profile::archives::rsync_hosts_allow:
+  - localhost
+  - archives.jenkins.io
+  - pkg.origin.jenkins.io
+  - get.jenkins.io
+  - 129.146.98.132 # archives.jenkins.io running on oracle in phoenix region

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -97,12 +97,6 @@ profile::letsencrypt::plugin: apache
 profile::pkgrepo::ssh_keys:
   release.ci.jenkins.io:
     key: AAAAB3NzaC1yc2EAAAADAQABAAABAQDBi5DJcmDRAa6J7d4Zj9alGw0ZNwDftfKPNqyMoJrbRyvqvhKi8z0mg5HMK+ohkc+Xk5+HWpLNf36nn4b+Jn9g2CZJfzkt2SL7HbCN4eVLkQmqmWG/y9HCSmld9bTVWFy1zD34qNiaZw1ldsusvokyU/LTIgWHsCtbsgMoE+CzRKKRJXDrUmnY4e4q5leTHjOdShlrFiakyy5XYtUKG0zlnJMqIvxyTSo+jKKA1iNeW0hP8knu4uhFCGcYOZps1eNH2z+7Vq+wq6lsNfU11CDfuCSZBG24VNMMf75giFVc2PdAzlWrY+BXi7QeDaPUqilMf3d2egKb/dFxhkTGQL11
-profile::archives::rsync_hosts_allow:
-  - localhost
-  - archives.jenkins.io
-  - pkg.origin.jenkins.io
-  - get.jenkins.io
-  - 129.146.98.132 # archives.jenkins.io running on oracle in phoenix region
 irc::irc_server: ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAg/IMh30AaTVOJqBSUwZ9q7ijpmxoS/rS2GyWkXZ9qnhCi2B0O1U1Ds+BSpsAszxA3Qf67tl7OkmfTyV7xDNjSfVlHuGbgJ5yRkOphndcO5tCd+ssFRXROROeHVJBhn64S11ayL4LSyx9zn6Nqk4SnUjZ9zKmS1KGGl3fjFLygI+3q8rPuv+ebSKFUiwXUUWPsPoTUPcxV9950npYiP5yaOJN9y7QJ8XqlA9cNU27cubgZJFxYRfReCa0zG12K6c+ordmc85R+Fp4ZJnPIuOVS4A6xS/x5a3EJz/qWdBZYCUjmrk+qmiMrp7mgc+EHKOAkmrdA+yZbWnYhv8PalufiDCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQYE9nAbni14xjBa6uM+gtOYBggqa4FnMWQ3eObLB5eu+Vje5vCo14q/bWY0uqio9aRO6pIEsKaBVE/DnF0VWuV9tqTcD3LInqpvS1g8cgcgLp8Z0chmQoZSGxdBGhTFkRGO0z+TJY1zXixeUedzp/K2Ly]
 irc::irc_join: true
 irc::use_ssl: true

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -31,7 +31,18 @@ node default {
 }
 
 # archives
+## Oracle VM (TODO: remove as part of https://github.com/jenkins-infra/helpdesk/issues/3760)
 node 'archives.jenkins.io' {
+  include role::archives
+}
+## DigitalOcean VM
+node 'archives.do.jenkins.io' {
+  mount { '/srv':
+    ensure => 'mounted',
+    atboot => 'true',
+    device => 'UUID=2bfde305-641d-4e6b-9376-96cdb1919860',
+    fstype => 'ext4',
+  }
   include role::archives
 }
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3760

This PR introduces the following changes:

- Stop trying to install the LVM2 package on both `archives.jenkins.io` and `archives.do.jenkins.io`
  - It was only used by `archives.jenkins.io` when it was running in rackspace, before Oracle
  - It won't remove the package from `archives.jenkins.io`, but at least it won't install it in `archives.do.jenkins.io`
- Add the node `archives.do.jenkins.io` under puppet management
  - Custom data volume mounted (UUID retrieved from the spawned VM)
- Add a hieradata client manifest for `archives.do.jenkins.io`
  - Includes a custom datadog naming to allow discriminating the metrics/logs between old and new VM
  - Customized allow list for rsync
