### PR TITLE
feat(ci.jenkins.io) setup ACI agents to use theirprivate subnet with private IP

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -241,6 +241,12 @@ jenkins:
         memory: "<%= agent['memory'] %>"
         name: "aci-<%= agent['name'] %>"
         osType: "<%= agent['os'] == "windows" ? 'Windows' : 'Linux' %>"
+        <%- if agent['usePrivateIP'] && aci_cloud_setup['virtualNetworkResourceGroupName'] && aci_cloud_setup['virtualNetworkName'] && aci_cloud_setup['subnetName'] -%>
+        privateIpAddress:
+          resourceGroup: "<%= aci_cloud_setup['virtualNetworkResourceGroupName'] %>"
+          vnet: "<%= aci_cloud_setup['virtualNetworkName'] %>"
+          subnet: "<%= aci_cloud_setup['subnetName'] %>"
+        <%- end -%>
         retentionStrategy: "containerOnce"
         rootFs: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][agent['os'].to_s]['agentDir'] %>"
         timeout: 60

--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -584,6 +584,9 @@ profile::jenkinscontroller::jcasc:
           credentialsId: azure-jenkins-sponsorship-credentials
           resourceGroup: ci-jenkins-io-ephemeral-agents
           acpServerId: azure-internal
+          virtualNetworkName: "public-jenkins-sponsorship-vnet"
+          virtualNetworkResourceGroupName: "public-jenkins-sponsorship"
+          subnetName: "public-jenkins-sponsorship-vnet-ci_jenkins_io_aci"
       agent_definitions:
         - name: maven-8-windows
           os: windows
@@ -593,6 +596,7 @@ profile::jenkinscontroller::jcasc:
           agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
           labels:
             - maven-windows
+          usePrivateIP: true
         - name: maven-11-windows
           os: windows
           command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
@@ -601,6 +605,7 @@ profile::jenkinscontroller::jcasc:
           agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
           labels:
             - maven-11-windows
+          usePrivateIP: true
         - name: maven-17-windows
           os: windows
           command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
@@ -609,6 +614,7 @@ profile::jenkinscontroller::jcasc:
           agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
           labels:
             - maven-17-windows
+          usePrivateIP: true
         - name: maven-21-windows
           os: windows
           command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
@@ -617,6 +623,7 @@ profile::jenkinscontroller::jcasc:
           agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
           labels:
             - maven-21-windows
+          usePrivateIP: true
   artifact_caching_proxy:
     enabled: true
     servers:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -333,6 +333,9 @@ profile::jenkinscontroller::jcasc:
           credentialsId: azure-credentials
           resourceGroup: ci-jenkins-io-ephemeral-agents
           acpServerId: internal
+          virtualNetworkName: "aci-vnet"
+          virtualNetworkResourceGroupName: "aci-vnet-rg"
+          subnetName: "aci-vnet-subnet"
         aci-windows-jenkins-sponsorship:
           credentialsId: azure-jenkins-sponsorship-credentials
           resourceGroup: ci-jenkins-io-ephemeral-agents
@@ -346,6 +349,7 @@ profile::jenkinscontroller::jcasc:
           agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
           labels:
             - maven-windows
+          usePrivateIP: true
         - name: maven-11-windows
           os: windows
           command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'
@@ -354,6 +358,7 @@ profile::jenkinscontroller::jcasc:
           agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
           labels:
             - maven-11-windows
+          usePrivateIP: true
         - name: maven-17-windows
           os: windows
           command: 'pwsh.exe C:/ProgramData/Jenkins/jenkins-agent.ps1 -Url ^${rootUrl} -Secret ^${secret} -Name ^${nodeName}'


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4204#issuecomment-2281268067

- ci.jenkins.io ACI agents have a dedicated (and delegated) subnet: https://github.com/jenkins-infra/azure-net/pull/281
- ci.jenkins.io Azure Client is now allowed to manage this subnet and the NSG rules are the same between Azure VM agents and ACI: https://github.com/jenkins-infra/azure/pull/800

This PR sets up the ACI agents of ci.jenkins.io to start with a private IP in their private subnet. It means these agent are slightly slower to spin up (takes 10-15 seconds more thant before) but are not exposed publicly and can use the internal ACP server.