### PR TITLE
cleanup(ci.jenkins.io) remove the ACI cloud (primary azure subscription) to only rely on the sponsored subscription

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -516,9 +516,6 @@ profile::jenkinscontroller::jcasc:
           spot: true
     azure-container-agents:
       clouds:
-        aci-windows:
-          credentialsId: azure-credentials
-          resourceGroup: ci-jenkins-io-ephemeral-agents
         aci-windows-jenkins-sponsorship:
           credentialsId: azure-jenkins-sponsorship-credentials
           resourceGroup: ci-jenkins-io-ephemeral-agents


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3818

This PR removes the former subscription to only uses the sponsored one for ACI.