### PR TITLE
Revert "Bump packer agent templates version to 1.27.1"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -227,7 +227,7 @@ profile::jenkinscontroller::jcasc:
       path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
   agent_images:
     azure_vms_gallery_image:
-      version: 1.27.1
+      version: 1.26.1
       subscription_id: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAluBQmOHo1MWoOCMVOCcgVUs9gOzFVEZMT7RA3V33KeolyRKh0lm5Ta5+C9aKJe9myuVGaDQsd99XsW40d7NdygJcnBxUV+VTnnLphjplPtCX5JIS4ww/S8JGOpOIE2zejy5bL2CpnZhgSFh+aD1FLD91ozNS5lgNOq9hNKqo+mSfUnX5wrUFvlCaadTWp3yxG7l7VluxP1Wh4BlsRmphmbUmmgFo56CjDUVz9dMwxT/p/uE1S/SPuEirJOAPtPCl7x2NQWg+Qlv5j1tC5ASgh9beD3SjUVPd6VYM+K+u07aw8jOj/meARXgghtUPgqHqWC44JGHPzWkZ4dQFhe6jyzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDc6VPQnQTEmwF9aAh/uK9IgDDXAM9S6QNxRH8cFSOAESeqOlLFBKVAlJc3Mnby3Pc/6H21BsehZbQLUd+1MfcoPI0=]
     container_images:
       jnlp-maven-8-windows: jenkinsciinfra/inbound-agent-maven:jdk8-nanoserver@sha256:39f461a27def271ad666d277d5b999c4d82ba2fab17049ec40fbd864f6ca8c39
@@ -235,7 +235,7 @@ profile::jenkinscontroller::jcasc:
       jnlp-maven-17-windows: jenkinsciinfra/inbound-agent-maven:jdk17-nanoserver@sha256:9cf02a8fe4608c5031321ed94831640dc2f3c90909de2d73454da78f6d9742c5
       jnlp-maven-19-windows: jenkinsciinfra/inbound-agent-maven:jdk19-nanoserver@sha256:32389a6b404ec3606c47cc58c8d874f77c234a4a6900a8b69dd6eac122e7c0b8
       jnlp-maven-21-windows: jenkinsciinfra/inbound-agent-maven:jdk21-nanoserver@sha256:6b18cca34fabd9c01bb468ca707c9fd7817d7874d1bad5ad06ece263f82240d3
-      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.27.1@sha256:e846b073c3cad2dfb89307ad716b0ae4087d64fb1aed4c764f398918261c4c59
+      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.26.1@sha256:ee585fc59a724e53ad1dc9e43bacb48107eb4c2b8570d04f0a6e25ccddc28a7d
       jnlp-webbuilder: jenkinsciinfra/builder:latest@sha256:af91f7558e98a8023e24214f29defcc82b1b02de7a1e0de7ca75fee127b3f053
       # default template from the official inbound-agent image here to provide a default agent (`node()` pipeline step)
       jnlp: jenkins/inbound-agent:latest-jdk17@sha256:107df49c9b3e2ff05a2fa584d69d111f71dc875efbaea2dd8914c133011a44b4


### PR DESCRIPTION
As discussed during today's team meeting, we are seeing provisioning issues with Windows 2019 VMs, so let's revert

Reverts jenkins-infra/jenkins-infra#3093


Ref. https://github.com/jenkins-infra/helpdesk/issues/3772