### PR TITLE
chore(Jenkinsfile_updatecli) no need to run `updatecli diff` on the principal branch

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -13,6 +13,9 @@ pipeline {
   }
   stages {
     stage('Check Configuration Update') {
+      when {
+        expression { not { env.BRANCH_IS_PRIMARY } }
+      }
       // Run updatecli's diff on both push and pull requests (in case a configuration change breaks updatecli)
       steps {
         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {


### PR DESCRIPTION
=> faster detection of new dependencies!