### PR TITLE
Remove obsolete javax-mail-api plugin from cert.ci

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -164,6 +164,3 @@ profile::jenkinscontroller::plugins:
 
   # Utility
   - compact-columns
-
-  # (Likely unused) detached
-  - javax-mail-api # split after 2.330


### PR DESCRIPTION
No installed plugin has an older core dependency than 2.361.1, so this is no longer an implicit dependency on anything.