### PR TITLE
fix(buildagent) ensure azcopy is usable when upgraded

### DIFF
--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -93,7 +93,7 @@ class profile::buildagent (
       $azcopy_url = "https://azcopyvnext.azureedge.net/releases/release-${tools_versions['azcopy']}/azcopy_linux_${architecture}_${azcopysemver}.tar.gz"
       exec { 'Install azcopy':
         require => [Package['curl'], Package['tar']],
-        command => "/usr/bin/curl --location ${azcopy_url} | /usr/bin/tar --extract --gzip --strip-components=1 --directory=/usr/local/bin/ --wildcards '*/azcopy'",
+        command => "/usr/bin/curl --location ${azcopy_url} | /usr/bin/tar --extract --gzip --strip-components=1 --directory=/usr/local/bin/ --wildcards '*/azcopy' && chmod a+x /usr/local/bin/azcopy",
         unless  => "/usr/bin/test -f /usr/local/bin/azcopy && /usr/local/bin/azcopy --version | /bin/grep --quiet ${tools_versions['azcopy']}",
       }
     }


### PR DESCRIPTION
While deploying #3173 , caught this problem on production: missing permissions on `azcopy` , failing the builds.

Related to https://github.com/jenkins-infra/helpdesk/issues/2649