### PR TITLE
Upgrade Groovy to latest 2.4.x version

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -72,7 +72,7 @@ profile::jenkinscontroller::jcasc:
   tools:
     groovy:
       groovy: # Default version is named "groovy"
-        version: "2.4.7"
+        version: "2.4.21"
     jdk:
       jdk8:
         installers:

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -44,7 +44,7 @@ profile::jenkinscontroller::jcasc:
   tools:
     groovy:
       groovy: # Default version is named "groovy"
-        version: "2.4.7"
+        version: "2.4.21"
     jdk:
       jdk8:
         installers:

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -14,7 +14,7 @@ profile::jenkinscontroller::jcasc:
   tools:
     groovy:
       groovy: # Default version is named "groovy"
-        version: "2.4.7"
+        version: "2.4.21"
       jdk11:
         installers:
           linux-arm64:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -56,7 +56,7 @@ profile::jenkinscontroller::jcasc:
   tools:
     groovy:
       groovy: # Default version is named "groovy"
-        version: "2.4.7"
+        version: "2.4.21"
     jdk:
       jdk8:
         installers:


### PR DESCRIPTION
This is needed for https://github.com/jenkins-infra/crawler/pull/136 to be able to run on Java 9+.

### Testing done

I have already changed this setting on https://ci.jenkins.io in the web UI and verified that these jobs build successfully:

- https://ci.jenkins.io/job/Infra/job/crawler/job/master/
- https://ci.jenkins.io/job/Infra/job/javadoc/job/master/
- https://ci.jenkins.io/job/Infra/job/crawler/job/PR-136/4/