### PR TITLE
feat(updates.jenkins.io): add `rclone` tool to `agent.trusted.ci.jenkins.io`

### DIFF
--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -89,7 +89,7 @@ class profile::buildagent (
     $rclone_url = "https://downloads.rclone.org/v1.64.0/rclone-v1.64.0-linux-${architecture}.zip"
     exec { 'Install rclone':
       require => [Package['curl'], Package['unzip']],
-      command => "/usr/bin/curl --location ${rclone_url} > rclone.zip && /usr/bin/unzip -j rclone.zip ./rclone && mv ./rclone/rclone /usr/local/bin/rclone && rm -rf ./rclone",
+      command => "/usr/bin/curl --location ${rclone_url} > rclone.zip && /usr/bin/unzip -j rclone.zip -d ./rclone && mv ./rclone/rclone /usr/local/bin/rclone && rm -rf ./rclone",
       creates => '/usr/local/bin/rclone',
     }
 

--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -86,6 +86,13 @@ class profile::buildagent (
       creates => '/usr/local/bin/azcopy',
     }
 
+    $rclone_url = "https://downloads.rclone.org/v1.64.0/rclone-v1.64.0-linux-${architecture}.zip"
+    exec { 'Install rclone':
+      require => [Package['curl'], Package['unzip']],
+      command => "/usr/bin/curl --location ${rclone_url} > rclone.zip && /usr/bin/unzip -j rclone.zip ./rclone && mv ./rclone/rclone /usr/local/bin/rclone && rm -rf ./rclone",
+      creates => '/usr/local/bin/rclone',
+    }
+
     if $aws_credentials or $aws_config {
       file { "${home_dir}/.aws":
         ensure  => directory,


### PR DESCRIPTION
This PR adds https://rclone.org/ to the permanent trusted agent in order to synchronize content into R2 buckets.

Ref: https://github.com/jenkins-infra/helpdesk/issues/2649