### PR TITLE
chore(jenkinscontroller) temporarily uses the new UC by changing IP to new one at Docker host level

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -305,7 +305,7 @@ class profile::jenkinscontroller (
     # actually map the UIDs properly. Using the extra_parameters option because
     # the `username` parameter will get shellescaped in the docker_run_flags()
     # function provided by garethr/docker
-    extra_parameters => '-u `id -u jenkins`:`id -g jenkins`',
+    extra_parameters => '-u `id -u jenkins`:`id -g jenkins` --add-host="updates.jenkins.io:20.7.178.24"',
     # Hard-coding some environment variables because there is no "parent" shell
     # environment to inherit some of these environment settings from.
     # Additionally, Jenkins picks up `user.home` as "?" without the explicit


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2283576911

This PR override the Jenkins controller Docker container's host for `updates.jenkins.io` to utilizes the new UC public IP.

Tested locally on vagrant with a host firewall rule forbidding any outbound request to the current AWS IP of updates.jenkins.io to be sure the Jenkins JVM uses the new IP.
 