### PR TITLE
hotfix(azcopy) ensure version check is idempotent

### DIFF
--- a/dist/profile/manifests/azcopy.pp
+++ b/dist/profile/manifests/azcopy.pp
@@ -22,7 +22,7 @@ class profile::azcopy (
     exec { 'Install azcopy':
       require => [Package['curl'], Package['tar']],
       command => "/usr/bin/curl --location ${azcopy_url} | /bin/tar --extract --gzip --strip-components=1 --directory=${install_dir}/ --wildcards '*/azcopy' && chmod a+x ${install_dir}/azcopy",
-      unless  => "/usr/bin/test -f ${install_dir}/azcopy && ${install_dir}/azcopy --version | /bin/grep --quiet 'azcopy ${azcopysemver}:'",
+      unless  => "/usr/bin/test -f ${install_dir}/azcopy && ${install_dir}/azcopy --version --skip-version-check | /bin/grep --quiet ${azcopysemver}",
     }
   }
 }


### PR DESCRIPTION
Fixup of #3302 

As I checked the upgrade was effective, but not the idempotency.

If you run puppet twice, you see `azcopy` being reinstalled on each run, while it should not:

```
Notice: /Stage[main]/Profile::Azcopy/Exec[Install azcopy]/returns: executed successfully
```

This PR fixes this behavior by using the `--skip-version-check` flag on `azcopy` as it is built for automation and scripts.


Note: tested multiple scenarios locally with success (install from scratch on 10.21 version + idempotency + upgrade to 10.23 + idempotency)