### PR TITLE
feat!(ci.jenkins.io, profile::jenkinscontroller) refactor ACP to support passing URL and new topologies

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -1,16 +1,16 @@
-<%- if @jcasc['artifact_caching_proxy'] && @jcasc['artifact_caching_proxy']['disabled'].to_s != "true" -%>
+<%- if @jcasc['artifact_caching_proxy'] && @jcasc['artifact_caching_proxy']['enabled'].to_s == "true" -%>
 unclassified:
   globalConfigFiles:
     configs:
-    <%- @jcasc['artifact_caching_proxy']['providers'].each do |providerId, provider| -%>
+    <%- @jcasc['artifact_caching_proxy']['servers'].each do |serverId, serverConfig| -%>
     - mavenSettings:
-        comment: "Artifact caching proxy settings for the <%= provider['name'] %> provider"
+        comment: "Artifact caching proxy settings for the <%= serverConfig['name'] %> serverConfig"
         content: |
           <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
             <mirrors>
               <mirror>
-                  <id><%= providerId %>-proxy</id>
-                  <url><% if provider['url'] %><%= provider['url'] %><% else %>https://repo.<%= providerId %>.jenkins.io/<% end %></url>
+                  <id><%= serverConfig['url'] %></id>
+                  <url><%= serverConfig['url'] %></url>
                   <mirrorOf>external:*,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven</mirrorOf>
               </mirror>
             </mirrors>
@@ -40,16 +40,16 @@ unclassified:
               <activeProfile>jenkins-infra-plugin-repositories</activeProfile>
             </activeProfiles>
           </settings>
-        id: "artifact-caching-proxy-<%= providerId %>"
+        id: "<%= serverConfig['url'] %>"
         isReplaceAll: true
-        name: "<%= provider['name'] %> Artifact Caching Proxy"
+        name: "<%= serverConfig['name'] %>"
         providerId: "org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig"
-        <%- unless provider['disableCredentials'] == true -%>
+        <%- if serverConfig['credentials'] -%>
         serverCredentialMappings:
-        - credentialsId: "<%= @jcasc['artifact_caching_proxy']['credentialsId'] %>"
-          serverId: "<%= providerId %>-proxy"
-        - credentialsId: "<%= @jcasc['artifact_caching_proxy']['credentialsId'] %>"
-          serverId: "<%= providerId %>-proxy-incrementals"
+          <%- serverConfig['credentials'].each do |acpCredentialId| -%>
+        - credentialsId: "<%= acpCredentialId %>"
+          serverId: "<%= serverConfig['url'] %>"
+          <%- end -%>
         <%- end -%>
       <%- end -%>
 <%- end -%>

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -107,7 +107,9 @@ jenkins:
             export AGENT_SECRETFILE="^${AGENT_WORKDIR}/agent-secret"
             export AGENT_URL="^${JENKINS_URL}computer/^${AGENT_NAME}/jenkins-agent.jnlp"
             export JENKINS_JAVA_OPTS='<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>'
-            export ARTIFACT_CACHING_PROXY_PROVIDER='azure'
+            <%- if @jcasc['artifact_caching_proxy'] && @jcasc['artifact_caching_proxy']['enabled'].to_s == "true" && cloudsetup['acpServerId'] -%>
+            export ARTIFACT_CACHING_PROXY_SERVERID='<%= @jcasc['artifact_caching_proxy']['servers'][cloudsetup['acpServerId']]['url'] %>'
+            <%- end -%>
             export JAVA_HOME='<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>'
             export JENKINS_JAVA_BIN='<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>'
 
@@ -129,7 +131,9 @@ jenkins:
             Restart=on-failure
             RestartSec=10
             Environment="JAVA_HOME=^${JAVA_HOME}"
-            Environment="ARTIFACT_CACHING_PROXY_PROVIDER=^${ARTIFACT_CACHING_PROXY_PROVIDER}"
+            <%- if @jcasc['artifact_caching_proxy'] && @jcasc['artifact_caching_proxy']['enabled'].to_s == "true" && cloudsetup['acpServerId'] -%>
+            Environment="ARTIFACT_CACHING_PROXY_SERVERID=^${ARTIFACT_CACHING_PROXY_SERVERID}"
+            <%- end -%>
             Environment="PATH=^${JAVA_HOME}/bin:<%= @jcasc['agents_setup']['ubuntu']['path'] %>"
 
             [Install]
@@ -143,7 +147,7 @@ jenkins:
 
           <%- else -%>
 
-          # Setup default java for build (not for agent process) 
+          # Setup default java for build (not for agent process)
           export DEFAULT_JDK=<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>
           update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
           echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
@@ -248,8 +252,10 @@ jenkins:
               <%= jenkinsJavaOpts %>
           - key: "JENKINS_JAVA_BIN"
             value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
-          - key: "ARTIFACT_CACHING_PROXY_PROVIDER"
-            value: "azure"
+          <%- if @jcasc['artifact_caching_proxy'] && @jcasc['artifact_caching_proxy']['enabled'].to_s == "true" && aci_cloud_setup['acpServerId'] -%>
+          - key: "ARTIFACT_CACHING_PROXY_SERVERID"
+            value: "<%= @jcasc['artifact_caching_proxy']['servers'][aci_cloud_setup['acpServerId']]['url'] %>"
+          <%- end -%>
       <%- end -%>
     <%- end -%>
   <%- end -%>
@@ -289,9 +295,11 @@ jenkins:
               - envVar:
                   key: "PATH"
                   value: "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup']['ubuntu']['javaHome'] %>/bin:<%= @jcasc['agents_setup']['ubuntu']['path'] %>"
+              <%- if @jcasc['artifact_caching_proxy'] && @jcasc['artifact_caching_proxy']['enabled'].to_s == "true" && k8s_setup['acpServerId'] -%>
               - envVar:
-                  key: "ARTIFACT_CACHING_PROXY_PROVIDER"
-                  value: "<%= k8s_setup['provider'] %>"
+                  key: "ARTIFACT_CACHING_PROXY_SERVERID"
+                  value: "<%= @jcasc['artifact_caching_proxy']['servers'][k8s_setup['acpServerId']]['url'] %>"
+              <%- end -%>
             livenessProbe:
               failureThreshold: 0
               initialDelaySeconds: 0

--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -109,8 +109,6 @@ profile::jenkinscontroller::jcasc:
       envVars:
         PATH+MAVEN: /home/jenkins/tools/apache-maven-3.9.8/bin
         JAVA_HOME: "/opt/jdk-17"
-        # For the permanent agents, we're using the artifact caching proxy on DigitalOcean (bandwith available)
-        ARTIFACT_CACHING_PROXY_PROVIDER: "azure"
       toolLocation:
         - home: /home/jenkins/tools/apache-maven-3.9.8
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
@@ -118,7 +116,7 @@ profile::jenkinscontroller::jcasc:
     kubernetes:
       ci.jenkins.io-agents-1:
         enabled: true
-        provider: "azure"
+        acpServerId: azure-internal
         credentialsId: "ci.jenkins.io-agents-1-jenkins-agent-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIJbQYJKoZIhvcNAQcDoIIJXjCCCVoCAQAxggEhMIIBHQIBAD
@@ -279,7 +277,7 @@ profile::jenkinscontroller::jcasc:
                 effect: "NoSchedule"
       ci.jenkins.io-agents-1-bom:
         enabled: true
-        provider: "azure"
+        acpServerId: azure-internal
         credentialsId: "ci.jenkins.io-agents-1-jenkins-agent-bom-sa-token"
         serverCertificate: >
           ENC[PKCS7,MIIJbQYJKoZIhvcNAQcDoIIJXjCCCVoCAQAxggEhMIIBHQIBAD
@@ -368,6 +366,7 @@ profile::jenkinscontroller::jcasc:
           subnetName: "public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"
           disableSpot: true # Not enough quota available
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAX1+w3HsG7jVw0T37cE9RVIEyAaNIg31kdhsxq/N3g0zehZB8QQw6K6/0y0uyNZhqxxdOUHHWN4qmLwrHXhsP+EXF/WHleC2qgYMJT8HHbJtVJ7yEVeeJKgUNipgWRf5FcB2hTKdcwfMqunMapQ4vmdREvAeWggN+racF1yJ1dsOJkzs0oR4GaCfGZLm3IxKMy13ifBJtlTl6dC6f8K70Z9aGbcWf3TqNVrznop9q8LlOPGOZXYyo8WGl1CheSUm5VbWa+o7J04cBOcYP+IAlJObZAN3rdM78Kt0GuDTTjlMZK3R/2e6+nyDw2LO2mMlfNPQcklI5uT1eh6nlWy+cjjBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAhoV9P3un0kUya+CJJTFAHgCBAr5FalXjPsRdLH9XztQDGwMHJj8jLCoBk9D+268MpZw==]
+          acpServerId: azure-internal
       agent_definitions:
         - name: "ubuntu-22-amd64-maven8"
           description: "Ubuntu 22.04 LTS x86_64 with JDK8 set as default java CLI"
@@ -576,6 +575,7 @@ profile::jenkinscontroller::jcasc:
         aci-windows-jenkins-sponsorship:
           credentialsId: azure-jenkins-sponsorship-credentials
           resourceGroup: ci-jenkins-io-ephemeral-agents
+          acpServerId: azure-internal
       agent_definitions:
         - name: maven-8-windows
           os: windows
@@ -610,7 +610,11 @@ profile::jenkinscontroller::jcasc:
           labels:
             - maven-21-windows
   artifact_caching_proxy:
-    disabled: false
+    enabled: true
+    servers:
+      azure-internal:
+        name: Azure (Internal) Artifact Caching Proxy
+        url: http://artifact-caching-proxy.privatelink.azurecr.io:8080/
   datadog:
     host: "ci.jenkins.io"
     targetHost: "172.17.0.1" # docker0 interface

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -241,14 +241,6 @@ profile::jenkinscontroller::jcasc:
     jdk17: 17.0.12+7
     jdk21: 21.0.4+7
     maven: 3.9.8
-  artifact_caching_proxy:
-    providers:
-      azure:
-        name: Azure
-        url: http://artifact-caching-proxy.privatelink.azurecr.io:8080/
-        disableCredentials: true
-    # Disabled by default, set this to "false" on children to enable
-    disabled: true
 ldap_url: "ldap://localhost:389"
 ldap_dn: "dc=example,dc=com"
 ldap_admin_dn: "cn=admin,dc=example,dc=com"

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -128,8 +128,6 @@ profile::jenkinscontroller::jcasc:
           agentJavaBin: java # From image maven:3.8.6-eclipse-temurin-11
           labels:
             - maven-11-windows
-  artifact_caching_proxy:
-    disabled: false
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - azure-container-agents

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -122,6 +122,7 @@ profile::jenkinscontroller::jcasc:
         max_capacity: 150
         url: SuperSecretThatShouldBeEncyptedInProduction
         defaultNamespace: jenkins-agents
+        acpServerId: internal
         agent_definitions:
           - name: jnlp-maven-bom
             imageName: jnlp-maven-all-in-one
@@ -197,6 +198,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkResourceGroupName: "vnet-rg"
           subnetName: "vnet-agents"
           storageAccount: SuperSecretEncryptedInProduction
+          acpServerId: internal
         azure-vms-secondary:
           azureCredentialsId: "azure-secondary-credentials" # Managed manually
           resourceGroup: ci-jenkins-io-ephemeral-agents-secondary
@@ -206,6 +208,7 @@ profile::jenkinscontroller::jcasc:
           subnetName: "vnet-secondary-subnet-agents"
           disableSpot: true # Not enough quota available
           storageAccount: SuperSecretEncryptedInProductionSecondary
+          acpServerId: external
       agent_definitions:
         - name: "ubuntu-22-inbound"
           description: "Ubuntu 22.04 LTS"
@@ -326,9 +329,11 @@ profile::jenkinscontroller::jcasc:
         aci-windows:
           credentialsId: azure-credentials
           resourceGroup: ci-jenkins-io-ephemeral-agents
+          acpServerId: internal
         aci-windows-jenkins-sponsorship:
           credentialsId: azure-jenkins-sponsorship-credentials
           resourceGroup: ci-jenkins-io-ephemeral-agents
+          acpServerId: external
       agent_definitions:
         - name: maven-8-windows
           os: windows
@@ -363,7 +368,16 @@ profile::jenkinscontroller::jcasc:
           labels:
             - maven-21-windows
   artifact_caching_proxy:
-    disabled: false
+    enabled: true
+    servers:
+      internal:
+        name: Dummy Internal Artifact Caching Proxy
+        url: http://127.0.0.1:8080/
+      external:
+        name: Dummy External Artifact Caching Proxy
+        url: http://external:8080/
+        credentials:
+          - "credentialIdInJenkins"
   datadog:
     host: "vagrant.local"
     targetHost: "172.18.0.1" # docker0 interface in vagrant is non standard (because docker in docker)


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4204#issuecomment-2278334260

This PR introduces a set of changes to cleanup the current Puppet code related to ACP which was written with public ACP servers, one per Cloud provider. This is no longer the case.

- A bit of renaming of attributes
- ACP definitions are now setup with the ID same as their URL (to allow dynamic retrieval)
- Conditionally set `ARTIFACT_CACHING_PROXY_SERVERID` in cloud agents

BREAKING CHANGE: ci.jenkins.io's s390x agent do not have any ACP provider anymore (no public one available)
BREAKING CHANGE: there are no more default `azure` ACP
BREAKING CHANGE: The env. variable `ARTIFACT_CACHING_PROXY_PROVIDER` is replaced by `ARTIFACT_CACHING_PROXY_SERVERID``
BREAKING CHANGE: update your hieradata configuration to enable ACP with `enable`


----

Tested locally on Vagrant