### PR TITLE
feat(vagrant&cijio):Add ubuntu-22 template for jdk17 and jdk21.

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -392,7 +392,7 @@ profile::jenkinscontroller::jcasc:
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           spot: true
-        - name: "ubuntu-22-inbound-jdk17"
+        - name: "ubuntu-22-inbound-amd64-jdk17"
           description: "Ubuntu 22.04 LTS"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
@@ -403,7 +403,7 @@ profile::jenkinscontroller::jcasc:
           ephemeralOSDisk: true
           architecture: amd64
           labels:
-            - ubuntu-22-maven-17
+            - ubuntu-22-amd64-maven-17
           javaHome: /opt/jdk-17 # Test override of the default JDK for builds
           agentJavaBin: /opt/jdk-17 # Test override of the default JDK for builds
           maxInstances: 50
@@ -411,7 +411,7 @@ profile::jenkinscontroller::jcasc:
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           spot: true
-        - name: "ubuntu-22-inbound-jdk21"
+        - name: "ubuntu-22-amd64-inbound-jdk21"
           description: "Ubuntu 22.04 LTS"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
@@ -422,7 +422,7 @@ profile::jenkinscontroller::jcasc:
           ephemeralOSDisk: true
           architecture: amd64
           labels:
-            - ubuntu-22-maven-21
+            - ubuntu-22-amd64-maven-21
           javaHome: /opt/jdk-21 # Test override of the default JDK for builds
           agentJavaBin: /opt/jdk-21 # Test override of the default JDK for builds
           maxInstances: 50

--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -392,8 +392,8 @@ profile::jenkinscontroller::jcasc:
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           spot: true
-        - name: "ubuntu-22-inbound-amd64-jdk17"
-          description: "Ubuntu 22.04 LTS"
+        - name: "ubuntu-22-amd64-maven17"
+          description: "Ubuntu 22.04 LTS with JDK17 set as default java CLI"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
           os_version: "22.04"
@@ -403,16 +403,15 @@ profile::jenkinscontroller::jcasc:
           ephemeralOSDisk: true
           architecture: amd64
           labels:
-            - ubuntu-22-amd64-maven-17
-          javaHome: /opt/jdk-17 # Test override of the default JDK for builds
-          agentJavaBin: /opt/jdk-17 # Test override of the default JDK for builds
+            - ubuntu-22-amd64-maven17
+          javaHome: /opt/jdk-17
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           spot: true
-        - name: "ubuntu-22-amd64-inbound-jdk21"
-          description: "Ubuntu 22.04 LTS"
+        - name: "ubuntu-22-amd64-maven21"
+          description: "Ubuntu 22.04 LTS with JDK21 set as default java CLI"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
           os_version: "22.04"
@@ -422,9 +421,8 @@ profile::jenkinscontroller::jcasc:
           ephemeralOSDisk: true
           architecture: amd64
           labels:
-            - ubuntu-22-amd64-maven-21
-          javaHome: /opt/jdk-21 # Test override of the default JDK for builds
-          agentJavaBin: /opt/jdk-21 # Test override of the default JDK for builds
+            - ubuntu-22-amd64-maven21
+          javaHome: /opt/jdk-21
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"

--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -392,6 +392,44 @@ profile::jenkinscontroller::jcasc:
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           spot: true
+        - name: "ubuntu-22-inbound-jdk17"
+          description: "Ubuntu 22.04 LTS"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "inbound"
+          location: "East US 2"
+          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          ephemeralOSDisk: true
+          architecture: amd64
+          labels:
+            - ubuntu-22-maven-17
+          javaHome: /opt/jdk-17 # Test override of the default JDK for builds
+          agentJavaBin: /opt/jdk-17 # Test override of the default JDK for builds
+          maxInstances: 50
+          useAsMuchAsPossible: true
+          credentialsId: "jenkinsvmagents-userpass"
+          usePrivateIP: true
+          spot: true
+        - name: "ubuntu-22-inbound-jdk21"
+          description: "Ubuntu 22.04 LTS"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "inbound"
+          location: "East US 2"
+          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          ephemeralOSDisk: true
+          architecture: amd64
+          labels:
+            - ubuntu-22-maven-21
+          javaHome: /opt/jdk-21 # Test override of the default JDK for builds
+          agentJavaBin: /opt/jdk-21 # Test override of the default JDK for builds
+          maxInstances: 50
+          useAsMuchAsPossible: true
+          credentialsId: "jenkinsvmagents-userpass"
+          usePrivateIP: true
+          spot: true
         - name: "ubuntu-22-arm64"
           description: "Ubuntu 22.04 LTS ARM64"
           imageDefinition: jenkins-agent-ubuntu-22.04-arm64

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -224,6 +224,11 @@ profile::jenkinscontroller::jcasc:
             - linux
             - docker
             - linux-amd64
+          maxInstances: 50
+          useAsMuchAsPossible: true
+          credentialsId: "jenkinsvmagents-userpass"
+          usePrivateIP: true
+          spot: true
         - name: "ubuntu-22-inbound-jdk17"
           description: "Ubuntu 22.04 LTS"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
@@ -238,6 +243,11 @@ profile::jenkinscontroller::jcasc:
             - ubuntu-22-maven-17
           javaHome: /opt/jdk-17 # Test override of the default JDK for builds
           agentJavaBin: /opt/jdk-17 # Test override of the default JDK for builds
+          maxInstances: 50
+          useAsMuchAsPossible: true
+          credentialsId: "jenkinsvmagents-userpass"
+          usePrivateIP: true
+          spot: true
         - name: "ubuntu-22-inbound-jdk21"
           description: "Ubuntu 22.04 LTS"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -235,12 +235,7 @@ profile::jenkinscontroller::jcasc:
           ephemeralOSDisk: true
           architecture: amd64
           labels:
-            - ubuntu
-            - java
-            - linux
-            - docker
-            - linux-amd64
-            - jdk17
+            - ubuntu-22-maven-17
           javaHome: /opt/jdk-17 # Test override of the default JDK for builds
           agentJavaBin: /opt/jdk-17 # Test override of the default JDK for builds
         - name: "ubuntu-22-inbound-jdk21"
@@ -254,12 +249,7 @@ profile::jenkinscontroller::jcasc:
           ephemeralOSDisk: true
           architecture: amd64
           labels:
-            - ubuntu
-            - java
-            - linux
-            - docker
-            - linux-amd64
-            - jdk21
+            - ubuntu-22-maven-21
           javaHome: /opt/jdk-21 # Test override of the default JDK for builds
           agentJavaBin: /opt/jdk-21 # Test override of the default JDK for builds
           maxInstances: 50

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -224,6 +224,44 @@ profile::jenkinscontroller::jcasc:
             - linux
             - docker
             - linux-amd64
+        - name: "ubuntu-22-inbound-jdk17"
+          description: "Ubuntu 22.04 LTS"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "inbound"
+          location: "East US 2"
+          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          ephemeralOSDisk: true
+          architecture: amd64
+          labels:
+            - ubuntu
+            - java
+            - linux
+            - docker
+            - linux-amd64
+            - jdk17
+          javaHome: /opt/jdk-17 # Test override of the default JDK for builds
+          agentJavaBin: /opt/jdk-17 # Test override of the default JDK for builds
+        - name: "ubuntu-22-inbound-jdk21"
+          description: "Ubuntu 22.04 LTS"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "inbound"
+          location: "East US 2"
+          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          ephemeralOSDisk: true
+          architecture: amd64
+          labels:
+            - ubuntu
+            - java
+            - linux
+            - docker
+            - linux-amd64
+            - jdk21
+          javaHome: /opt/jdk-21 # Test override of the default JDK for builds
+          agentJavaBin: /opt/jdk-21 # Test override of the default JDK for builds
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -229,8 +229,8 @@ profile::jenkinscontroller::jcasc:
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           spot: true
-        - name: "ubuntu-22-inbound-jdk17"
-          description: "Ubuntu 22.04 LTS"
+        - name: "ubuntu-22-amd64-maven17"
+          description: "Ubuntu 22.04 LTS with JDK17 set as default java CLI"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
           os_version: "22.04"
@@ -240,16 +240,15 @@ profile::jenkinscontroller::jcasc:
           ephemeralOSDisk: true
           architecture: amd64
           labels:
-            - ubuntu-22-maven-17
-          javaHome: /opt/jdk-17 # Test override of the default JDK for builds
-          agentJavaBin: /opt/jdk-17 # Test override of the default JDK for builds
+            - ubuntu-22-amd64-maven17
+          javaHome: /opt/jdk-17
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           spot: true
-        - name: "ubuntu-22-inbound-jdk21"
-          description: "Ubuntu 22.04 LTS"
+        - name: "ubuntu-22-amd64-maven21"
+          description: "Ubuntu 22.04 LTS with JDK21 set as default java CLI"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
           os_version: "22.04"
@@ -259,9 +258,8 @@ profile::jenkinscontroller::jcasc:
           ephemeralOSDisk: true
           architecture: amd64
           labels:
-            - ubuntu-22-maven-21
-          javaHome: /opt/jdk-21 # Test override of the default JDK for builds
-          agentJavaBin: /opt/jdk-21 # Test override of the default JDK for builds
+            - ubuntu-22-amd64-maven21
+          javaHome: /opt/jdk-21
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"


### PR DESCRIPTION
Adding templates for ubuntu-22 maven-17 and maven-21 to ci.jenkins.io

Related to https://github.com/jenkins-infra/helpdesk/issues/4124