### PR TITLE
hotfix(ci.jenkins.io) remove S3 artifact manager plugin and configuration

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -50,24 +50,6 @@ profile::jenkinscontroller::jcasc:
               discarder:
                 logRotator:
                   numToKeepStr: "5"
-  artifact-manager:
-    data: |-
-      unclassified:
-        artifactManager:
-          artifactManagerFactories:
-          - jclouds:
-              provider: "s3"
-      aws:
-        awsCredentials:
-          credentialsId: "aws-s3-artifact-manager"
-          region: "us-east-2"
-        s3:
-          container: "ci-jenkins-io-artifacts"  # Resource defined in jenkins-infra/aws/ci.jenkins.io.tf
-          disableSessionToken: false            # For non AWS services only
-          prefix: "ci.jenkins.io/"              # Rule of thumb: Controller's hostname
-          useHttp: false                        # TLS for everyone \o/
-          usePathStyleUrl: false                # For non AWS services only
-          useTransferAcceleration: false        # Too expensive
   tools:
     groovy:
       groovy: # Default version is named "groovy"
@@ -561,7 +543,6 @@ profile::jenkinscontroller::jcasc:
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor # Provides ANSI color in the UI when checking log outputs
-  - artifact-manager-s3 # Store Artifact and stashes in AWS S3 (instead of the VM JENKINS_HOME directory)
   - azure-container-agents # ACI agents
   - azure-vm-agents # Azure VM Agents
   - blueocean # A nice view for pipelines


### PR DESCRIPTION
We disabled the S3 artifact manager plugin the 14th of May. But it restarted the controller and started to fail terribly (HTTP/503 error during class loading).

This PR (hot-)fixes this problem by removing JCas config and stop trying to install the plugin.

Related to https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2112395520