### PR TITLE
feat(ci.jenkins.io) add ACI cloud on the secondary (sponsored) subscription

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -186,14 +186,14 @@ jenkins:
     <%- end -%>
   <%- end -%>
   <%- end -%>
-  <%- if @jcasc['cloud_agents']['azure-container-agents'] && !@jcasc['cloud_agents']['azure-container-agents'].empty? -%>
-    <%- @jcasc['cloud_agents']['azure-container-agents'].each do |aci_cloud_name, aci_cloud_setup| -%>
+  <%- if @jcasc['cloud_agents']['azure-container-agents'] && @jcasc['cloud_agents']['azure-container-agents']['clouds'] -%>
+    <%- @jcasc['cloud_agents']['azure-container-agents']['clouds'].each do |aci_cloud_name, aci_cloud_setup| -%>
   - aci:
       credentialsId: "<%= aci_cloud_setup['credentialsId'] %>"
       name: "<%= aci_cloud_name %>"
       resourceGroup: "<%= aci_cloud_setup['resourceGroup'] %>"
       templates:
-      <%- aci_cloud_setup['agent_definitions'].each do |agent| -%>
+      <%-  @jcasc['cloud_agents']['azure-container-agents']['agent_definitions'].each do |agent| -%>
       - command: "<%= agent['command'] %>"
         cpu: "<%= agent['cpus'] %>"
         image: "<%= @jcasc['agent_images']['container_images']['jnlp-' + agent['name'].to_s] %>"

--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -515,42 +515,46 @@ profile::jenkinscontroller::jcasc:
           usePrivateIP: true
           spot: true
     azure-container-agents:
-      aci-windows:
-        credentialsId: "azure-credentials"
-        resourceGroup: ci-jenkins-io-ephemeral-agents
-        agent_definitions:
-          - name: maven-8-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
-            labels:
-              - maven-windows
-          - name: maven-11-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
-            labels:
-              - maven-11-windows
-          - name: maven-17-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
-            labels:
-              - maven-17-windows
-          - name: maven-21-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
-            labels:
-              - maven-21-windows
+      clouds:
+        aci-windows:
+          credentialsId: azure-credentials
+          resourceGroup: ci-jenkins-io-ephemeral-agents
+        aci-windows-jenkins-sponsorship:
+          credentialsId: azure-jenkins-sponsorship-credentials
+          resourceGroup: ci-jenkins-io-ephemeral-agents
+      agent_definitions:
+        - name: maven-8-windows
+          os: windows
+          command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+          cpus: 4
+          memory: 8
+          agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
+          labels:
+            - maven-windows
+        - name: maven-11-windows
+          os: windows
+          command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+          cpus: 4
+          memory: 8
+          agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
+          labels:
+            - maven-11-windows
+        - name: maven-17-windows
+          os: windows
+          command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+          cpus: 4
+          memory: 8
+          agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
+          labels:
+            - maven-17-windows
+        - name: maven-21-windows
+          os: windows
+          command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+          cpus: 4
+          memory: 8
+          agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
+          labels:
+            - maven-21-windows
   artifact_caching_proxy:
     disabled: false
   datadog:

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -64,7 +64,7 @@ profile::jenkinscontroller::jcasc:
     azure_vm_agents:
       clouds:
         azure-vms:
-          azureCredentialsId: "azure-credentials"
+          azureCredentialsId: azure-credentials
           resourceGroup: ci-jenkins-io-ephemeral-agents
         azure-vms-jenkins-sponsorship:
           azureCredentialsId: "azure-jenkins-sponsorship-credentials" # Managed manually
@@ -112,18 +112,22 @@ profile::jenkinscontroller::jcasc:
           spot: false
           agentDir: 'C:/Foo'
     azure-container-agents:
-      aci-windows:
-        credentialsId: "azure-credentials"
-        resourceGroup: ci-jenkins-io-ephemeral-agents
-        agent_definitions:
-          - name: maven-11-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
-            labels:
-              - maven-11-windows
+      clouds:
+        aci-windows:
+          credentialsId: azure-credentials
+          resourceGroup: ci-jenkins-io-ephemeral-agents
+        aci-windows-jenkins-sponsorship:
+          credentialsId: azure-jenkins-sponsorship-credentials
+          resourceGroup: ci-jenkins-io-ephemeral-agents
+      agent_definitions:
+        - name: maven-11-windows
+          os: windows
+          command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+          cpus: 4
+          memory: 8
+          agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
+          labels:
+            - maven-11-windows
   artifact_caching_proxy:
     disabled: false
 # These are plugins we need in our ci environment

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -194,7 +194,7 @@ profile::jenkinscontroller::jcasc:
     azure_vm_agents:
       clouds:
         azure-vms:
-          azureCredentialsId: "azure-credentials"
+          azureCredentialsId: azure-credentials
           resourceGroup: ci-jenkins-io-ephemeral-agents
           virtualNetworkName: "vnet"
           virtualNetworkResourceGroupName: "vnet-rg"
@@ -290,34 +290,46 @@ profile::jenkinscontroller::jcasc:
           usePrivateIP: true
           spot: false
     azure-container-agents:
-      aci-windows:
-        credentialsId: "azure-credentials"
-        resourceGroup: ci-jenkins-io-ephemeral-agents
-        agent_definitions:
-          - name: maven-8-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
-            labels:
-              - maven-windows
-          - name: maven-11-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
-            labels:
-              - maven-11-windows
-          - name: maven-17-windows
-            os: windows
-            command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
-            cpus: 4
-            memory: 8
-            agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
-            labels:
-              - maven-17-windows
+      clouds:
+        aci-windows:
+          credentialsId: azure-credentials
+          resourceGroup: ci-jenkins-io-ephemeral-agents
+        aci-windows-jenkins-sponsorship:
+          credentialsId: azure-jenkins-sponsorship-credentials
+          resourceGroup: ci-jenkins-io-ephemeral-agents
+      agent_definitions:
+        - name: maven-8-windows
+          os: windows
+          command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+          cpus: 4
+          memory: 8
+          agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
+          labels:
+            - maven-windows
+        - name: maven-11-windows
+          os: windows
+          command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+          cpus: 4
+          memory: 8
+          agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
+          labels:
+            - maven-11-windows
+        - name: maven-17-windows
+          os: windows
+          command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+          cpus: 4
+          memory: 8
+          agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
+          labels:
+            - maven-17-windows
+        - name: maven-21-windows
+          os: windows
+          command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
+          cpus: 4
+          memory: 8
+          agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
+          labels:
+            - maven-21-windows
   artifact_caching_proxy:
     disabled: false
   datadog:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3818, this PR adds a 2nd ACI cloud configuration on ci.jenkins.io to use the secondary subscription.


Note: no changes applied to the hieradata configuration for trusted.ci or cert.ci as they do not use ACI.