### PR TITLE
feat(ci.jenkins.io) enable datadog log collection for the controller

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -23,7 +23,6 @@ datadog_agent::apm_enabled: true
 datadog_agent::apm_non_local_traffic: true # Allow jenkins container to contact the agent for traces and logs
 datadog_agent::agent_extra_options:
   bind_host: "0.0.0.0" # All hosts interfaces to allow container access
-datadog_agent::container_collect_all: false # Don't collect Jenkins container logs (the only container running) as we're already collecting these logs via the Datadog plugin
 profile::jenkinscontroller::anonymous_access: true
 profile::jenkinscontroller::admin_ldap_groups:
   - admins


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3943

This PR removes the attribute which disable log collection on the controller ci.jenkins.io.

Tested locally and works as expected (with valid collection on datadog).