### PR TITLE
chore(ci.jenkins.io): switch default notification URL to Jenkins Classic

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -50,6 +50,8 @@ profile::jenkinscontroller::jcasc:
               discarder:
                 logRotator:
                   numToKeepStr: "5"
+      defaultDisplayUrlProvider:
+        providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
   artifact-manager:
     data: |-
       unclassified:


### PR DESCRIPTION
This PR switches the default notification URL of ci.jenkins.io from "default" to "Jenkins Classic" so `display/redirect` links redirect to the main build page instead of the less useful pipeline graph view page.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2833#issuecomment-2100635026

