### PR TITLE
feat(pkg,agent): add `azure-cli`

### DIFF
--- a/dist/profile/manifests/azcopy.pp
+++ b/dist/profile/manifests/azcopy.pp
@@ -1,8 +1,10 @@
-# Profile to ensure `azcopy` is installed, up-to-date and set up (SAS token generation, etc.)
+# Profile to ensure `azcopy` and `az-cli` are installed, up-to-date and set up (SAS token generation, etc.)
 class profile::azcopy (
-  String $version,
-  String $install_dir = '/usr/local/bin',
+  String $azcopy_version,
+  String $az_cli_version,
+  String $install_dir   = '/usr/local/bin',
 ) {
+  include apt
   # There is no linux_aarch64 azcopy release, considering that aarch64 = arm64 so vagrant can run on Mac Silicon
   $architecture = $facts['os']['architecture'] ? {
     'aarch64' => 'arm64',
@@ -15,14 +17,34 @@ class profile::azcopy (
       'tar',
   ])
 
-  if $version {
-    $azcopysemver = split($version, /-/)[0]
-    $azcopy_url = "https://azcopyvnext.azureedge.net/releases/release-${version}/azcopy_linux_${architecture}_${azcopysemver}.tar.gz"
+  if $azcopy_version {
+    $azcopysemver = split($azcopy_version, /-/)[0]
+    $azcopy_url = "https://azcopyvnext.azureedge.net/releases/release-${azcopy_version}/azcopy_linux_${architecture}_${azcopysemver}.tar.gz"
 
     exec { 'Install azcopy':
       require => [Package['curl'], Package['tar']],
       command => "/usr/bin/curl --location ${azcopy_url} | /bin/tar --extract --gzip --strip-components=1 --directory=${install_dir}/ --wildcards '*/azcopy' && chmod a+x ${install_dir}/azcopy",
       unless  => "/usr/bin/test -f ${install_dir}/azcopy && ${install_dir}/azcopy --version --skip-version-check | /bin/grep --quiet ${azcopysemver}",
+    }
+  }
+
+  if $az_cli_version {
+    apt::source { 'microsoft':
+      comment  => 'microsoft',
+      location => 'https://packages.microsoft.com/repos/azure-cli/',
+      repos    => 'main',
+      key      => {
+        # id retrieved by running "gpg microsoft.asc"
+        id     => 'BC528686B50D79E339D3721CEB3E94ADBE1229CF',
+        name   => 'microsoft.asc',
+        source => 'https://packages.microsoft.com/keys/microsoft.asc',
+      },
+    }
+
+    package { 'azure-cli':
+      # azure-cli package have additional suffixes to their semver version like "<az_cli_version>-1~bionic"
+      ensure  => "${az_cli_version}-1~${facts['os']['distro']['codename']}",
+      require => Class['apt::update'],
     }
   }
 }

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -278,7 +278,8 @@ docker::version: 5:25.0.3-1~ubuntu.22.04~jammy
 # distribution Jenkins core releases
 azure::releases::account_name: "overridewithstorageaccountname"
 azure::releases::access_key: "overridewithaccesskey"
-profile::azcopy::version: 10.23.0-20240129
+profile::azcopy::azcopy_version: 10.23.0-20240129
+profile::azcopy::az_cli_version: 2.57.0
 profile::datadog_pluginsite_check::sites:
   - plugins.jenkins.io
 limits:

--- a/spec/classes/profile/azcopy_spec.rb
+++ b/spec/classes/profile/azcopy_spec.rb
@@ -5,4 +5,5 @@ describe 'profile::azcopy' do
   it { is_expected.to contain_exec('Install azcopy') }
   it { is_expected.to contain_package('curl') }
   it { is_expected.to contain_package('tar') }
+  it { is_expected.to contain_package('azure-cli') }
 end


### PR DESCRIPTION
This PR adds `azure-cli` if its version is set in hieradata, needed to generate short-lived SAS token for file share with a service principal.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1952035761
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1973817455