### PR TITLE
hotfix(pkg,agent.trusted) correct binary absolute paths for azcopy installation

### DIFF
--- a/dist/profile/manifests/azcopy.pp
+++ b/dist/profile/manifests/azcopy.pp
@@ -1,6 +1,7 @@
 # Profile to ensure `azcopy` is installed, up-to-date and set up (SAS token generation, etc.)
 class profile::azcopy (
   String $version
+  String $install_dir = '/usr/local/bin'
 ) {
   # There is no linux_aarch64 azcopy release, considering that aarch64 = arm64 so vagrant can run on Mac Silicon
   $architecture = $facts['os']['architecture'] ? {
@@ -17,10 +18,11 @@ class profile::azcopy (
   if $version {
     $azcopysemver = split($version, /-/)[0]
     $azcopy_url = "https://azcopyvnext.azureedge.net/releases/release-${version}/azcopy_linux_${architecture}_${azcopysemver}.tar.gz"
+
     exec { 'Install azcopy':
       require => [Package['curl'], Package['tar']],
-      command => "/usr/bin/curl --location ${azcopy_url} | /usr/bin/tar --extract --gzip --strip-components=1 --directory=/usr/local/bin/ --wildcards '*/azcopy' && chmod a+x /usr/local/bin/azcopy",
-      unless  => "/usr/bin/test -f /usr/local/bin/azcopy && /usr/local/bin/azcopy --version | /bin/grep --quiet ${azcopysemver}",
+      command => "/usr/bin/curl --location ${azcopy_url} | /bin/tar --extract --gzip --strip-components=1 --directory=${install_dir}/ --wildcards '*/azcopy' && chmod a+x ${install_dir}/azcopy",
+      unless  => "/usr/bin/test -f ${install_dir}/azcopy && ${install_dir}/azcopy --version | /bin/grep --quiet ${azcopysemver}",
     }
   }
 }


### PR DESCRIPTION
Fixup of #3295 to avoid the error 

```
sh: 1: /usr/bin/tar: not found
```

Notes:

- As per https://packages.ubuntu.com/jammy/amd64/tar/filelist, the file `/bin/tar` is where the Ubuntu package installs the binary. In our case, some machines such as `agent.trusted.ci.jenkins.io` have a symlink `/bin -> usr/bin` and others are not (such as `pkg.origin.jenkins.io`). So we stick to the official package path.
- This PR also contains a factorization of the installation directory of `azcopy` to a profile-level variable with the default value `/usr/local/bin` alongside the fix