### PR TITLE
feat(pkg,agent): include `get-fileshare-signed-url.sh` script

### DIFF
--- a/dist/profile/manifests/azcopy.pp
+++ b/dist/profile/manifests/azcopy.pp
@@ -46,5 +46,11 @@ class profile::azcopy (
       ensure  => "${az_cli_version}-1~${facts['os']['distro']['codename']}",
       require => Class['apt::update'],
     }
+
+    file { '/usr/local/bin/get-fileshare-signed-url.sh':
+      ensure => file,
+      mode   => '0755',
+      source => 'https://raw.githubusercontent.com/jenkins-infra/pipeline-library/master/resources/get-fileshare-signed-url.sh',
+    }
   }
 }


### PR DESCRIPTION
This PR includes the script from the shared pipeline library to generate short-lived SAS token for a File Share with a service principal so it's available and kept up to date for everything needing it:
- crawler
- update-center2
- mirror-scripts

Follow-up of:
- #3322 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1952035761
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1973817455