### PR TITLE
feat(jenkinscontroller) use Docker registry mirror for Azure VM VM agents

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -20,7 +20,16 @@ jenkins:
           # Setup datadog
           (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: <%= @jcasc['datadog_api_key'] %>' | Set-Content C:\ProgramData\Datadog\datadog.yaml
           & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart
-            <%- if agent['launcher'] && agent['launcher'] == "inbound" -%>
+
+          # Setup Docker Engine
+          @'
+          {
+            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][agent['os'].to_s]['registryMirror'] %>"]
+          }
+          '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
+          Restart-Service docker
+
+          <%- if agent['launcher'] && agent['launcher'] == "inbound" -%>
           # Setup inbound agent
           $jenkinsServerUrl = $args[0] # Always ends with a '/'
           $agentName = $args[1]
@@ -73,6 +82,17 @@ jenkins:
             systemctl enable datadog-agent.service
             systemctl start datadog-agent.service
           ) 2>&1 | tee /var/log/agent-init-datadog.log
+
+          # Setup Docker Engine
+          mkdir -p /etc/docker
+          cat <<EOF >/etc/docker/daemon.json
+          {
+            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][agent['os'].to_s]['registryMirror'] %>"]
+          }
+          EOF
+          systemctl daemon-reload
+          systemctl restart docker
+
           <%- if agent['launcher'] && agent['launcher'] == "inbound" -%>
           # Setup Jenkins Agent Service
           (

--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -459,7 +459,7 @@ profile::jenkinscontroller::jcasc:
           osDiskSize: 100 # https://github.com/jenkinsci/azure-vm-agents-plugin/issues/349
           architecture: arm64
           labels:
-            - ubuntu-22-amd64-maven17
+            - ubuntu-22-arm64-maven17
             # Labels indicating it is the default VM template for arm64
             - arm64docker
             - arm64linux
@@ -482,7 +482,7 @@ profile::jenkinscontroller::jcasc:
           osDiskSize: 100 # https://github.com/jenkinsci/azure-vm-agents-plugin/issues/349
           architecture: arm64
           labels:
-            - ubuntu-22-amd64-maven21
+            - ubuntu-22-arm64-maven21
           javaHome: /opt/jdk-21
           maxInstances: 50
           useAsMuchAsPossible: true

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -207,6 +207,7 @@ profile::jenkinscontroller::jcasc:
       agentJavaBin: 'C:/tools/jdk-17/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
       javaHome: 'C:/tools/jdk-17' # Default JDK provided for builds when no pipeline setup exists
+      registryMirror: https://cijenkinsio.azurecr.io
     ubuntu:
       agentDir: "/home/jenkins/agent"
       remoteAdmin: jenkins
@@ -217,6 +218,7 @@ profile::jenkinscontroller::jcasc:
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
       javaHome: '/opt/jdk-17' # Default JDK provided for builds when no pipeline setup exists
       path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
+      registryMirror: https://cijenkinsio.azurecr.io
   agent_images:
     azure_vms_gallery_image:
       version: 1.81.0


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4192#issuecomment-2263339493

This PR adds setup, on all controllers, of the Docker Engine (in Azure VM agents) to use the new ACR registry as a mirror cache to decrease impact on DockerHub (it's a common good!) and limit risks of rate limiting.

Note: it also fixes Azure VM arm64 invalid labels caught during the pairing session with @timja 

Tested manually on ci.jenkins.io with success (first on Linux, then on Windows): if you run `docker info` on these machines, you should see the registry mirror setup in the output