### PR TITLE
hotfix(profile::mirrorbits) fix idemptocy test to avoid installing CLI on each run

### DIFF
--- a/dist/profile/manifests/mirrorbits.pp
+++ b/dist/profile/manifests/mirrorbits.pp
@@ -19,7 +19,7 @@ class profile::mirrorbits (
     exec { 'Install mirrorbits CLI':
       require => [Package['curl'], Package['tar']],
       command => "/usr/bin/curl --location ${mirrorbits_url} | /bin/tar --extract --gzip --strip-components=1 --directory=${install_dir}/ mirrorbits/mirrorbits && chmod a+x ${install_dir}/mirrorbits",
-      unless  => "/usr/bin/test -f ${install_dir}/mirrorbits && { ${install_dir}/mirrorbits version || true} 2>/dev/null | /bin/grep --quiet ${mirrorbits_version}",
+      unless  => "/usr/bin/test -f ${install_dir}/mirrorbits && { ${install_dir}/mirrorbits version || true; } 2>/dev/null | /bin/grep --quiet ${mirrorbits_version}",
     }
   }
 }


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/jenkins-infra/pull/3642

Tested directly on production (hence hotfix)