### PR TITLE
chore(updatecli) fix az CLI manifest to only get the latest GH release

### DIFF
--- a/updatecli/weekly.d/azure-cli.yaml
+++ b/updatecli/weekly.d/azure-cli.yaml
@@ -22,6 +22,8 @@ sources:
       repository: "azure-cli"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
+      typefilter:
+        latest: true
     transformers:
       - trimprefix: 'azure-cli-'
 


### PR DESCRIPTION
Closes https://github.com/jenkins-infra/jenkins-infra/pull/3488