### PR TITLE
fix(openvpn) add missing protocol in the routing tables from VPN to other network/IPs

### DIFF
--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -174,6 +174,7 @@ class profile::openvpn (
             80,   # Allow HTTP to private networks
             443,  # Allow HTTPS to private networks
             5432, # Allow Postgres to private networks
+            3306, # Allow MySQL to private networks
           ],
           destination => $destination_cidr,
           table       => 'nat',
@@ -191,7 +192,9 @@ class profile::openvpn (
           outiface    => 'eth0',
           source      => $vpn_network['cidr'],
           dport       => [
-            22,
+            22,   # Allow SSH to external VMs
+            80,   # Allow HTTP to external VMs
+            443,  # Allow HTTPS to external VMs
           ],
           destination => $external_ssh_ip_cidr,
           table       => 'nat',


### PR DESCRIPTION
- Follow up of #3553 (for https://github.com/jenkins-infra/helpdesk/issues/4196) has we also need to allow HTTP(S) otherwise admin users will loose access to the web services of these VMs when connected to VPN
- Add MySQL to the private network, as we already had postgres. Required for https://github.com/jenkins-infra/azure/blob/8a94cf7d8bc19bd1e48566c804e512b3def80ed1/providers.tf#L63-L69 through VPN in the near future