### PR TITLE
feat(cijio_agents_1): Disabling kubernetes for cluster cijio-agents1

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -119,7 +119,7 @@ profile::jenkinscontroller::jcasc:
   cloud_agents:
     kubernetes:
       ci.jenkins.io-agents-1:
-        enabled: true
+        enabled: false
         provider: "azure-aks-internal"
         credentialsId: "ci.jenkins.io-agents-1-jenkins-agent-sa-token"
         serverCertificate: >
@@ -280,7 +280,7 @@ profile::jenkinscontroller::jcasc:
                 value: "true"
                 effect: "NoSchedule"
       ci.jenkins.io-agents-1-bom:
-        enabled: true
+        enabled: false
         provider: "azure-aks-internal"
         credentialsId: "ci.jenkins.io-agents-1-jenkins-agent-bom-sa-token"
         serverCertificate: >


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4144#issuecomment-2182701643

Disabling kubernetes for cluster cijio-agents1 to proceed with kub upgrade 1.28.