### PR TITLE
Replace code-coverage-api with coverage

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -568,7 +568,7 @@ profile::jenkinscontroller::plugins:
   - buildtriggerbadge # Add an icon with the build cause in the build history
   - build-discarder # Remove older builds if no policy defined - https://github.com/jenkins-infra/helpdesk/issues/3495
   - cloudbees-folder # Provides a job type "Folder"
-  - code-coverage-api # Provides nice code covergae view in the Web UI (used by multiple downstream plugins)
+  - coverage # Provides nice code covergae view in the Web UI (used by multiple downstream plugins)
   - config-file-provider # Used to provide Maven settings for proxies
   - configuration-as-code # Required for CasC
   - credentials # Provides Jenkins Credentials management

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -347,7 +347,7 @@ profile::jenkinscontroller::plugins:
   - buildtriggerbadge
   - build-discarder # Remove older builds if no policy defined - https://github.com/jenkins-infra/helpdesk/issues/3495
   - cloudbees-folder
-  - code-coverage-api
+  - coverage
   - config-file-provider
   - configuration-as-code
   - credentials


### PR DESCRIPTION
ref https://github.com/jenkins-infra/helpdesk/issues/3880

![Screenshot 2023-12-29 at 20 59 20](https://github.com/jenkins-infra/jenkins-infra/assets/13383509/ee071cef-aeed-4aca-afc6-cf73e1fc63ce)

I've created a local instance with the plugins installed to check that there's no dependent left, allowing us to remove the plugin from the file.

Once merged and applied, an admin of ci.j still needs to delete the plugin.