### PR TITLE
feat(ci.jenkins.io) add a new Kubernetes Pod agent for jenkinsci/packaging

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -249,6 +249,20 @@ profile::jenkinscontroller::jcasc:
                 operator: "Equal"
                 value: "true"
                 effect: "NoSchedule"
+          - name: jnlp-packaging
+            imageName: packaging
+            javaHome: /opt/jdk-17
+            labels:
+              - packaging
+              - jnlp-packaging
+            cpus: 1
+            memory: 1
+            nodeSelector: "role=jenkins-agents"
+            tolerations:
+              - key: "ci.jenkins.io/agents"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
           - name: jnlp
             agentJavaBin: /opt/java/openjdk/bin/java
             javaHome: /opt/java/openjdk

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -232,6 +232,7 @@ profile::jenkinscontroller::jcasc:
       jnlp-webbuilder: jenkinsciinfra/builder:latest@sha256:e7370e29fc1aefa0daffe2b72ba7d1f59d84b44ddc451f8a140610b66cd99eb8
       # default template from the official inbound-agent image here to provide a default agent (`node()` pipeline step)
       jnlp: jenkins/inbound-agent:latest-jdk17@sha256:d35ded3be6daaa839dd1cef181f2dd424f95ea4088374130f6e87e3bacd637f7
+      jnlp-packaging: jenkinsciinfra/packaging:latest
   tools_default_versions:
     jdk8: 8u412-b08
     jdk11: 11.0.23+9


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4106, this PR introduces a new administrator-managed Pod template to be used in https://github.com/jenkinsci/packaging/pull/465