### PR TITLE
hotfix(cert.ci.jenkins.io) fix Azure VM agent labels

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -152,6 +152,7 @@ profile::jenkinscontroller::jcasc:
             - linux
             - docker
             - ubuntu
+            - ubuntu-amd64-maven-11
             - ubuntu-22-amd64-maven-11
           maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
@@ -169,7 +170,8 @@ profile::jenkinscontroller::jcasc:
           spot: false
           architecture: amd64
           labels:
-            - ubuntu-22-maven-17
+            - ubuntu-amd64-maven-17
+            - ubuntu-22-amd64-maven-17
           javaHome: '/opt/jdk-17'
           maxInstances: 10
           useAsMuchAsPossible: true
@@ -187,7 +189,8 @@ profile::jenkinscontroller::jcasc:
           spot: false
           architecture: amd64
           labels:
-            - ubuntu-22-maven-21
+            - ubuntu-amd64-maven-21
+            - ubuntu-22-amd64-maven-21
           javaHome: '/opt/jdk-21'
           maxInstances: 10
           useAsMuchAsPossible: true


### PR DESCRIPTION
Fixup of #3565 (cc @jayfranco999 for info), related to https://github.com/jenkins-infra/helpdesk/issues/4124#issue-2335345048

This PR:

- Fixes the labels for JDK17 and JDK21 so they look the same as JDK11
- Add Ubuntu version-less labels (as we might want, soon, to update to Ubuntu 24.04 Noble)