### PR TITLE
feat(ci.jenkins.io) use the same private ACP provider in all types of Azure agents

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -118,7 +118,7 @@ profile::jenkinscontroller::jcasc:
     kubernetes:
       ci.jenkins.io-agents-1:
         enabled: true
-        provider: "azure-aks-internal"
+        provider: "azure"
         credentialsId: "ci.jenkins.io-agents-1-jenkins-agent-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIJbQYJKoZIhvcNAQcDoIIJXjCCCVoCAQAxggEhMIIBHQIBAD
@@ -279,7 +279,7 @@ profile::jenkinscontroller::jcasc:
                 effect: "NoSchedule"
       ci.jenkins.io-agents-1-bom:
         enabled: true
-        provider: "azure-aks-internal"
+        provider: "azure"
         credentialsId: "ci.jenkins.io-agents-1-jenkins-agent-bom-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIJbQYJKoZIhvcNAQcDoIIJXjCCCVoCAQAxggEhMIIBHQIBAD

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -245,11 +245,9 @@ profile::jenkinscontroller::jcasc:
     providers:
       azure:
         name: Azure
-      azure-aks-internal:
-        name: Azure AKS internal
-        url: http://artifact-caching-proxy.artifact-caching-proxy:8080/
+        url: http://artifact-caching-proxy.privatelink.azurecr.io:8080/
         disableCredentials: true
-    credentialsId: artifact-caching-proxy-credentials
+    # Disabled by default, set this to "false" on children to enable
     disabled: true
 ldap_url: "ldap://localhost:389"
 ldap_dn: "dc=example,dc=com"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4204#issuecomment-2278334260

This PR moves all ACPs usages to the internal one, using the new URL and disabling credentials