### PR TITLE
fix(ci.jenkins.io) specify correct 'java' PATH for the basic jnlp container

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -343,6 +343,8 @@ profile::jenkinscontroller::jcasc:
               - ruby
               - webbuilder
           - name: jnlp
+            agentJavaBin: /opt/java/openjdk/bin/java
+            javaHome: /opt/java/openjdk
             labels:
               - default
             cpus: 1
@@ -446,6 +448,8 @@ profile::jenkinscontroller::jcasc:
               - ruby
               - webbuilder
           - name: jnlp
+            agentJavaBin: /opt/java/openjdk/bin/java
+            javaHome: /opt/java/openjdk
             labels:
               - default
             cpus: 1


### PR DESCRIPTION
While testing https://github.com/jenkinsci/docker-inbound-agent/releases/tag/3181.v78543a_987053-1, I realized that the default `jnlp` container agent template was misconfigured: the java installation is not on the same path as the one we use on our packer-images.

Ideally, we should specify the packer image container image "all in one" on this one, but on short term, I would like to have this fixed, then proceed with #3125 and finally see what we can do to change to the "all in one" image