### PR TITLE
cleanup: remove superseded blobxfer variable and checks

### DIFF
--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -141,7 +141,6 @@ Host ftp-osl.osuosl.org
     group   => $mirror_group,
     mode    => '0600',
     content => "
-export AZURE_STORAGE_ACCOUNT=${lookup('azure::getjenkinsio::storageaccount')}
 export STORAGE_NAME=${lookup('azure::getjenkinsio::storageaccount')}
 export STORAGE_FILESHARE=${lookup('azure::getjenkinsio::fileshare')}
 export AZURE_STORAGE_KEY=${lookup('azure::getjenkinsio::storagekey')}

--- a/dist/profile/templates/mirror-scripts/sync-recent-releases.sh.erb
+++ b/dist/profile/templates/mirror-scripts/sync-recent-releases.sh.erb
@@ -16,7 +16,6 @@ echo ">> Update artifacts on get.jenkins.io"
 ## Tell shellcheck to NOT check the sourced file (as it is not available when running shellcheck outside of production)
 #shellcheck disable=SC1091
 source "<%= @azure_storage_env_file %>"
-: "${AZURE_STORAGE_ACCOUNT?}" "${AZURE_STORAGE_KEY?}" "${STORAGE_NAME?}" "${STORAGE_FILESHARE?}"
 
 RECENT_RELEASES=$( jq --raw-output '.releases[] | .name + "/" + .version' "${RECENT_RELEASES_JSON}" )
 if [[ -z "${RECENT_RELEASES}" ]] ; then

--- a/dist/profile/templates/mirror-scripts/sync.sh.erb
+++ b/dist/profile/templates/mirror-scripts/sync.sh.erb
@@ -83,7 +83,6 @@ if [[ "${FLAG}" = '--full-sync' ]]; then
   ## Tell shellcheck to NOT check the sourced file (as it is not available when running shellcheck outside of production)
   #shellcheck disable=SC1091
   source "<%= @azure_storage_env_file %>"
-  : "${AZURE_STORAGE_ACCOUNT?}" "${AZURE_STORAGE_KEY?}"
 
   export STORAGE_DURATION_IN_MINUTE=30 #TODO: to be adjusted
   export STORAGE_PERMISSIONS=dlrw


### PR DESCRIPTION
This PR removes the `AZURE_STORAGE_ACCOUNT` variable previously used by blobxfer in pkg sync scripts (its value is also in `STORAGE_NAME`, used by the get-fileshare-signed-url.sh script) and associated checks that were added to pass shellcheck before implementing azcopy as replacement of blobxfer in https://github.com/jenkins-infra/mirror-scripts/pull/14.

Verification procedure after merging this PR: ensure update_center job still passes on trusted.ci.jenkins.io

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-2034806598