### PR TITLE
feat(jenkinscontroller) ensure the cloud name is added to the labels list for azure-vms

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -152,7 +152,7 @@ jenkins:
         installMaven: false
         javaPath: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
         jvmOptions: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
-        labels: "<%= agent['os'].to_s + "-" + agent['os_version'].to_s %> <%= agent['architecture'].to_s %> azure vm <%= agent['labels'].join(' ') %>"
+        labels: "<%= agent['os'].to_s + "-" + agent['os_version'].to_s %> <%= agent['architecture'].to_s %> azure vm <%= agent['labels'].join(' ') %> <%= cloudname %>"
         location: "<%= agent['location'] %>"
         noOfParallelJobs: 1
         osDiskSize: <%= agent['osDiskSize'] ? agent['osDiskSize'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskSize'] %>


### PR DESCRIPTION
Nitpick improvement: as part of https://github.com/jenkins-infra/helpdesk/issues/3818, we added the possibility to have a secondary subscription cloud.

This PR adds the cloud name in the label, same as for the Kubernetes cloud, to easily identify in which cloud is a given agent (and to allow acceptance infra test to spin up in a specific cloud).