### PR TITLE
fix(jenkinscontroller) ensure agent subnet setups are properly setup for each azure-vm cloud

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -177,9 +177,9 @@ jenkins:
         <%- end -%>
       <%- if agent['usePrivateIP'] -%>
         usePrivateIP: true
-        virtualNetworkName: "<%= agent['virtualNetworkName'] %>"
-        virtualNetworkResourceGroupName: "<%= agent['virtualNetworkResourceGroupName'] %>"
-        subnetName: "<%= agent['subnetName'] %>"
+        virtualNetworkName: "<%= cloudsetup['virtualNetworkName'] %>"
+        virtualNetworkResourceGroupName: "<%= cloudsetup['virtualNetworkResourceGroupName'] %>"
+        subnetName: "<%= cloudsetup['subnetName'] %>"
       <%- else -%>
         usePrivateIP: false
       <%- end -%>

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -96,6 +96,9 @@ profile::jenkinscontroller::jcasc:
         azure-vms:
           azureCredentialsId: "azure-sp-agents" # Managed manually
           resourceGroup: "cert-ci-jenkins-io-ephemeral-agents"
+          virtualNetworkName: "cert-ci-jenkins-io-vnet"
+          virtualNetworkResourceGroupName: "cert-ci-jenkins-io"
+          subnetName: "cert-ci-jenkins-io-vnet-ephemeral-agents"
       agent_definitions:
         - name: "ubuntu"
           description: "Ubuntu 22.04 LTS (jdk11-default)"
@@ -116,9 +119,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
           usePrivateIP: true
-          virtualNetworkName: "cert-ci-jenkins-io-vnet"
-          virtualNetworkResourceGroupName: "cert-ci-jenkins-io"
-          subnetName: "cert-ci-jenkins-io-vnet-ephemeral-agents"
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64
@@ -138,9 +138,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
           usePrivateIP: true
-          virtualNetworkName: "cert-ci-jenkins-io-vnet"
-          virtualNetworkResourceGroupName: "cert-ci-jenkins-io"
-          subnetName: "cert-ci-jenkins-io-vnet-ephemeral-agents"
 ## Ensure we override the default plugins to install defined from hieradata/common.yaml
 profile::jenkinscontroller::plugins:
   # System configuration

--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -436,10 +436,16 @@ profile::jenkinscontroller::jcasc:
           azureCredentialsId: "azure-credentials" # Managed manually
           resourceGroup: ci-jenkins-io-ephemeral-agents
           maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
+          virtualNetworkName: "public-vnet"
+          virtualNetworkResourceGroupName: "public"
+          subnetName: "public-vnet-ci_jenkins_io_agents"
         azure-vms-jenkins-sponsorship:
           azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
           resourceGroup: ci-jenkins-io-ephemeral-agents
           maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
+          virtualNetworkName: "public-jenkins-sponsorship-vnet"
+          virtualNetworkResourceGroupName: "public-jenkins-sponsorship"
+          subnetName: "public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"
       agent_definitions:
         - name: "ubuntu-22"
           description: "Ubuntu 22.04 LTS"
@@ -462,9 +468,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
         - name: "ubuntu-22-arm64"
           description: "Ubuntu 22.04 LTS ARM64"
@@ -486,9 +489,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
         - name: "ubuntu-22-highmem"
           description: "Ubuntu 22.04 LTS Highmem"
@@ -511,9 +511,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: false
           usePrivateIP: true
           credentialsId: "jenkinsvmagents-userpass"
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
         - name: "ubuntu-22-highmem-nonspot"
           description: "Ubuntu 22.04 LTS Highmem"
@@ -535,9 +532,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: false
           usePrivateIP: true
           credentialsId: "jenkinsvmagents-userpass"
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: false
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
@@ -558,9 +552,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
         - name: "win-2022" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2022"
@@ -579,9 +570,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
     azure-container-agents:
       aci-windows:

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -71,6 +71,9 @@ profile::jenkinscontroller::jcasc:
         azure-vms:
           azureCredentialsId: "azure-sponsorship-credentials" # Managed manually
           resourceGroup: jenkinsinfra-trusted-ephemeral-agents
+          virtualNetworkName: trusted-ci-jenkins-io-vnet
+          virtualNetworkResourceGroupName: trusted-ci-jenkins-io
+          subnetName: trusted-ci-jenkins-io-vnet-ephemeral-agents
       agent_definitions:
         - name: "ubuntu-22"
           description: "Ubuntu 22.04 LTS"
@@ -94,9 +97,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
-          virtualNetworkName: trusted-ci-jenkins-io-vnet
-          virtualNetworkResourceGroupName: trusted-ci-jenkins-io
-          subnetName: trusted-ci-jenkins-io-vnet-ephemeral-agents
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64
@@ -115,9 +115,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
-          virtualNetworkName: trusted-ci-jenkins-io-vnet
-          virtualNetworkResourceGroupName: trusted-ci-jenkins-io
-          subnetName: trusted-ci-jenkins-io-vnet-ephemeral-agents
         - name: "win-2022" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2022"
           imageDefinition: jenkins-agent-windows-2022-amd64
@@ -136,9 +133,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
-          virtualNetworkName: trusted-ci-jenkins-io-vnet
-          virtualNetworkResourceGroupName: trusted-ci-jenkins-io
-          subnetName: trusted-ci-jenkins-io-vnet-ephemeral-agents
 # These are plugins we need only in our trusted-ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -70,6 +70,9 @@ profile::jenkinscontroller::jcasc:
           azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
           resourceGroup: ci-jenkins-io-ephemeral-agents
           maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
+          virtualNetworkName: "prod-jenkins-public-prod"
+          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
+          subnetName: "ci.j-agents-vm"
       agent_definitions:
         - name: "ubuntu-20"
           description: "Ubuntu 20.04 LTS"
@@ -89,9 +92,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
           spot: true
         - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
@@ -109,9 +109,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "prod-jenkins-public-prod"
-          virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
-          subnetName: "ci.j-agents-vm"
           spot: false
           agentDir: 'C:/Foo'
     azure-container-agents:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -196,10 +196,16 @@ profile::jenkinscontroller::jcasc:
         azure-vms:
           azureCredentialsId: "azure-credentials"
           resourceGroup: ci-jenkins-io-ephemeral-agents
-        azure-vms-jenkins-sponsorship:
-          azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
-          resourceGroup: ci-jenkins-io-ephemeral-agents
+          virtualNetworkName: "vnet"
+          virtualNetworkResourceGroupName: "vnet-rg"
+          subnetName: "vnet-agents"
+        azure-vms-secondary:
+          azureCredentialsId: "azure-secondary-credentials" # Managed manually
+          resourceGroup: ci-jenkins-io-ephemeral-agents-secondary
           maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
+          virtualNetworkName: "vnet-secondary"
+          virtualNetworkResourceGroupName: "vnet-secondary-rg"
+          subnetName: "vnet-secondary-subnet-agents"
       agent_definitions:
         - name: "ubuntu-22-inbound"
           description: "Ubuntu 22.04 LTS"
@@ -222,9 +228,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
         - name: "ubuntu-22-arm64-ssh"
           description: "Ubuntu 22.04 LTS ARM64"
@@ -245,9 +248,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
           javaHome: /opt/jdk-11       # Test override of the default JDK for builds
           agentJavaBin: /opt/jdk-17   # Test override of the default JDK for builds
         - name: "win-2019-inbound" # The name must not contains "windows" or Azure API complains :facepalm:
@@ -269,9 +269,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: true
           javaHome: 'C:/Tools/openjdk-11'       # Test override of the default JDK for builds
           agentJavaBin: 'C:/Tools/openjdk-17'   # Test override of the default JDK for builds
@@ -291,9 +288,6 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
           spot: false
     azure-container-agents:
       aci-windows:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3818

Requires https://github.com/jenkins-infra/azure/pull/522 (to have the proper vnet permissions)

This PR fixes up #3189 by factorizing the network configuration of azure VM agent clouds to ensure each agent template has the expected vnet setup.

Of course, the vnet setup for the new subscription is added (forgot to commit it in #3189)


----

- Tested locally in Vagrant (I'll let rspec do its job for the unit testing)
- Tested in production on ci.jenkins.io
