### PR TITLE
hotfix(ci.jenkins.io) correct the JCasc configuration for the BOM agents on AKS

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -576,7 +576,7 @@ profile::jenkinscontroller::jcasc:
           2v4qWQVeWfx8spHopW6fH9H6QwqsXZJ/rQqjZx8feO2rG3xc4UXndqmlvmUG
           JVN7Kz/PNG4ozveOV2YsCN+DFfxD5rNSl5GhVnfQkgRSwGTuZnKdJ9xVIx5f
           KjkyriOLova9/0vsl1ewMtKREDUYlH5s6B/ZKHJlas0cpV780JRgE=]
-        defaultNamespace: jenkins-agents
+        defaultNamespace: jenkins-agents-bom
         max_capacity: 150 # TODO: Re-evaluate and setup updatecli
         url: ENC[PKCS7,MIIBqQYJKoZIhvcNAQcDoIIBmjCCAZYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAc0StQoSNO1r57vSJe9WktTQV6ibUu7hN6XkzjrUFwcLC81hLR7WK88EKEatPKkG/Nv3ZdnZDnBDOA1Zj+vrFWgXVqdXAe+Xw0pU3QX894US9wNaS7+uwviUPxd91lIvwIde69MdG22oStSlOkZimdJQ3YZfb2sCROlqb0I6mi2SEsqYLUPoOkW4FIqyfIwk0+//diCKMrSDd20YZKre7vnXj1rEmMIMZvGkXlDOlTjCAJ7mqX9xEU1JWpbxaQ+zuO9q8PmtE/ZPQ7uVEjClBDMJA04nRBKe8LUmSvB7FvsOIdfwFZ3+kliZf5NjZAoxJ76NQjPmJR6k7fxjQBGJtdzBsBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCs1F+GHCCnyGtd3LYjZxdNgEAzPr1zdAaCJy6JIyYTb3iIXBGLVQppVz8GrOqexBitGOYzuEloomLv7205Jl0qy31xyPk2n4KzZYKvKjsd+EqH]
         agent_definitions:
@@ -587,7 +587,7 @@ profile::jenkinscontroller::jcasc:
               - maven-bom-helpdesk-3954
             cpus: 4
             memory: 12
-            nodeSelector: "role=jenkins-agents"
+            nodeSelector: "role=jenkins-agents-bom"
             tolerations:
               - key: "ci.jenkins.io/agents"
                 operator: "Equal"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2114950444

This PR fixes the configuration for the ci.jenkins.io's BOM agent to allow running in the new AKS cluster with 2 changes:

- Ensure pods are scheduled on the dedicated BOM node pool (requires https://github.com/jenkins-infra/azure/pull/701)
- Fixes the namespace used for agent BOM to fix the HTTP/403 error (see https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2114950444)