### PR TITLE
feat(ci.jenkins.io) disable DOKS kubernetes agent cloud for 1.26 upgrade

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -350,7 +350,7 @@ profile::jenkinscontroller::jcasc:
             cpus: 1
             memory: 1
       doks:
-        enabled: true
+        enabled: false
         provider: do
         credentialsId: "doks-jenkins-agent-sa-token"
         serverCertificate: >


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3683#issuecomment-1780857936