### PR TITLE
chore(updatecli):Track mirrorbits CLI version

### DIFF
--- a/updatecli/weekly.d/mirrorbits.yaml
+++ b/updatecli/weekly.d/mirrorbits.yaml
@@ -22,8 +22,9 @@ sources:
       repository: "mirrorbits"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-      typefilter:
-        latest: true
+      versionFilter:
+        kind: semver
+        strict: false
 
 targets:
   updateHieradataVersion:

--- a/updatecli/weekly.d/mirrorbits.yaml
+++ b/updatecli/weekly.d/mirrorbits.yaml
@@ -1,0 +1,46 @@
+---
+name: Bump `mirrorbits-cli` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest `mirrorbits-cli` version
+    spec:
+      owner: "etix"
+      repository: "mirrorbits"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      typefilter:
+        latest: true
+
+targets:
+  updateHieradataVersion:
+    name: Update the `mirrorbits-cli` version in the hieradata/common.yaml file
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: $.profile::mirrorbits::mirrorbits_version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump `mirrorbits-cli` version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - mirrorbits

--- a/updatecli/weekly.d/mirrorbits.yaml
+++ b/updatecli/weekly.d/mirrorbits.yaml
@@ -44,3 +44,4 @@ actions:
       labels:
         - updatecli
         - mirrorbits
+

--- a/updatecli/weekly.d/mirrorbits.yaml
+++ b/updatecli/weekly.d/mirrorbits.yaml
@@ -42,5 +42,5 @@ actions:
     scmid: default
     spec:
       labels:
-        - enhancement
+        - updatecli
         - mirrorbits


### PR DESCRIPTION
As per https://github.com/jenkins-infra/jenkins-infra/issues/3645#issue-2506872631:

Added updatecli manifest to track the latest version of mirrorbits CLI from the GH repo.

Tested locally and successful (rolled-back mirrorbits version to check the solution)

(Also related: https://github.com/jenkins-infra/jenkins-infra/pull/3642 )

