### PR TITLE
feat(ci.jenkins.io) switch all azure-vms agents to the secondary (sponsored) subscription

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -432,13 +432,6 @@ profile::jenkinscontroller::jcasc:
             memory: 1
     azure_vm_agents:
       clouds:
-        azure-vms:
-          azureCredentialsId: "azure-credentials" # Managed manually
-          resourceGroup: ci-jenkins-io-ephemeral-agents
-          maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
-          virtualNetworkName: "public-vnet"
-          virtualNetworkResourceGroupName: "public"
-          subnetName: "public-vnet-ci_jenkins_io_agents"
         azure-vms-jenkins-sponsorship:
           azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
           resourceGroup: ci-jenkins-io-ephemeral-agents


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3818#issuecomment-1831970571

This PR removes the JCasc configuration for the Azure VM cloud named `azure-vms` (pointing to the base subscription which we are billed for).

Please note that we keep the associated resources for now, to allow a quick rollback if needed
- (top-level) Credential on ci.jenkins.io
- Resources in Azure (NSG,storageaccount in jenkins-infra/azure and subnet/vnet in jenkins-infra/azure-net)


Tested manually with https://ci.jenkins.io/blue/organizations/jenkins/Packaging%2Fdocker-agent/detail/master/488/pipeline/158 with success (we saw Ubuntu, Windows 2019 and Windows 2022 VMs spinned up in the new subscription)