### PR TITLE
Revert "Bump packer agent templates version to 1.34.0"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -227,11 +227,11 @@ profile::jenkinscontroller::jcasc:
       path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
   agent_images:
     azure_vms_gallery_image:
-      version: 1.34.0
+      version: 1.30.0
       subscription_id: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAluBQmOHo1MWoOCMVOCcgVUs9gOzFVEZMT7RA3V33KeolyRKh0lm5Ta5+C9aKJe9myuVGaDQsd99XsW40d7NdygJcnBxUV+VTnnLphjplPtCX5JIS4ww/S8JGOpOIE2zejy5bL2CpnZhgSFh+aD1FLD91ozNS5lgNOq9hNKqo+mSfUnX5wrUFvlCaadTWp3yxG7l7VluxP1Wh4BlsRmphmbUmmgFo56CjDUVz9dMwxT/p/uE1S/SPuEirJOAPtPCl7x2NQWg+Qlv5j1tC5ASgh9beD3SjUVPd6VYM+K+u07aw8jOj/meARXgghtUPgqHqWC44JGHPzWkZ4dQFhe6jyzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDc6VPQnQTEmwF9aAh/uK9IgDDXAM9S6QNxRH8cFSOAESeqOlLFBKVAlJc3Mnby3Pc/6H21BsehZbQLUd+1MfcoPI0=]
     container_images:
       # All in one image (same as VM templates)
-      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.34.0@sha256:1484625cf1e09177a6ff08e678452cc6e8cc2048f4349e903d532e64fbdd7c1e
+      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.30.0@sha256:bba6a15352f55f8f3e4cfa61b94fcae8724622b2924e04e96c97f9a3c86cb3f5
       # Windows container images (jenkins-infra/docker-inbound-agents)
       jnlp-maven-8-windows: jenkinsciinfra/inbound-agent-maven:jdk8-nanoserver@sha256:75ea35bf8356835f31da9b64cc91ff62e073817a943a49581f78e7b1409f3c92
       jnlp-maven-11-windows: jenkinsciinfra/inbound-agent-maven:jdk11-nanoserver@sha256:29a9c1023613004467dd43151ba72fe938dd2f11c8b12ea68d808c097c47d1a0


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#3122

The VM agents works as expected but the container agents are failing to launch:

```
+ '[' 0 -eq 1 ']'
+ case "$@" in
+ '[' '!' -z '' ']'
+ '[' '!' -z /home/jenkins/agent ']'
+ case "$@" in
+ WORKDIR='-workDir /home/jenkins/agent'
+ '[' -n '' ']'
+ '[' -n jnlp-maven-11-hkthp ']'
+ JENKINS_AGENT_NAME=jnlp-maven-11-hkthp
+ '[' '' = true ']'
+ '[' -n JNLP4-connect ']'
+ PROTOCOLS='-protocols JNLP4-connect'
+ '[' -n ci.jenkins.io:50000 ']'
+ DIRECT='-direct ci.jenkins.io:50000'
+ '[' -n <redacted> ']'
+ INSTANCE_IDENTITY='-instanceIdentity <redacted>'
+ '[' /opt/jdk-17/bin/java ']'
+ JAVA_BIN=/opt/jdk-17/bin/java
+ '[' -XX:+PrintCommandLineFlags ']'
+ JAVA_OPTIONS=-XX:+PrintCommandLineFlags
+ OPT_JENKINS_SECRET=
+ '[' -n <redacted> ']'
+ case "$@" in
+ OPT_JENKINS_SECRET=<redacted>
+ OPT_JENKINS_AGENT_NAME=
+ '[' -n jnlp-maven-11-hkthp ']'
+ case "$@" in
+ OPT_JENKINS_AGENT_NAME=jnlp-maven-11-hkthp
+ exec /opt/jdk-17/bin/java -XX:+PrintCommandLineFlags -cp /usr/share/jenkins/agent.jar hudson.remoting.jnlp.Main -workDir /home/jenkins/agent -direct ci.jenkins.io:50000 -protocols JNLP4-connect -instanceIdentity <redacted> <redacted> jnlp-maven-11-hkthp
-XX:ConcGCThreads=1 -XX:G1ConcRefinementThreads=4 -XX:GCDrainStackTargetSize=64 -XX:InitialHeapSize=125000000 -XX:MarkStackSize=4194304 -XX:MaxHeapSize=2000000000 -XX:MinHeapSize=6815736 -XX:+PrintCommandLineFlags -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC 
Oct 21, 2023 10:04:46 AM org.jenkinsci.remoting.engine.WorkDirManager initializeWorkDir
INFO: Using /home/jenkins/agent/remoting as a remoting work directory
Oct 21, 2023 10:04:46 AM org.jenkinsci.remoting.engine.WorkDirManager setupLogging
INFO: Both error and output logs will be printed to /home/jenkins/agent/remoting
Exception in thread "main" java.io.EOFException: unexpected stream termination
        at hudson.remoting.ChannelBuilder.negotiate(ChannelBuilder.java:459)
        at hudson.remoting.ChannelBuilder.build(ChannelBuilder.java:404)
        at hudson.remoting.Launcher.main(Launcher.java:878)
        at hudson.remoting.Launcher.runWithStdinStdout(Launcher.java:826)
        at hudson.remoting.Launcher.run(Launcher.java:428)
        at hudson.remoting.Launcher.main(Launcher.java:377)
<===[JENKINS REMOTING CAPACITY]===>rO0ABXNyABpodWRzb24ucmVtb3RpbmcuQ2FwYWJpbGl0eQAAAAAAAAABAgABSgAEbWFza3hwAAAAAAAAAf4=% 
```

