### PR TITLE
feat(trusted.ci): Added Azure VM templates for Ubuntu-22 jdk-17 and jdk-21

### DIFF
--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -105,11 +105,14 @@ profile::jenkinscontroller::jcasc:
           spot: true
           architecture: amd64
           labels:
+            - java
             - linux
             - docker
             - ubuntu
             - ubuntu-amd64-maven-11
             - ubuntu-22-amd64-maven-11
+            - maven-11
+            - jdk11
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
@@ -128,6 +131,8 @@ profile::jenkinscontroller::jcasc:
           labels:
             - ubuntu-amd64-maven-17
             - ubuntu-22-amd64-maven-17
+            - maven-17
+            - jdk17
           javaHome: '/opt/jdk-17'
           maxInstances: 7
           useAsMuchAsPossible: true
@@ -147,6 +152,8 @@ profile::jenkinscontroller::jcasc:
           labels:
             - ubuntu-amd64-maven-21
             - ubuntu-22-amd64-maven-21
+            - maven-21
+            - jdk21
           javaHome: '/opt/jdk-21'
           maxInstances: 7
           useAsMuchAsPossible: true

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -102,7 +102,7 @@ profile::jenkinscontroller::jcasc:
           javaHome: "/opt/jdk-11"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
-          spot: true
+          spot: false
           architecture: amd64
           labels:
             - java
@@ -110,6 +110,43 @@ profile::jenkinscontroller::jcasc:
             - docker
             - maven-11
             - jdk11
+          javaHome: '/opt/jdk-11'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "ubuntu-22-maven-17"
+          description: "Ubuntu 22.04 LTS"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: false
+          architecture: amd64
+          labels:
+            - ubuntu-22-maven-17
+          javaHome: '/opt/jdk-17'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "ubuntu-22-maven-21"
+          description: "Ubuntu 22.04 LTS"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: false
+          architecture: amd64
+          labels:
+            - ubuntu-22-maven-21
+          javaHome: '/opt/jdk-21'
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -92,8 +92,30 @@ profile::jenkinscontroller::jcasc:
           disableSpot: true # Not enough quota available
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEABg+VT2jJfm39KjS0i/PhizdtKpy7AC4wLmKN4DWOsdfea3XUbUU0FQfuPLNY/9CA7iuEIAtO9y7pht9vwX16b2sC2xqL9CJlxj2B6bgLkJsqo9Qeib7Sy7nYe0LyIgE+HUrQ8Y1rCU1itPxHCdXFjy+GiG/q7xs1bMUuulQf/aL48uTC8BvO3DGNaNdNadpI+6NpVwtzk5wtLZS6mbL053f8t+DFmpyUR0HYYnYGxVl2eDFRlR5qV93kErpPMGfuWj3sk7P3o4h8RXt5BIgR/0Hd9/ypd60mKjGJpUn3y4LMBthDEIB0iEwiIBw5oE5EJHnBTPVEYkKMPZ+5Ct837zBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDuNBYp213f+ubJVbpnKwIbgCChAER2/Kp5oAKS60k5HWAcu0cgHJMIK2d6SgAHv5FhuA==]
       agent_definitions:
-        - name: "ubuntu-22-maven-17"
-          description: "Ubuntu 22.04 LTS"
+        - name: "ubuntu-22-amd64-maven-11"
+          description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          javaHome: "/opt/jdk-11"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - linux
+            - docker
+            - ubuntu
+            - ubuntu-amd64-maven-11
+            - ubuntu-22-amd64-maven-11
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "ubuntu-22-amd64-maven-17"
+          description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
           os_version: "22.04"
@@ -101,17 +123,18 @@ profile::jenkinscontroller::jcasc:
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
-          spot: false
+          spot: true
           architecture: amd64
           labels:
-            - ubuntu-22-maven-17
+            - ubuntu-amd64-maven-17
+            - ubuntu-22-amd64-maven-17
           javaHome: '/opt/jdk-17'
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
-        - name: "ubuntu-22-maven-21"
-          description: "Ubuntu 22.04 LTS"
+        - name: "ubuntu-22-amd64-maven-21"
+          description: "Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: "ubuntu"
           os_version: "22.04"
@@ -119,10 +142,11 @@ profile::jenkinscontroller::jcasc:
           location: "East US 2"
           instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
-          spot: false
+          spot: true
           architecture: amd64
           labels:
-            - ubuntu-22-maven-21
+            - ubuntu-amd64-maven-21
+            - ubuntu-22-amd64-maven-21
           javaHome: '/opt/jdk-21'
           maxInstances: 7
           useAsMuchAsPossible: true

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -109,6 +109,7 @@ profile::jenkinscontroller::jcasc:
             - linux
             - docker
             - ubuntu
+            - ubuntu-22
             - ubuntu-amd64-maven-11
             - ubuntu-22-amd64-maven-11
             - maven-11

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -92,29 +92,6 @@ profile::jenkinscontroller::jcasc:
           disableSpot: true # Not enough quota available
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEABg+VT2jJfm39KjS0i/PhizdtKpy7AC4wLmKN4DWOsdfea3XUbUU0FQfuPLNY/9CA7iuEIAtO9y7pht9vwX16b2sC2xqL9CJlxj2B6bgLkJsqo9Qeib7Sy7nYe0LyIgE+HUrQ8Y1rCU1itPxHCdXFjy+GiG/q7xs1bMUuulQf/aL48uTC8BvO3DGNaNdNadpI+6NpVwtzk5wtLZS6mbL053f8t+DFmpyUR0HYYnYGxVl2eDFRlR5qV93kErpPMGfuWj3sk7P3o4h8RXt5BIgR/0Hd9/ypd60mKjGJpUn3y4LMBthDEIB0iEwiIBw5oE5EJHnBTPVEYkKMPZ+5Ct837zBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDuNBYp213f+ubJVbpnKwIbgCChAER2/Kp5oAKS60k5HWAcu0cgHJMIK2d6SgAHv5FhuA==]
       agent_definitions:
-        - name: "ubuntu-22"
-          description: "Ubuntu 22.04 LTS"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          location: "East US 2"
-          javaHome: "/opt/jdk-11"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - java
-            - linux
-            - docker
-            - maven-11
-            - jdk11
-          javaHome: '/opt/jdk-11'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
         - name: "ubuntu-22-maven-17"
           description: "Ubuntu 22.04 LTS"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4124#issue-2335345048:

Added jdk-17 and jdk-21 ssh agents to trusted.ci, Ubuntu-22 template will have jdk-11 by deafult.