### PR TITLE
feat(profiles - docker,azcopy) add missing Garbage collections to avoid filling hard drives

### DIFF
--- a/dist/profile/manifests/docker.pp
+++ b/dist/profile/manifests/docker.pp
@@ -57,4 +57,16 @@ class profile::docker {
     minute  => 0,
     require => [Class['docker'],Package['cron']],
   }
+
+  # Cleanup non-dangling (docker system prune already do this) but non-used images
+  # This cleanup is safe: if you do not use the '-f, --force' flag on `docker image`,
+  # then Docker refuses to remove running container's images with 'image is being used by running container' message
+  cron { 'docker-images-cleanup':
+    # Override the content of the log file to avoid heavy files not rotated in 2-3 years.
+    command => "bash -c 'date &&  docker image ls -q | xargs docker image rm' >/var/log/docker-images-cleanup.log 2>&1",
+    user    => 'root',
+    hour    => 3,
+    minute  => 0,
+    require => [Class['docker'],Package['cron']],
+  }
 }

--- a/spec/classes/role/updatecenter_spec.rb
+++ b/spec/classes/role/updatecenter_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe 'role::updatecenter' do
+  it { expect(subject).to contain_class 'role::jenkins::agent' }
+  it { expect(subject).to contain_class 'profile::updatecenter' }
+end

--- a/spec/server/updatecenter/updatecenter_spec.rb
+++ b/spec/server/updatecenter/updatecenter_spec.rb
@@ -1,0 +1,5 @@
+require_relative './../spec_helper'
+
+describe 'updatecenter' do
+  it_behaves_like "a standard Linux machine"
+end


### PR DESCRIPTION
This PR adds garbage collection of the 2 following elements, to avoid filling hard drives:

- All `.azcopy/` log files older than 10 days on the trusted permanent agent (ref. https://github.com/jenkins-infra/helpdesk/issues/4212) and the `pkg` VM to
- All Docker images which are not dangling (e.g. not anonymous so not cleaned up by `docker system prune`) but not used anymore