### PR TITLE
feat(updatecenter agent) add mirrorbits CLI

### DIFF
--- a/dist/profile/manifests/mirrorbits.pp
+++ b/dist/profile/manifests/mirrorbits.pp
@@ -1,0 +1,25 @@
+# Profile to ensure `mirrorbits` CLI is installed
+class profile::mirrorbits (
+  String $mirrorbits_version,
+  String $install_dir   = '/usr/local/bin',
+) {
+  # Only x86_64 is currently supported out of the box - https://github.com/etix/mirrorbits/issues/150
+  # If arm64 CLI is needed, extract it from https://github.com/jenkins-infra/docker-mirrorbits built container images
+
+  # Dependencies used to install mirrorbits CLI
+  include apt
+  ensure_packages([
+      'curl',
+      'tar',
+  ])
+
+  if $mirrorbits_version {
+    $mirrorbits_url = "https://github.com/etix/mirrorbits/releases/download/${mirrorbits_version}/mirrorbits-${mirrorbits_version}.tar.gz"
+
+    exec { 'Install mirrorbits CLI':
+      require => [Package['curl'], Package['tar']],
+      command => "/usr/bin/curl --location ${mirrorbits_url} | /bin/tar --extract --gzip --strip-components=1 --directory=${install_dir}/ mirrorbits/mirrorbits && chmod a+x ${install_dir}/mirrorbits",
+      unless  => "/usr/bin/test -f ${install_dir}/mirrorbits && { ${install_dir}/mirrorbits version || true} 2>/dev/null | /bin/grep --quiet ${mirrorbits_version}",
+    }
+  }
+}

--- a/dist/profile/manifests/updatecenter.pp
+++ b/dist/profile/manifests/updatecenter.pp
@@ -13,6 +13,7 @@ class profile::updatecenter (
 ) {
   include stdlib # Required to allow using stlib methods and custom datatypes
   include profile::azcopy
+  include profile::mirrorbits
 
   if $rsync_privkey {
     $rsync_privkeyfile = "${home_dir}/.ssh/updates-rsync-key"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -270,6 +270,7 @@ azure::getjenkinsio::fileshare: "overridewithfilestoragename"
 azure::getjenkinsio::storagekey: "overridewithstoragekey"
 profile::azcopy::azcopy_version: 10.26.0-20240731
 profile::azcopy::az_cli_version: 2.64.0
+profile::mirrorbits::mirrorbits_version: v0.5.1
 profile::datadog_pluginsite_check::sites:
   - plugins.jenkins.io
 limits:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2325103688

This PR introduces a new profile `mirrorbits` which makes sure the `mirrorbits` CLI is installed.
It also adds this profile in the `updatecenter` profile to ensure any agent used to generate the "update center" will have the CLI installed.


Tested with a local Vagrant up to install, but could not reliably verify the idempotency as it's an x86 only binary (and I have an arm64 machine).