### PR TITLE
fix(profiles `azcopy` / `buildagent`) fix version checks and tools installation

### DIFF
--- a/dist/profile/manifests/azcopy.pp
+++ b/dist/profile/manifests/azcopy.pp
@@ -22,7 +22,7 @@ class profile::azcopy (
     exec { 'Install azcopy':
       require => [Package['curl'], Package['tar']],
       command => "/usr/bin/curl --location ${azcopy_url} | /bin/tar --extract --gzip --strip-components=1 --directory=${install_dir}/ --wildcards '*/azcopy' && chmod a+x ${install_dir}/azcopy",
-      unless  => "/usr/bin/test -f ${install_dir}/azcopy && ${install_dir}/azcopy --version | /bin/grep --quiet ${azcopysemver}",
+      unless  => "/usr/bin/test -f ${install_dir}/azcopy && ${install_dir}/azcopy --version | /bin/grep --quiet 'azcopy ${azcopysemver}:'",
     }
   }
 }

--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -83,6 +83,12 @@ class profile::buildagent (
       }
     }
 
+    # There is no linux_aarch64 azcopy release, considering that aarch64 = arm64 so vagrant can run on Mac Silicon
+    $architecture = $facts['os']['architecture'] ? {
+      'aarch64' => 'arm64',
+      default   => $facts['os']['architecture'],
+    }
+
     if $tools_versions['kubectl'] {
       $kubectl_url = "https://dl.k8s.io/release/${tools_versions['kubectl']}/bin/linux/${architecture}/kubectl"
       exec { 'Install kubectl':


### PR DESCRIPTION
This PR corrects 2 PRs related to `azcopy`:

- Fixup of #3173 which is not strict enough when checking the `azcopy` version, as the latest available version can be printed alongside the current version in the output of `azcopy --version`
  - Tested locally

- Fixup of #3295 which removed the `$architecture` variable from the profile `buildagent` when factorizing `azcopy`