### PR TITLE
chore(controller.ci.jenkins.io): disable DigitalOcean agents

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -288,7 +288,7 @@ profile::jenkinscontroller::jcasc:
             cpus: 1
             memory: 1
       doks:
-        enabled: true
+        enabled: false # While working on https://github.com/jenkins-infra/helpdesk/issues/3916
         provider: do
         credentialsId: "doks-jenkins-agent-sa-token"
         serverCertificate: >


### PR DESCRIPTION
This PR disables DO agents for ci.jenkins.io while we work on https://github.com/jenkins-infra/helpdesk/issues/3916.