### PR TITLE
chore(updatecli) use native YAML and HCL resources feature to parse remote files or checking keys in conditions

### DIFF
--- a/updatecli/weekly.d/docker-ce.yaml
+++ b/updatecli/weekly.d/docker-ce.yaml
@@ -24,11 +24,12 @@ sources:
 
 conditions:
   checkIfHieradataCommonHasDockerVersionKey:
-    kind: file
+    kind: yaml
     disablesourceinput: true
     spec:
       file: hieradata/common.yaml
-      matchpattern: "docker::version:.*"
+      keyonly: true
+      key: $.docker::version
 
 targets:
   UpdateHieradataCommonHasDockerVersionKey:

--- a/updatecli/weekly.d/jenkinscontroller-agents-windows-vm-disk-size.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents-windows-vm-disk-size.yaml
@@ -22,18 +22,12 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
   getWindowsVMAgentsDiskSize:
-    kind: file
+    kind: hcl
     dependson:
       - packerImageVersion
     spec:
       file: 'https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source `packerImageVersion` }}/locals.pkr.hcl'
-      # matchpattern can only retrieve the full line. A transformer is required after to strip the unused content
-      matchpattern: 'windows_disk_size_gb = (.*)'
-    transformers:
-      ## Retrieve only the integer (ignore whitespaces, comments, etc.)
-      - findsubmatch:
-          pattern: 'windows_disk_size_gb = (\d*)'
-          captureindex: 1
+      path: locals.windows_disk_size_gb
 
 targets:
   setWindowsVMAgentDiskSize:

--- a/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-maven.yaml
@@ -23,17 +23,13 @@ sources:
   # Retrieving Maven from packer-images to synchronize its version across our infra
   # See https://github.com/jenkins-infra/docker-inbound-agents/issues/18
   getMavenVersionFromPackerImages:
-    kind: file
-    name: Get the latest Maven version set in packer-images
+    kind: yaml
+    name: Get the latest Maven version set in the "production" Packer images
     dependson:
       - getPackerImageDeployedVersion
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getPackerImageDeployedVersion" }}/provisioning/tools-versions.yml
-      matchpattern: 'maven_version:\s(.*)'
-    transformers:
-      - findsubmatch:
-          pattern: 'maven_version:\s(.*)'
-          captureindex: 1
+      key: $.maven_version
 
 conditions:
   checkIfReleaseIsAvailable:
@@ -74,7 +70,6 @@ targets:
         - hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
       key: $.profile::jenkinscontroller::jcasc.permanent_agents.s390x-agent.toolLocation[0].home
     scmid: default
-
 
 actions:
   default:

--- a/updatecli/weekly.d/kubectl.yaml
+++ b/updatecli/weekly.d/kubectl.yaml
@@ -22,17 +22,13 @@ sources:
       key: $.profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version
   # Retrieving kubectl from packer-images to synchronize its version across our infra
   getKubectlVersionFromPackerImages:
-    kind: file
+    kind: yaml
     name: Get the latest kubectl version set in packer-images
     dependson:
       - getPackerImageDeployedVersion
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getPackerImageDeployedVersion" }}/provisioning/tools-versions.yml
-      matchpattern: 'kubectl_version:\s(.*)'
-    transformers:
-      - findsubmatch:
-          pattern: 'kubectl_version:\s(.*)'
-          captureindex: 1
+      key: $.kubectl_version
 
 targets:
   updateHieradataVersion:

--- a/updatecli/weekly.d/openvpn.yaml
+++ b/updatecli/weekly.d/openvpn.yaml
@@ -33,11 +33,13 @@ conditions:
       architecture: amd64
       # Tag comes from the source input value
   checkIfKeyExist:
-    kind: file
+    kind: yaml
     disablesourceinput: true
     spec:
       file: hieradata/common.yaml
-      matchpattern: "profile::openvpn::image"
+      keyonly: true
+      key: $.profile::openvpn::image_tag
+
 
 targets:
   imageTag:


### PR DESCRIPTION
While reviewing https://github.com/jenkins-infra/contributor-spotlight/pull/146, I realized that we could use the (recent?) native features of `updatecli` YAML and HCL to simplify the setups.

Why this change? https://blog.codinghorror.com/regular-expressions-now-you-have-two-problems/ => we want to avoid overusing regex when not needed. As `updatecli` evolved to provide us the "remote YAML file" or "remote HCL" ability, we can get rid of the tedious pattern matching + transformer submatch.

Additionally, we have some historical conditions over the existence of YAML keys which can now benefit from the `keyonly` attribute, unlocking the native YAML parsing (instead of tedious pattern matching, again).