### PR TITLE
feat(jenkinscontroller) add the ACI cloud name to the labels of its templates

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -197,7 +197,7 @@ jenkins:
       - command: "<%= agent['command'] %>"
         cpu: "<%= agent['cpus'] %>"
         image: "<%= @jcasc['agent_images']['container_images']['jnlp-' + agent['name'].to_s] %>"
-        label: "<%= agent['os'] %> azure aci container <%= agent['labels'].join(' ') %>"
+        label: "<%= agent['os'] %> azure aci container <%= agent['labels'].join(' ') %> <%= aci_cloud_name %>"
         memory: "<%= agent['memory'] %>"
         name: "aci-<%= agent['name'] %>"
         osType: "<%= agent['os'] == "windows" ? 'Windows' : 'Linux' %>"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3818

This PR has been tested in a local vagrant (with before/after diff) VM.

Only impacts ci.jenkins.io (as it is the only one with ACI agents)

(edited) Same as https://github.com/jenkins-infra/jenkins-infra/pull/3198 but for ACI agents