### PR TITLE
Revert adding disable-job to ci.jenkins.io

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -632,7 +632,6 @@ profile::jenkinscontroller::plugins:
   - credentials-binding # Bind Jenbkins credentials to variables in jobs
   - datadog # Datadog plugin
   - dark-theme # Dark theme
-  - disable-job-button # Removed from Core by 2.461.x
   - docker-workflow # Provides the "withDockerContainer" pipeline keyword
   - embeddable-build-status # https://github.com/jenkins-infra/helpdesk/issues/3013
   - git # Used for... git


### PR DESCRIPTION
see https://github.com/jenkins-infra/jenkins-infra/pull/3578#issuecomment-2273528093

This goes again the removal of it and ci.jenkins.io being an exemplar instance as well.

The disable-job-button plugin reduces a couple of clicks for when people are frequently disabling jobs. I'm not aware of jobs ever being disabled on ci.jenkins.io and if they are the extra click or two shouldn't be a pain for the rarity of it