### PR TITLE
fix(ci.jio) maven mirror server ID must not have special chars

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -9,8 +9,8 @@ unclassified:
           <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
             <mirrors>
               <mirror>
-                  <id><%= serverConfig['url'] %></id>
-                  <url><%= serverConfig['url'] %></url>
+                  <id><%= serverId %></id>
+                  <url><%= serverConfig['url']%></url>
                   <mirrorOf>external:*,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven</mirrorOf>
               </mirror>
             </mirrors>
@@ -48,7 +48,7 @@ unclassified:
         serverCredentialMappings:
           <%- serverConfig['credentials'].each do |acpCredentialId| -%>
         - credentialsId: "<%= acpCredentialId %>"
-          serverId: "<%= serverConfig['url'] %>"
+          serverId: "<%= serverId %>"
           <%- end -%>
         <%- end -%>
       <%- end -%>


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4204

Fixes the Maven warning message `[WARNING] 'mirrors.mirror.id' must not contain any of these characters \/:"<>|?* but found / @ <...>` in the build logs