### PR TITLE
feat(ci.jenkins.io): Default notification URL switched to Jenkins Classic

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/unclassified.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/unclassified.yaml.erb
@@ -1,4 +1,4 @@
-<%- if @jcasc['unclassified'] && @jcasc['unclassified']['data'] -%>
+<% if @jcasc['unclassified'] && @jcasc['unclassified']['data'] -%>
 unclassified:
   <%= @jcasc['unclassified']['data'] %>
-<%- end -%>
+<% end -%>

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -46,6 +46,8 @@ profile::jenkinscontroller::jcasc:
               discarder:
                 logRotator:
                   numToKeepStr: "5"
+      defaultDisplayUrlProvider:
+        providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
   tools:
     groovy:
       groovy: # Default version is named "groovy"


### PR DESCRIPTION
The JCasC template was modified (Using [Hervé solution](https://github.com/jenkins-infra/jenkins-infra/pull/3414)) and tested on Vagrant machine profile::jenkinscontroller with success.

Ref:         [Replace Blue Ocean in default display URL (or remove the Blue Ocean plugins) #2833](https://github.com/jenkins-infra/helpdesk/issues/2833)