### PR TITLE
fix(ci.jenkins.io) use the correct storage account name for the secondary sponsored subscription

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -137,7 +137,7 @@ jenkins:
         enableMSI: false
         enableUAMI: false
         ephemeralOSDisk: "<%= agent['ephemeralOSDisk'] ? agent['ephemeralOSDisk'] : false %>"
-        existingStorageAccountName: "<%= agent['storageAccount'] %>"
+        existingStorageAccountName: "<%= cloudsetup['storageAccount'] %>"
         storageAccountNameReferenceType: "existing"
         storageAccountType: "Standard_LRS"
         imageReference:

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -99,6 +99,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: "cert-ci-jenkins-io-vnet"
           virtualNetworkResourceGroupName: "cert-ci-jenkins-io"
           subnetName: "cert-ci-jenkins-io-vnet-ephemeral-agents"
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAeKRjv1bRcYHvDq0BDY61R8NjlYOcqQwGvQdSQGw97IocmyAHu8KWjbgG1rry1Y5AnaAuTYycrXreIYOdxvCp0bt28ZUTaVIKBj6Wj7NhrLgmT4bivEIwoceofsomGQzAVFy9d0A/ubi/BHsYE1S9ZTEvFZ3nxU1W59I7BEmERWn5W8lgMuXkiOhkRbHs2UIcbpepaXa0PCeF8pA999U49+NWZZ8Xw6D/YxNh7slDlVQs9MR7rCuoesqAaXGxvkRN+xP2r4IXHyesbb1lwaLVQUko7rAsc1c6wAPLlDN4iPoX07tfaVc5BV/RZPcHyHPVG5zbt3A7pmF/8iPQDC0dAzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCjvP3lYtLyHGNYAdelA3Y3gCBC7Yw5PHTPmzDvONYd7/onkGRLnydibBz1+Q+2oD5HCw==]
       agent_definitions:
         - name: "ubuntu"
           description: "Ubuntu 22.04 LTS (jdk11-default)"
@@ -106,7 +107,6 @@ profile::jenkinscontroller::jcasc:
           os: "ubuntu"
           os_version: "22.04"
           launcher: "ssh"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAeKRjv1bRcYHvDq0BDY61R8NjlYOcqQwGvQdSQGw97IocmyAHu8KWjbgG1rry1Y5AnaAuTYycrXreIYOdxvCp0bt28ZUTaVIKBj6Wj7NhrLgmT4bivEIwoceofsomGQzAVFy9d0A/ubi/BHsYE1S9ZTEvFZ3nxU1W59I7BEmERWn5W8lgMuXkiOhkRbHs2UIcbpepaXa0PCeF8pA999U49+NWZZ8Xw6D/YxNh7slDlVQs9MR7rCuoesqAaXGxvkRN+xP2r4IXHyesbb1lwaLVQUko7rAsc1c6wAPLlDN4iPoX07tfaVc5BV/RZPcHyHPVG5zbt3A7pmF/8iPQDC0dAzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCjvP3lYtLyHGNYAdelA3Y3gCBC7Yw5PHTPmzDvONYd7/onkGRLnydibBz1+Q+2oD5HCw==]
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
@@ -125,7 +125,6 @@ profile::jenkinscontroller::jcasc:
           os: "windows"
           os_version: "2019"
           launcher: "ssh"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAE6RybUpjNDuve0SJ9CqVYByWMTuxyYGUKnIyNJQcTCkjb7Ru96Z3vUi0QQcBDmtzTa5gs8ob9Z0CnxdrEOECq2gugz5KQuLIl1sziidBv7UXtaQyZhr+tx4Vnt0lQoXBWzEr+54Y66o0tdvyypWDtAKXiyq0ZCzE0rJiV6VaKVMq+pdFvwVh95oG2ypyM56/yRVvBhi7wT70aZTsPta/HJdgxSFETsKhHtUNOPy6y1r+NdAWnbMZX8X09fhw9j0UcTAXaJqrZ1iT1fvaKAfGREv9bM1wSsB3uZCCyTrDJsGPxzQPSsNqSpcQOpz1V1+n/ImNdmXvrf/o8SIukNbLqzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA5aa632Fw04CJM5y/rCd1kgCCo6GibyePNOvdWuwHVmipYWTWtEJoXw4DgcFa3PiIhQQ==]
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true

--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -394,6 +394,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "public-jenkins-sponsorship"
           subnetName: "public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"
           disableSpot: true # Not enough quota available
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAX1+w3HsG7jVw0T37cE9RVIEyAaNIg31kdhsxq/N3g0zehZB8QQw6K6/0y0uyNZhqxxdOUHHWN4qmLwrHXhsP+EXF/WHleC2qgYMJT8HHbJtVJ7yEVeeJKgUNipgWRf5FcB2hTKdcwfMqunMapQ4vmdREvAeWggN+racF1yJ1dsOJkzs0oR4GaCfGZLm3IxKMy13ifBJtlTl6dC6f8K70Z9aGbcWf3TqNVrznop9q8LlOPGOZXYyo8WGl1CheSUm5VbWa+o7J04cBOcYP+IAlJObZAN3rdM78Kt0GuDTTjlMZK3R/2e6+nyDw2LO2mMlfNPQcklI5uT1eh6nlWy+cjjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAhoV9P3un0kUya+CJJTFAHgCBAr5FalXjPsRdLH9XztQDGwMHJj8jLCoBk9D+268MpZw==]
       agent_definitions:
         - name: "ubuntu-22"
           description: "Ubuntu 22.04 LTS"
@@ -401,7 +402,6 @@ profile::jenkinscontroller::jcasc:
           os: "ubuntu"
           os_version: "22.04"
           launcher: "inbound"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEA1Nsg1Pm61jyGb87jWWKChYAFr5V6N3gPm3kzp9DfdL7ntn2eN+ZWUH3Q2IjfKVqM2AIubG8yopiG7fC6/6/hjkGl9HvQCEmnL6pYtxCr5c3aa/E5HUWV4NdhBS0aphW3BGK4eMuEZVtAwOsyjM2VrUQyX5j653l0TX9DSzWbRpg1b8L07yfIxyRHIwn3Os+CFRIiIEjH5/9hHLhVaX47RmoQAo4tqaVM63Jzwgwac0QYmXFjfJ9Nr0vptL9bb8mahcrlVplRgrLYJgRfyVU/5ACRLuRPphlrIubTxAZedII1hSzwPVZCc3hbRsvZT0/fUBTJNrwTKj6vtKwTIoMJszBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBC4aAckaWcMKMpLzJP6QsTGgCB22xvs2eN/1mbe8eTwtnyyIuUElyAHsmGO+z7Hycat4g==]
           location: "East US 2"
           instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
@@ -423,7 +423,6 @@ profile::jenkinscontroller::jcasc:
           os: "ubuntu"
           os_version: "22.04"
           launcher: "inbound"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXUzOSOWZy2EI9QzQS/rHOuDVVykF9iKin47MtO85BsRdLIncooCcdD/WWJizYLnTXg7SzcS6E/rHP/QML+ymHfQYYTcbnbjYQQbI5t9kLlQB49QOSKrP3elsg9j/r24sUh7fGsV354j281ADD1meMwZ4nj5aYWLVN4KIAGzqYx113PkS1I/B+5Gtl06P9Mrt9myf7SXxuya7X9M3OZR/USuGXM47nDpQN57zmpgtSrZoaQ+9h+67prX1wq1hRsWwwt6Ve9j3JHwYGnVRPaU5zUbfRMHYW0exbnl/6KJn6pLVcRwiI4l740nUgJgzWfeASk7qAEGM6eVo3BZBW2A+VzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDdbrT/4ubtoeKc07/uQk14gCCdGGZJAjSgpN30zDmrfVQkXBtIoYQ2+lr/vFStxH4VBw==]
           location: "East US 2"
           instanceType: Standard_D4pds_v5 # 4 vCPUS / 16 Gb / Max 100 Gb OsCacheDisk local storage (150 temp)
           ephemeralOSDisk: true
@@ -444,7 +443,6 @@ profile::jenkinscontroller::jcasc:
           os: "ubuntu"
           os_version: "22.04"
           launcher: "inbound"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAu0efEH9NzGrhuJpSxNZWuWwGOIeGBpsvNfNlxezGgbDjT7JFihJcHTCue/I3jG5afzT7LM+2sOlzx3X02gEAYyfIF6f87lWkyU8JwgAawBSQv4RZe9F/xPb5EIZUC1aTsV6c4i9IUbDsXnN6riJe5Cad/jhl0eE9C9s3kxugP9GHSgRsLrdBVon+VEm2VRRtdspEU3k249KY7kzUEjbxSCYFSCPW3Bq4naFRIab/DwcJcx7yYjboAaDeGwuPxCDxsSBfkz4Mv5c3xALlyIcEtjzucRVnXkX0mqpOTc4CzRJ4+2sL6GApK5CuSuU4xUdKsNzzZx5ZxfQcnBJhtLB6ejBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDAK7JsGHPsFqAY/Hjj7OEtgCDRSLKM6BQQHHKQl2PHZmx/AxHdWav7GE5z/vVyVmG8OQ==]
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
@@ -466,7 +464,6 @@ profile::jenkinscontroller::jcasc:
           os: "ubuntu"
           os_version: "22.04"
           launcher: "inbound"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAu0efEH9NzGrhuJpSxNZWuWwGOIeGBpsvNfNlxezGgbDjT7JFihJcHTCue/I3jG5afzT7LM+2sOlzx3X02gEAYyfIF6f87lWkyU8JwgAawBSQv4RZe9F/xPb5EIZUC1aTsV6c4i9IUbDsXnN6riJe5Cad/jhl0eE9C9s3kxugP9GHSgRsLrdBVon+VEm2VRRtdspEU3k249KY7kzUEjbxSCYFSCPW3Bq4naFRIab/DwcJcx7yYjboAaDeGwuPxCDxsSBfkz4Mv5c3xALlyIcEtjzucRVnXkX0mqpOTc4CzRJ4+2sL6GApK5CuSuU4xUdKsNzzZx5ZxfQcnBJhtLB6ejBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDAK7JsGHPsFqAY/Hjj7OEtgCDRSLKM6BQQHHKQl2PHZmx/AxHdWav7GE5z/vVyVmG8OQ==]
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
@@ -487,7 +484,6 @@ profile::jenkinscontroller::jcasc:
           os: "windows"
           os_version: "2019"
           launcher: "inbound"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAEDWY4jm5b9+cuyyygyxro0ei9gdjlctC/r7ArLUs8poPS/TtPRjC+HToOF52ZDp9cueq1qnFFbEkh5Y0IxFwC9FMRKkdCKmst7OnjcWCd2DOfgkau8SX0Y9UwVXKswv3xHGfAVDge6KmsXo0uVemafWgflhWKOlnQ8/EZyRQiq7GdGQEYAvN8RgSH+AhqTZgYYKdMdjHeMSw8AIKsBZgVkc/mKUZDicxbAwAw290jx5SgAGw4CGvzWe4SO57LxWhst1Y80KXY3NRcfNrqFUa+t4mIFCHfNk9c+eap+cSwVTvN20Y+0ClFccFqevQP5IOrRYPwsaYfdWoiUbDTh5zJDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAtlI9ee6IQCNrI7sv/L5ungCDnUJfb1bXoY0Vf45rbG2bujlYXAIuu5I+SR/5tmAqtFg==]
           location: "East US 2"
           instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
@@ -507,7 +503,6 @@ profile::jenkinscontroller::jcasc:
           os: "windows"
           os_version: "2022"
           launcher: "inbound"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAxqeuJ/JuJ8Z1sdTo3G/NLrcP7cYSC/m8w7+UE6Hdx3eH1aywUKjk+9nOIix9ccLvfhMNcPAqecLbkQBx2whqry/soSEMdK43Pk4yZluCtWGpfbAC3CH9CGSwMuf98T4azupZHYcttdo9ZSi1LD031G1fG7UTPFj74jMc9c+xnpF4h8zWmZLu7B4AA33bCQQfsjgcWn2vjRCL+8AcM70DH9SdPLb36RxCb1OGz4lTMhyFGMZe0cUcc8VOsg7XGUURX/m7apHghO5GN7KX02bb0tsLODbc2gJqi0YJPV17S3yijwadMGViaTCBS2cAGMKjmUO84dEUHqhMjuuARQ8JCjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAlsml6TC3ewPAJ5STsIHoggCAb2sm1Y7aJeaHEYPtIXKXlsktj2MjVoXuexTDgYPUx0w==]
           location: "East US 2"
           instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -74,6 +74,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: trusted-ci-jenkins-io-vnet
           virtualNetworkResourceGroupName: trusted-ci-jenkins-io
           subnetName: trusted-ci-jenkins-io-vnet-ephemeral-agents
+          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAV0UHUA2ynllZMXtGzQtnVBXgdAvS4vPHQULBOFbspqNInDLJgcOlkwo5yrc1yWdx6nZ0WPSoPBH8itNYsOhBO83b1ER0VuZiiQp20PUx5v4rkmHFe2XEA3VrVLKZyqoniwpf6FhgVEa0tujtN0K7m03/uuL/AAjejz9EmKvwmKaIQyT3dUMgXyxuOaklWJP+URAgsDSxFAUqEADIn90EMT2rzHYCkztU9Ron/By7WpAAfqWijdjluEoTFS8pWICkax7c/pKEmN/y0onaAy4sr49D9zyFX34dHYOaIntdVOAc/1A07dUa2S1yfwv/CAvubdS66quMykpOZG6AgbFxiDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAVnae6Xt49IT6H71Lb93PugCDdA8sP3KpmZN5g4Irwfu+/JUN0PMnZV7bKgFLpRWZDrA==]
       agent_definitions:
         - name: "ubuntu-22"
           description: "Ubuntu 22.04 LTS"
@@ -81,7 +82,6 @@ profile::jenkinscontroller::jcasc:
           os: "ubuntu"
           os_version: "22.04"
           launcher: "ssh"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAV0UHUA2ynllZMXtGzQtnVBXgdAvS4vPHQULBOFbspqNInDLJgcOlkwo5yrc1yWdx6nZ0WPSoPBH8itNYsOhBO83b1ER0VuZiiQp20PUx5v4rkmHFe2XEA3VrVLKZyqoniwpf6FhgVEa0tujtN0K7m03/uuL/AAjejz9EmKvwmKaIQyT3dUMgXyxuOaklWJP+URAgsDSxFAUqEADIn90EMT2rzHYCkztU9Ron/By7WpAAfqWijdjluEoTFS8pWICkax7c/pKEmN/y0onaAy4sr49D9zyFX34dHYOaIntdVOAc/1A07dUa2S1yfwv/CAvubdS66quMykpOZG6AgbFxiDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAVnae6Xt49IT6H71Lb93PugCDdA8sP3KpmZN5g4Irwfu+/JUN0PMnZV7bKgFLpRWZDrA==]
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
@@ -103,7 +103,6 @@ profile::jenkinscontroller::jcasc:
           os: "windows"
           os_version: "2019"
           launcher: "ssh"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAQ3r9h0iq+GWsy6L8+avm4Zyl+ceMIVwE4jkWtizO6Z2z4n7UMce0ykzGqS1N40q39Hav/u9RkKXC6ObIO2WOf1lSKEpGWdjQGijq5vFHvaak+BBX13t45ZVxeR2fApeUPDMMKreLh58G6NlgG59fJ9gH5SsTyyobZZvxbD2pKou3A9soL/5tm7Td2rSSls5zmKYZvvDooqR869fpaeaeIqmf5PlKpIznbYxYnedizPK1Hk/n+Du8J+h9+JlrRpHTr3euYqDbNxLmMaEBoZAi4PhPWXfJ1ODbfFlnap36VjbVNCzz3APUawLyHkz8WzAYflTTE1jHpYSag+h/AohLtTBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDHUZsei+WM3m6xpdMbw2MZgCA4qSXD+tuliubzmMN/baT3Lc/JLFa+kOtL5K4fy2Y9Vg==]
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
@@ -121,7 +120,6 @@ profile::jenkinscontroller::jcasc:
           os: "windows"
           os_version: "2022"
           launcher: "ssh"
-          storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAbAxg7BN6ITc6YT94PCxtwzZUwytEOTcWa0LK8/NJZNi5huyrSDb4XkFHbO0Fgmy/i110hZNY3kid27ZCm1//Aiq6Y0c3puLofOMydKg+KtrAzXJrWZ9GpJScH6jOHJoSjcHz7TmnwYXhJTLTgXW/I6qwsnL98SpdK1hikWnWjl0jtJhMT9yayAYsBPx9gyEgsOl0fhJNxb3lrTA4pWj+fvWFIuxsxs4iaXlRnWy/lqyoKH8JOOrmkrqvdEBmHy3TMW92bxxce3yARIaXoXdrxnEJKJUTaw7WYqxSG6t2CmeIyxGddWUomIQ8c9yqRYAWG7BE85YnDZPW+u9Jm/ijOzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDKCN844A+3necghexQVs2QgCB5e17lG0VeqtYMtMKPerxXMCDPjPVxKQaVWrM6L2/L+g==]
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -199,6 +199,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: "vnet"
           virtualNetworkResourceGroupName: "vnet-rg"
           subnetName: "vnet-agents"
+          storageAccount: SuperSecretEncryptedInProduction
         azure-vms-secondary:
           azureCredentialsId: "azure-secondary-credentials" # Managed manually
           resourceGroup: ci-jenkins-io-ephemeral-agents-secondary
@@ -207,6 +208,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "vnet-secondary-rg"
           subnetName: "vnet-secondary-subnet-agents"
           disableSpot: true # Not enough quota available
+          storageAccount: SuperSecretEncryptedInProductionSecondary
       agent_definitions:
         - name: "ubuntu-22-inbound"
           description: "Ubuntu 22.04 LTS"
@@ -214,7 +216,7 @@ profile::jenkinscontroller::jcasc:
           os: "ubuntu"
           os_version: "22.04"
           launcher: "inbound"
-          storageAccount: SuperSecretEncryptedInProduction
+
           location: "East US 2"
           instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
@@ -236,7 +238,6 @@ profile::jenkinscontroller::jcasc:
           os: "ubuntu"
           os_version: "22.04"
           launcher: "ssh"
-          storageAccount: SuperSecretEncryptedInProduction
           location: "East US 2"
           instanceType: Standard_D4pds_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
@@ -257,7 +258,6 @@ profile::jenkinscontroller::jcasc:
           os: "windows"
           os_version: "2019"
           launcher: "inbound"
-          storageAccount: SuperSecretEncryptedInProduction
           location: "East US 2"
           instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
@@ -278,7 +278,6 @@ profile::jenkinscontroller::jcasc:
           imageDefinition: jenkins-agent-windows-2022-amd64
           os: "windows"
           os_version: "2022"
-          storageAccount: SuperSecretEncryptedInProduction
           location: "East US 2"
           instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/jenkins-infra/pull/3189, this PR ensures the storage account is defined at the cloud level (same idea as https://github.com/jenkins-infra/jenkins-infra/pull/3190).


It fixes the ci.jenkins.io to use the new storage account with the new agent Azure VM cloud (instead of creating ephemeral ones)

Tested on a local vagrant setup.