### PR TITLE
feat(jenkinscontroller) setup required environement variables during init of Azure VM Windows inbound agent

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -42,6 +42,16 @@ jenkins:
           $configFile = '{0}\jenkins-agent.xml'  -f $jenkinsWorkDir
           $agentExeConfig = '{0}\jenkins-agent.exe.config' -f $jenkinsWorkDir
 
+          # Setup agent-level environment variables
+          <%- if @jcasc['artifact_caching_proxy'] && @jcasc['artifact_caching_proxy']['enabled'].to_s == "true" && cloudsetup['acpServerId'] -%>
+          [System.Environment]::SetEnvironmentVariable("ARTIFACT_CACHING_PROXY_SERVERID", "<%= @jcasc['artifact_caching_proxy']['servers'][cloudsetup['acpServerId']]['url'] %>", "Machine")
+          $Env:ARTIFACT_CACHING_PROXY_SERVERID = "<%= @jcasc['artifact_caching_proxy']['servers'][cloudsetup['acpServerId']]['url'] %>"
+          <%- end -%>
+          $javaHome = "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>"
+          [System.Environment]::SetEnvironmentVariable("JAVA_HOME", ${javaHome}, "Machine")
+          [System.Environment]::SetEnvironmentVariable("PATH", $Env:Path + ";${javaHome}\bin", "Machine")
+          $Env:Path += ";${javaHome}\bin"
+
           mkdir $jenkinsWorkDir
           $wc = New-Object System.Net.WebClient
           $wc.DownloadFile('https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW.NET461.exe', $wrapperExec)

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -196,7 +196,7 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
           usePrivateIP: true
-        - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
+        - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64
           os: "windows"
@@ -210,6 +210,10 @@ profile::jenkinscontroller::jcasc:
           labels:
             - windows
             - docker-windows
+            - win-2019
+            - windows-2019
+            - win-2019-amd64-maven-11
+          javaHome: 'C:/tools/jdk-11'
           maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-login"

--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -534,7 +534,7 @@ profile::jenkinscontroller::jcasc:
           usePrivateIP: true
           credentialsId: "jenkinsvmagents-userpass"
           spot: false
-        - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
+        - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64
           os: "windows"
@@ -548,12 +548,16 @@ profile::jenkinscontroller::jcasc:
             - docker-windows
             - docker-windows-2019
             - windows
+            - win-2019
+            - windows-2019
+            - win-2019-amd64-maven-11
+          javaHome: 'C:/tools/jdk-11'
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           spot: true
-        - name: "win-2022" # The name must not contains "windows" or Azure API complains :facepalm:
+        - name: "win-2022-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2022"
           imageDefinition: jenkins-agent-windows-2022-amd64
           os: "windows"
@@ -565,6 +569,10 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - docker-windows-2022
+            - win-2022
+            - windows-2022
+            - win-2022-amd64-maven-11
+          javaHome: 'C:/tools/jdk-11'
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -160,7 +160,7 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
-        - name: "win-2019" # The name must not contains "windows" or Azure API complains :facepalm:
+        - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64
           os: "windows"
@@ -173,11 +173,15 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - docker-windows
+            - win-2019
+            - windows-2019
+            - win-2019-amd64-maven-11
+          javaHome: 'C:/tools/jdk-11'
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
-        - name: "win-2022" # The name must not contains "windows" or Azure API complains :facepalm:
+        - name: "win-2022-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2022"
           imageDefinition: jenkins-agent-windows-2022-amd64
           os: "windows"
@@ -190,6 +194,10 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - docker-windows-2022
+            - win-2022
+            - windows-2022
+            - win-2022-amd64-maven-11
+          javaHome: 'C:/tools/jdk-11'
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -301,12 +301,15 @@ profile::jenkinscontroller::jcasc:
             - docker-windows
             - docker-windows-2019
             - windows
+            - win-2019
+            - windows-2019
+            - win-2019-amd64-maven-11
+          javaHome: 'C:/Tools/openjdk-11' # Test override of the default JDK for builds
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"
           usePrivateIP: true
           spot: true
-          javaHome: 'C:/Tools/openjdk-11' # Test override of the default JDK for builds
           agentJavaBin: 'C:/Tools/openjdk-17' # Test override of the default JDK for builds
         - name: "win-2022-ssh" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2022"


### PR DESCRIPTION
Related to both https://github.com/jenkins-infra/helpdesk/issues/4204#issuecomment-2280686803 and https://github.com/jenkins-infra/helpdesk/issues/4124

This PR sets ups the following agent-level environment variables for the Azure VM Windows agents using the *inbound* method.

Inspired by https://github.com/Azure/jenkins/blob/ba240aa8c2392577f607646e841b83ebcf554992/agents_scripts/Jenkins-Windows-Init-Script-Jnlp.ps1#L14C1-L17C32 (thanks @timja for the reference to this repository)