### PR TITLE
feat(ci.jenkins.io): Adding a label `linux-arm64` for arm64 VM to match infra.ci

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -431,6 +431,7 @@ profile::jenkinscontroller::jcasc:
             - ubuntu
             - arm64docker
             - arm64linux
+            - linux-arm64
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3823#issuecomment-1961400721
allow to use the same label for both ci and infra.ci unified pipeline for ARM64