### PR TITLE
feat: add the new (sponsored) vnet routes to routing table of the VPN VM

### DIFF
--- a/hieradata/clients/private.vpn.jenkins.io.yaml
+++ b/hieradata/clients/private.vpn.jenkins.io.yaml
@@ -11,9 +11,13 @@ profile::openvpn::networks:
     network_cidr: 10.248.1.0/24
     peered_network_cidrs:
       - 10.244.0.0/14 # Access to the public-vnet network
+      - 10.200.0.0/14 # Access to the public-sponsorship vnet network
       - 10.253.0.0/21 # Access to the public-db network
+      - 10.206.0.0/23 # Access to the infra-ci-sponsorship vnet network
       - 10.252.8.0/21 # Access to the cert-ci-jenkins-io network
+      - 10.205.8.0/24 # Access to the cert-ci-jenkins-io-sponsorship network
       - 10.252.0.0/21 # Access to the trusted-ci-jenkins-io network
+      - 10.204.0.0/24 # Access to the trusted-ci-jenkins-io-sponsorship network
 profile::openvpn::vpn_network:
   name: private
   # Abstract network


### PR DESCRIPTION
Follow up of https://github.com/jenkins-infra/docker-openvpn/pull/326

Since https://github.com/jenkins-infra/helpdesk/issues/3818, there is a whole lot bunch of new virtual networks.

Our VPN virtual machine must be able to route to this new networks otherwise we can't reach new VMs such as in https://github.com/jenkins-infra/helpdesk/issues/3913

For proper review or audit: list of vnet and their CIDRs are defined here: https://github.com/jenkins-infra/azure-net/blob/main/vnets.tf