### PR TITLE
feat(ci.jenkins.io) disable spot for the whole azure-vm agent cloud

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -166,7 +166,7 @@ jenkins:
         retentionStrategy: "azureVMCloudOnce"
       <%- end -%>
         shutdownOnIdle: false
-        spotInstance: <%= agent['spotInstance'] || agent['spot'] ? true : false %>
+        spotInstance: <%= cloudsetup['disableSpot'] ? false : (agent['spot'] ? true : false) %>
         templateDesc: "Dynamically provisioned <%= agent['description'] %> machine"
         templateDisabled: false
         templateName: "<%= agent['name'] %>"

--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -446,6 +446,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: "public-jenkins-sponsorship-vnet"
           virtualNetworkResourceGroupName: "public-jenkins-sponsorship"
           subnetName: "public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"
+          disableSpot: true # Not enough quota available
       agent_definitions:
         - name: "ubuntu-22"
           description: "Ubuntu 22.04 LTS"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -206,6 +206,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: "vnet-secondary"
           virtualNetworkResourceGroupName: "vnet-secondary-rg"
           subnetName: "vnet-secondary-subnet-agents"
+          disableSpot: true # Not enough quota available
       agent_definitions:
         - name: "ubuntu-22-inbound"
           description: "Ubuntu 22.04 LTS"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3818

This PR introduces a new hieradata attribute `disableSpot` to allow disabling "Spot" on all VM templates of a given Azure-VM agent cloud.

This new attribute is set to `true` for the new ci.jenkins.io's Azure VM cloud on the secondary subscription, as we don't have enough quota for spot VMs.