### PR TITLE
chore(updatecli): track kubectl version

### DIFF
--- a/updatecli/weekly.d/kubectl.yaml
+++ b/updatecli/weekly.d/kubectl.yaml
@@ -1,0 +1,57 @@
+---
+name: Bump `kubectl` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getPackerImageDeployedVersion:
+    kind: yaml
+    name: Retrieve the current version of the Packer images used in production
+    spec:
+      file: hieradata/common.yaml
+      key: $.profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version
+  # Retrieving kubectl from packer-images to synchronize its version across our infra
+  getKubectlVersionFromPackerImages:
+    kind: file
+    name: Get the latest kubectl version set in packer-images
+    dependson:
+      - getPackerImageDeployedVersion
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getPackerImageDeployedVersion" }}/provisioning/tools-versions.yml
+      matchpattern: 'kubectl_version:\s(.*)'
+    transformers:
+      - findsubmatch:
+          pattern: 'kubectl_version:\s(.*)'
+          captureindex: 1
+
+targets:
+  updateHieradataVersion:
+    name: Update the `kubectl` version in the hieradata/common.yaml file
+    sourceid: getKubectlVersionFromPackerImages
+    kind: yaml
+    spec:
+      files:
+        - hieradata/clients/agent.trusted.ci.jenkins.io.yaml
+        - hieradata/vagrant/common.yaml
+      key: $.profile::buildagent::tools_versions.kubectl
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump `kubectl` version to {{ source "getKubectlVersionFromPackerImages" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - kubectl


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3948

this PR adds an updatecli manifest tracking the kubectl CLI version to keep it up to date with the AllInOne image used in production.

once merged a subsequent PR is expected (automatically created by updatecli) to bump kubectl to 1.27.x 

Note: using AllInOne image as source (instead of regex version constraint) avoids to forget updating the regex when upgrading kubernetes.