### PR TITLE
chore(pipeline): cleanup useless env and install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,24 +10,9 @@ pipeline {
         timestamps()
     }
 
-    environment {
-        // To allow using ASDF shims
-        PATH = "${env.PATH}:/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin"
-    }
-
     stages {
         stage('Prepare Puppet Project') {
             steps {
-                // Install `yq` until https://github.com/jenkins-infra/packer-images/pull/277 is merged and available
-                sh '''
-                if ! command -v yq >/dev/null 2>&1
-                then
-                    asdf plugin-add yq https://github.com/sudermanjr/asdf-yq.git || true
-                    asdf install yq 4.25.3
-                    asdf global yq 4.25.3
-                fi
-                '''
-
                 // Install Dependencies once for all
                 sh 'bash ./scripts/setupgems.sh'
                 // For auditing purposes: if tests are failing with "module not found" or "object not found" for instance


### PR DESCRIPTION
as https://github.com/jenkins-infra/packer-images/pull/277 is merged, no need to install yq and no need to specify asdf in path anymore.