### PR TITLE
fix(ci.jenkins.io, trusted.ci.jenkins.io) ensure `arm64` agents and Windows agents have proper disk sizing for hypervisor temp storages

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -468,8 +468,9 @@ profile::jenkinscontroller::jcasc:
           launcher: "inbound"
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXUzOSOWZy2EI9QzQS/rHOuDVVykF9iKin47MtO85BsRdLIncooCcdD/WWJizYLnTXg7SzcS6E/rHP/QML+ymHfQYYTcbnbjYQQbI5t9kLlQB49QOSKrP3elsg9j/r24sUh7fGsV354j281ADD1meMwZ4nj5aYWLVN4KIAGzqYx113PkS1I/B+5Gtl06P9Mrt9myf7SXxuya7X9M3OZR/USuGXM47nDpQN57zmpgtSrZoaQ+9h+67prX1wq1hRsWwwt6Ve9j3JHwYGnVRPaU5zUbfRMHYW0exbnl/6KJn6pLVcRwiI4l740nUgJgzWfeASk7qAEGM6eVo3BZBW2A+VzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDdbrT/4ubtoeKc07/uQk14gCCdGGZJAjSgpN30zDmrfVQkXBtIoYQ2+lr/vFStxH4VBw==]
           location: "East US 2"
-          instanceType: Standard_D4pds_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          instanceType: Standard_D4pds_v5 # 4 vCPUS / 16 Gb / Max 100 Gb OsCacheDisk local storage (150 temp)
           ephemeralOSDisk: true
+          osDiskSize: 100 # https://github.com/jenkinsci/azure-vm-agents-plugin/issues/349
           architecture: arm64
           labels:
             - ubuntu

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -104,6 +104,7 @@ profile::jenkinscontroller::jcasc:
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAQ3r9h0iq+GWsy6L8+avm4Zyl+ceMIVwE4jkWtizO6Z2z4n7UMce0ykzGqS1N40q39Hav/u9RkKXC6ObIO2WOf1lSKEpGWdjQGijq5vFHvaak+BBX13t45ZVxeR2fApeUPDMMKreLh58G6NlgG59fJ9gH5SsTyyobZZvxbD2pKou3A9soL/5tm7Td2rSSls5zmKYZvvDooqR869fpaeaeIqmf5PlKpIznbYxYnedizPK1Hk/n+Du8J+h9+JlrRpHTr3euYqDbNxLmMaEBoZAi4PhPWXfJ1ODbfFlnap36VjbVNCzz3APUawLyHkz8WzAYflTTE1jHpYSag+h/AohLtTBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDHUZsei+WM3m6xpdMbw2MZgCA4qSXD+tuliubzmMN/baT3Lc/JLFa+kOtL5K4fy2Y9Vg==]
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
           spot: true
           architecture: amd64
           labels:
@@ -124,6 +125,7 @@ profile::jenkinscontroller::jcasc:
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAbAxg7BN6ITc6YT94PCxtwzZUwytEOTcWa0LK8/NJZNi5huyrSDb4XkFHbO0Fgmy/i110hZNY3kid27ZCm1//Aiq6Y0c3puLofOMydKg+KtrAzXJrWZ9GpJScH6jOHJoSjcHz7TmnwYXhJTLTgXW/I6qwsnL98SpdK1hikWnWjl0jtJhMT9yayAYsBPx9gyEgsOl0fhJNxb3lrTA4pWj+fvWFIuxsxs4iaXlRnWy/lqyoKH8JOOrmkrqvdEBmHy3TMW92bxxce3yARIaXoXdrxnEJKJUTaw7WYqxSG6t2CmeIyxGddWUomIQ8c9yqRYAWG7BE85YnDZPW+u9Jm/ijOzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDKCN844A+3necghexQVs2QgCB5e17lG0VeqtYMtMKPerxXMCDPjPVxKQaVWrM6L2/L+g==]
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
           spot: true
           architecture: amd64
           labels:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3812, this PR introduces 2 configuration changes:

- ci.jenkins.io: ensures `arm64` Linux VM agents have a 100 Gb sized ephemeral disk (despite the advertised 150Gb, the `OSDiskPlacement` default option restricts the disk to 100Gb)
- trusted.ci.jenkins.io: ensure Windows agents utilizes an ephemeral OS disk (like agent with same setup on cert.ci.jenkins.io)