### PR TITLE
Revert "feat(ci.jenkins.io) disable DOKS kubernetes agent cloud for 1.26 upgrade"

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -350,7 +350,7 @@ profile::jenkinscontroller::jcasc:
             cpus: 1
             memory: 1
       doks:
-        enabled: false
+        enabled: true
         provider: do
         credentialsId: "doks-jenkins-agent-sa-token"
         serverCertificate: >


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#3140

It re-enables DO cluster for ci.jenkins.io as part of the https://github.com/jenkins-infra/helpdesk/issues/3683#issuecomment-1780857936 operation.

- Upgrade to Kubernetes 1.26 went well (no issue, no warning)
- The ACP service in DigitalOcean is up and running (https://repo.do.jenkins.io/public/org/jenkins-ci/plugins/plugin/4.61/)