### PR TITLE
chore(updatecli): fix `azcopy` target

### DIFF
--- a/updatecli/weekly.d/azcopy.yaml
+++ b/updatecli/weekly.d/azcopy.yaml
@@ -29,7 +29,7 @@ targets:
     kind: yaml
     spec:
       file: hieradata/common.yaml
-      key: $.profile::azcopy::version
+      key: $.profile::azcopy::azcopy_version
     scmid: default
 
 actions:


### PR DESCRIPTION
This PR fixes the target of `azcopy` updatecli manifest.

Fixup of:
- #3322 
