### PR TITLE
feat(profile::jenkinscontroller) change Maven mirror `settings.xml` file to use "unified" ACP

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -10,13 +10,8 @@ unclassified:
             <mirrors>
               <mirror>
                   <id><%= providerId %>-proxy</id>
-                  <url>https://repo.<%= providerId %>.jenkins.io/public/</url>
-                  <mirrorOf>external:*,!central,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven</mirrorOf>
-              </mirror>
-              <mirror>
-                  <id><%= providerId %>-proxy-incrementals</id>
-                  <url>https://repo.<%= providerId %>.jenkins.io/incrementals/</url>
-                  <mirrorOf>incrementals</mirrorOf>
+                  <url>https://repo.<%= providerId %>.jenkins.io/</url>
+                  <mirrorOf>external:*,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven</mirrorOf>
               </mirror>
             </mirrors>
             <profiles>


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3969

This PR updates the Maven `settings.xml` used by agents to fit with the [1.0.0 version of ACP](https://github.com/jenkins-infra/helm-charts/pull/1110)