### PR TITLE
fix(jenkinscontrollers) switch to the correct ACR

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -207,7 +207,7 @@ profile::jenkinscontroller::jcasc:
       agentJavaBin: 'C:/tools/jdk-17/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
       javaHome: 'C:/tools/jdk-17' # Default JDK provided for builds when no pipeline setup exists
-      registryMirror: https://cijenkinsio.azurecr.io
+      registryMirror: https://dockerhubmirror.azurecr.io
     ubuntu:
       agentDir: "/home/jenkins/agent"
       remoteAdmin: jenkins
@@ -218,7 +218,7 @@ profile::jenkinscontroller::jcasc:
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
       javaHome: '/opt/jdk-17' # Default JDK provided for builds when no pipeline setup exists
       path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
-      registryMirror: https://cijenkinsio.azurecr.io
+      registryMirror: https://dockerhubmirror.azurecr.io
   agent_images:
     azure_vms_gallery_image:
       version: 1.84.0


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4192

Fixup of https://github.com/jenkins-infra/jenkins-infra/pull/3568

This PR is associated with https://github.com/jenkins-infra/azure/pull/794 and sets up all controllers (ci.jio, cert.ci.jio and trusted.ci.jio) to use the new ACR as a mirror.

Note: not blocked as Docker CE falls back to the DockerHub if it cannot use the specified mirror registry (really handy!).