### PR TITLE
fix(profile::jenkinscontroller) Keep indentation to prevent JCasC misconfiguration

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/unclassified.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/unclassified.yaml.erb
@@ -1,4 +1,4 @@
-<%- if @jcasc['unclassified'] && @jcasc['unclassified']['data'] -%>
+<% if @jcasc['unclassified'] && @jcasc['unclassified']['data'] -%>
 unclassified:
   <%= @jcasc['unclassified']['data'] %>
-<%- end -%>
+<% end -%>


### PR DESCRIPTION
Fix was tested on the Vagrant machine profile::jenkinscontroller and JCasC was successfully configured. 