### PR TITLE
Revert "chore(ci.jenkins.io): switch default notification URL to Jenkins Classic"

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -50,8 +50,6 @@ profile::jenkinscontroller::jcasc:
               discarder:
                 logRotator:
                   numToKeepStr: "5"
-      defaultDisplayUrlProvider:
-        providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
   artifact-manager:
     data: |-
       unclassified:


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#3414

Got the following error when reloading jcasc config on ci.jenkins.io:

![image](https://github.com/jenkins-infra/jenkins-infra/assets/91831478/1d78917c-e451-42df-8468-9ca4ec3710d5)

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2833
