### PR TITLE
feat(ci.jenkins.io) add azurevm cloud configuration for the new subscription

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -1,14 +1,15 @@
 <%- if @jcasc['cloud_agents'] && @jcasc['cloud_agents']['disabled'].to_s != "true" -%>
 jenkins:
   clouds:
-  <%- if @jcasc['cloud_agents']['azure-vm-agents'] && !@jcasc['cloud_agents']['azure-vm-agents'].empty? -%>
+  <%- if @jcasc['cloud_agents']['azure-vm-agents'] && @jcasc['cloud_agents']['azure-vm-agents']['azureVMClouds'] -%>
+  <%- @jcasc['cloud_agents']['azure-vm-agents']['azureVMClouds'].each do |azureVMCloudName, azureVMCloudSetup| -%>
   - azureVM:
-      azureCredentialsId: "<%= @jcasc['cloud_agents']['azure-vm-agents']['azureCredentialsId'] %>"
-      name: "azure-vms"
+      azureCredentialsId: "<%= azureVMCloudSetup['azureCredentialsId'] %>"
+      name: "<%= azureVMCloudName %>"
       deploymentTimeout: 1200
-      existingResourceGroupName: "<%= @jcasc['cloud_agents']['azure-vm-agents']['resource_group'] %>"
+      existingResourceGroupName: "<%= azureVMCloudSetup['resource_group'] %>"
       resourceGroupReferenceType: "existing"
-      maxVirtualMachinesLimit: <%= @jcasc['cloud_agents']['azure-vm-agents']['maxInstances'] %>
+      maxVirtualMachinesLimit: <%= azureVMCloudSetup['maxInstances'] %>
       vmTemplates:
     <%- @jcasc['cloud_agents']['azure-vm-agents']['agent_definitions'].each do |agent| -%>
       - agentWorkspace: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][agent['os'].to_s]['agentDir'] %>"
@@ -183,6 +184,7 @@ jenkins:
         usePrivateIP: false
       <%- end -%>
     <%- end -%>
+  <%- end -%>
   <%- end -%>
   <%- if @jcasc['cloud_agents']['azure-container-agents'] && !@jcasc['cloud_agents']['azure-container-agents'].empty? -%>
     <%- @jcasc['cloud_agents']['azure-container-agents'].each do |aci_cloud_name, aci_cloud_setup| -%>

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -1,17 +1,17 @@
 <%- if @jcasc['cloud_agents'] && @jcasc['cloud_agents']['disabled'].to_s != "true" -%>
 jenkins:
   clouds:
-  <%- if @jcasc['cloud_agents']['azure-vm-agents'] && @jcasc['cloud_agents']['azure-vm-agents']['azureVMClouds'] -%>
-  <%- @jcasc['cloud_agents']['azure-vm-agents']['azureVMClouds'].each do |azureVMCloudName, azureVMCloudSetup| -%>
+  <%- if @jcasc['cloud_agents']['azure_vm_agents'] && @jcasc['cloud_agents']['azure_vm_agents']['clouds'] -%>
+  <%- @jcasc['cloud_agents']['azure_vm_agents']['clouds'].each do |azureVMCloudName, cloudsetup| -%>
   - azureVM:
-      azureCredentialsId: "<%= azureVMCloudSetup['azureCredentialsId'] %>"
+      azureCredentialsId: "<%= cloudsetup['azureCredentialsId'] %>"
       name: "<%= azureVMCloudName %>"
       deploymentTimeout: 1200
-      existingResourceGroupName: "<%= azureVMCloudSetup['resource_group'] %>"
+      existingResourceGroupName: "<%= cloudsetup['resourceGroup'] %>"
       resourceGroupReferenceType: "existing"
-      maxVirtualMachinesLimit: <%= azureVMCloudSetup['maxInstances'] %>
+      maxVirtualMachinesLimit: <%= cloudsetup['maxInstances'] %>
       vmTemplates:
-    <%- @jcasc['cloud_agents']['azure-vm-agents']['agent_definitions'].each do |agent| -%>
+    <%- @jcasc['cloud_agents']['azure_vm_agents']['agent_definitions'].each do |agent| -%>
       - agentWorkspace: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][agent['os'].to_s]['agentDir'] %>"
         <%- if agent['os'].to_s == 'windows' -%>
         executeInitScriptAsRoot: false
@@ -191,7 +191,7 @@ jenkins:
   - aci:
       credentialsId: "<%= aci_cloud_setup['credentialsId'] %>"
       name: "<%= aci_cloud_name %>"
-      resourceGroup: "<%= aci_cloud_setup['resource_group'] %>"
+      resourceGroup: "<%= aci_cloud_setup['resourceGroup'] %>"
       templates:
       <%- aci_cloud_setup['agent_definitions'].each do |agent| -%>
       - command: "<%= agent['command'] %>"

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -2,10 +2,10 @@
 jenkins:
   clouds:
   <%- if @jcasc['cloud_agents']['azure_vm_agents'] && @jcasc['cloud_agents']['azure_vm_agents']['clouds'] -%>
-  <%- @jcasc['cloud_agents']['azure_vm_agents']['clouds'].each do |azureVMCloudName, cloudsetup| -%>
+  <%- @jcasc['cloud_agents']['azure_vm_agents']['clouds'].each do |cloudname, cloudsetup| -%>
   - azureVM:
       azureCredentialsId: "<%= cloudsetup['azureCredentialsId'] %>"
-      name: "<%= azureVMCloudName %>"
+      name: "<%= cloudname %>"
       deploymentTimeout: 1200
       existingResourceGroupName: "<%= cloudsetup['resourceGroup'] %>"
       resourceGroupReferenceType: "existing"

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -91,11 +91,11 @@ profile::jenkinscontroller::jcasc:
       groovy-3.0.6:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.6.zip"
   cloud_agents:
-    azure-vm-agents:
-      azureVMClouds:
+    azure_vm_agents:
+      clouds:
         azure-vms:
           azureCredentialsId: "azure-sp-agents" # Managed manually
-          resource_group: "cert-ci-jenkins-io-ephemeral-agents"
+          resourceGroup: "cert-ci-jenkins-io-ephemeral-agents"
       agent_definitions:
         - name: "ubuntu"
           description: "Ubuntu 22.04 LTS (jdk11-default)"

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -92,8 +92,10 @@ profile::jenkinscontroller::jcasc:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.6.zip"
   cloud_agents:
     azure-vm-agents:
-      azureCredentialsId: "azure-sp-agents" # Managed manually
-      resource_group: "cert-ci-jenkins-io-ephemeral-agents"
+      azureVMClouds:
+        azure-vms:
+          azureCredentialsId: "azure-sp-agents" # Managed manually
+          resource_group: "cert-ci-jenkins-io-ephemeral-agents"
       agent_definitions:
         - name: "ubuntu"
           description: "Ubuntu 22.04 LTS (jdk11-default)"

--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -430,15 +430,15 @@ profile::jenkinscontroller::jcasc:
               - default
             cpus: 1
             memory: 1
-    azure-vm-agents:
-      azureVMClouds:
+    azure_vm_agents:
+      clouds:
         azure-vms:
           azureCredentialsId: "azure-credentials" # Managed manually
-          resource_group: ci-jenkins-io-ephemeral-agents
+          resourceGroup: ci-jenkins-io-ephemeral-agents
           maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
         azure-vms-jenkins-sponsorship:
           azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
-          resource_group: ci-jenkins-io-ephemeral-agents
+          resourceGroup: ci-jenkins-io-ephemeral-agents
           maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
       agent_definitions:
         - name: "ubuntu-22"
@@ -586,7 +586,7 @@ profile::jenkinscontroller::jcasc:
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"
-        resource_group: ci-jenkins-io-ephemeral-agents
+        resourceGroup: ci-jenkins-io-ephemeral-agents
         agent_definitions:
           - name: maven-8-windows
             os: windows

--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -431,9 +431,15 @@ profile::jenkinscontroller::jcasc:
             cpus: 1
             memory: 1
     azure-vm-agents:
-      azureCredentialsId: "azure-credentials"
-      resource_group: ci-jenkins-io-ephemeral-agents
-      maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
+      azureVMClouds:
+        azure-vms:
+          azureCredentialsId: "azure-credentials" # Managed manually
+          resource_group: ci-jenkins-io-ephemeral-agents
+          maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
+        azure-vms-jenkins-sponsorship:
+          azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
+          resource_group: ci-jenkins-io-ephemeral-agents
+          maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
       agent_definitions:
         - name: "ubuntu-22"
           description: "Ubuntu 22.04 LTS"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -66,11 +66,11 @@ profile::jenkinscontroller::jcasc:
         retryWaitTime: 0
         hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFQNVOQ1pujfnfhOpFRV2AQOWm1I4mL6Xz+3TFJDL5iN"
   cloud_agents:
-    azure-vm-agents:
-      azureVMClouds:
+    azure_vm_agents:
+      clouds:
         azure-vms:
           azureCredentialsId: "azure-sponsorship-credentials" # Managed manually
-          resource_group: jenkinsinfra-trusted-ephemeral-agents
+          resourceGroup: jenkinsinfra-trusted-ephemeral-agents
       agent_definitions:
         - name: "ubuntu-22"
           description: "Ubuntu 22.04 LTS"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -67,8 +67,10 @@ profile::jenkinscontroller::jcasc:
         hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFQNVOQ1pujfnfhOpFRV2AQOWm1I4mL6Xz+3TFJDL5iN"
   cloud_agents:
     azure-vm-agents:
-      azureCredentialsId: "azure-sponsorship-credentials"
-      resource_group: jenkinsinfra-trusted-ephemeral-agents
+      azureVMClouds:
+        azure-vms:
+          azureCredentialsId: "azure-sponsorship-credentials" # Managed manually
+          resource_group: jenkinsinfra-trusted-ephemeral-agents
       agent_definitions:
         - name: "ubuntu-22"
           description: "Ubuntu 22.04 LTS"

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -62,8 +62,14 @@ profile::jenkinscontroller::jcasc:
               - ruby
             imagePullSecrets: dockerhub-credentials
     azure-vm-agents:
-      azureCredentialsId: "azure-credentials"
-      resource_group: ci-jenkins-io-ephemeral-agents
+      azureVMClouds:
+        azure-vms:
+          azureCredentialsId: "azure-credentials"
+          resource_group: ci-jenkins-io-ephemeral-agents
+        azure-vms-jenkins-sponsorship:
+          azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
+          resource_group: ci-jenkins-io-ephemeral-agents
+          maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
       agent_definitions:
         - name: "ubuntu-20"
           description: "Ubuntu 20.04 LTS"

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -61,14 +61,14 @@ profile::jenkinscontroller::jcasc:
               - webbuilder
               - ruby
             imagePullSecrets: dockerhub-credentials
-    azure-vm-agents:
-      azureVMClouds:
+    azure_vm_agents:
+      clouds:
         azure-vms:
           azureCredentialsId: "azure-credentials"
-          resource_group: ci-jenkins-io-ephemeral-agents
+          resourceGroup: ci-jenkins-io-ephemeral-agents
         azure-vms-jenkins-sponsorship:
           azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
-          resource_group: ci-jenkins-io-ephemeral-agents
+          resourceGroup: ci-jenkins-io-ephemeral-agents
           maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
       agent_definitions:
         - name: "ubuntu-20"
@@ -117,7 +117,7 @@ profile::jenkinscontroller::jcasc:
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"
-        resource_group: ci-jenkins-io-ephemeral-agents
+        resourceGroup: ci-jenkins-io-ephemeral-agents
         agent_definitions:
           - name: maven-11-windows
             os: windows

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -191,14 +191,14 @@ profile::jenkinscontroller::jcasc:
         url: SuperSecretThatShouldBeEncryptedInProduction
         defaultNamespace: jenkins-agents
         # No agent definitions (to test an empty cloud)
-    azure-vm-agents:
-      azureVMClouds:
+    azure_vm_agents:
+      clouds:
         azure-vms:
           azureCredentialsId: "azure-credentials"
-          resource_group: ci-jenkins-io-ephemeral-agents
+          resourceGroup: ci-jenkins-io-ephemeral-agents
         azure-vms-jenkins-sponsorship:
           azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
-          resource_group: ci-jenkins-io-ephemeral-agents
+          resourceGroup: ci-jenkins-io-ephemeral-agents
           maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
       agent_definitions:
         - name: "ubuntu-22-inbound"
@@ -298,7 +298,7 @@ profile::jenkinscontroller::jcasc:
     azure-container-agents:
       aci-windows:
         credentialsId: "azure-credentials"
-        resource_group: ci-jenkins-io-ephemeral-agents
+        resourceGroup: ci-jenkins-io-ephemeral-agents
         agent_definitions:
           - name: maven-8-windows
             os: windows

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -192,9 +192,14 @@ profile::jenkinscontroller::jcasc:
         defaultNamespace: jenkins-agents
         # No agent definitions (to test an empty cloud)
     azure-vm-agents:
-      azureCredentialsId: "azure-credentials"
-      resource_group: ci-jenkins-io-ephemeral-agents
-      maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
+      azureVMClouds:
+        azure-vms:
+          azureCredentialsId: "azure-credentials"
+          resource_group: ci-jenkins-io-ephemeral-agents
+        azure-vms-jenkins-sponsorship:
+          azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
+          resource_group: ci-jenkins-io-ephemeral-agents
+          maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
       agent_definitions:
         - name: "ubuntu-22-inbound"
           description: "Ubuntu 22.04 LTS"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3818

This PR adds support for a secondary azureVM cloud on ci.jenkins.io.
Implementation assumes that VM templates must be identical between the different clouds.


Tested with local unit tests (see also CI checks) and also with the local vagrant

