### PR TITLE
feat(jenkinscontroller) use native git tool on cert.ci.jio but keep default jgit tool on ci.jio and trusted.ci.jio

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
@@ -18,7 +18,12 @@ tool:
   <%- end -%>
   git:
     installations:
+    <%- if @jcasc['tools']['jgit'] -%>
     - name: "jgit"
+    <%- else -%>
+    - home: "git"
+      name: "git-native"
+    <%- end -%>
   <%- if @jcasc['tools']['groovy'] -%>
   groovy:
     installations:

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -123,6 +123,7 @@ profile::jenkinscontroller::jcasc:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.6.zip"
       groovy-4.0.22:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-4.0.22.zip"
+    jgit: false # Use native git to allow private repo without errors
   cloud_agents:
     azure_vm_agents:
       clouds:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -197,6 +197,7 @@ profile::jenkinscontroller::jcasc:
             type: "zip"
             label: "windows"
             os: "windows"
+    jgit: true # Set to false to use Native `git` CLI
   agents_setup:
     windows:
       agentDir: 'C:/Jenkins/agent'

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -51,6 +51,7 @@ profile::jenkinscontroller::jcasc:
         defaultDisplayUrlProvider:
           providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
   tools:
+    jgit: false # Use native git instead of default JGit
     groovy:
       groovy: # Default version is named "groovy"
         version: "2.4.21"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4186#issuecomment-2236868804

This PR introduces a new customization for controller Jenkins `git` tool.

By default, we keep the Jgit tool, but you can disable it with a boolean passed to hieradata.

cert.ci.jenkins.io switches to native `git` CLI as per the linked issue, while we keep the default behavior for ci.jenkins.io and trusted.ci.jenkins.io.