### PR TITLE
feat(cert.ci&trusted.ci):Added AZ SSH VM templates for win-2019 & win-2022

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -70,6 +70,11 @@ jenkins:
           # Install the service
           & $wrapperExec install
           & $wrapperExec start
+          <%- else -%>
+          $javaHome = "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>"
+          [System.Environment]::SetEnvironmentVariable("JAVA_HOME", ^${javaHome}, "Machine")
+          [System.Environment]::SetEnvironmentVariable("PATH", $Env:Path + ";^${javaHome}\bin", "Machine")
+          $Env:Path += ";^${javaHome}\bin"
           <%- end -%>
         <%- else -%>
         executeInitScriptAsRoot: true

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -230,10 +230,6 @@ profile::jenkinscontroller::jcasc:
           spot: false
           architecture: amd64
           labels:
-            - windows
-            - docker-windows
-            - win-2019
-            - windows-2019
             - win-2019-amd64-maven-17
           javaHome: 'C:/tools/jdk-17'
           maxInstances: 10 # Quota of 80 vCPUs
@@ -252,10 +248,6 @@ profile::jenkinscontroller::jcasc:
           spot: false
           architecture: amd64
           labels:
-            - windows
-            - docker-windows
-            - win-2019
-            - windows-2019
             - win-2019-amd64-maven-21
           javaHome: 'C:/tools/jdk-21'
           maxInstances: 10 # Quota of 80 vCPUs

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -197,7 +197,7 @@ profile::jenkinscontroller::jcasc:
           credentialsId: "azure-login"
           usePrivateIP: true
         - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2019"
+          description: "Windows 2019 Maven-11"
           imageDefinition: jenkins-agent-windows-2019-amd64
           os: "windows"
           os_version: "2019"
@@ -214,6 +214,50 @@ profile::jenkinscontroller::jcasc:
             - windows-2019
             - win-2019-amd64-maven-11
           javaHome: 'C:/tools/jdk-11'
+          maxInstances: 10 # Quota of 80 vCPUs
+          useAsMuchAsPossible: true
+          credentialsId: "azure-login"
+          usePrivateIP: true
+        - name: "win-2019-amd64-maven-17" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2019 Maven-17"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: false
+          architecture: amd64
+          labels:
+            - windows
+            - docker-windows
+            - win-2019
+            - windows-2019
+            - win-2019-amd64-maven-17
+          javaHome: 'C:/tools/jdk-17'
+          maxInstances: 10 # Quota of 80 vCPUs
+          useAsMuchAsPossible: true
+          credentialsId: "azure-login"
+          usePrivateIP: true
+        - name: "win-2019-amd64-maven-21" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2019 Maven-21"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: false
+          architecture: amd64
+          labels:
+            - windows
+            - docker-windows
+            - win-2019
+            - windows-2019
+            - win-2019-amd64-maven-21
+          javaHome: 'C:/tools/jdk-21'
           maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-login"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -193,9 +193,6 @@ profile::jenkinscontroller::jcasc:
           spot: true
           architecture: amd64
           labels:
-            - docker-windows
-            - win-2019
-            - windows-2019
             - win-2019-amd64-maven-17
           javaHome: 'C:/tools/jdk-17'
           maxInstances: 7
@@ -214,9 +211,6 @@ profile::jenkinscontroller::jcasc:
           spot: true
           architecture: amd64
           labels:
-            - docker-windows
-            - win-2019
-            - windows-2019
             - win-2019-amd64-maven-21
           javaHome: 'C:/tools/jdk-21'
           maxInstances: 7
@@ -256,9 +250,6 @@ profile::jenkinscontroller::jcasc:
           spot: true
           architecture: amd64
           labels:
-            - docker-windows-2022
-            - win-2022
-            - windows-2022
             - win-2022-amd64-maven-17
           javaHome: 'C:/tools/jdk-17'
           maxInstances: 7
@@ -277,9 +268,6 @@ profile::jenkinscontroller::jcasc:
           spot: true
           architecture: amd64
           labels:
-            - docker-windows-2022
-            - win-2022
-            - windows-2022
             - win-2022-amd64-maven-21
           javaHome: 'C:/tools/jdk-21'
           maxInstances: 7

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -161,7 +161,7 @@ profile::jenkinscontroller::jcasc:
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
         - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2019"
+          description: "Windows 2019 Maven-11"
           imageDefinition: jenkins-agent-windows-2019-amd64
           os: "windows"
           os_version: "2019"
@@ -181,8 +181,50 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
+        - name: "win-2019-amd64-maven-17"
+          description: "Windows 2019 Maven-17"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - docker-windows
+            - win-2019
+            - windows-2019
+            - win-2019-amd64-maven-17
+          javaHome: 'C:/tools/jdk-17'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2019-amd64-maven-21"
+          description: "Windows 2019 Maven-21"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - docker-windows
+            - win-2019
+            - windows-2019
+            - win-2019-amd64-maven-21
+          javaHome: 'C:/tools/jdk-21'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
         - name: "win-2022-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2022"
+          description: "Windows 2022 Maven-11"
           imageDefinition: jenkins-agent-windows-2022-amd64
           os: "windows"
           os_version: "2022"
@@ -198,6 +240,48 @@ profile::jenkinscontroller::jcasc:
             - windows-2022
             - win-2022-amd64-maven-11
           javaHome: 'C:/tools/jdk-11'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2022-amd64-maven-17"
+          description: "Windows 2022 Maven-17"
+          imageDefinition: jenkins-agent-windows-2022-amd64
+          os: "windows"
+          os_version: "2022"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - docker-windows-2022
+            - win-2022
+            - windows-2022
+            - win-2022-amd64-maven-17
+          javaHome: 'C:/tools/jdk-17'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2022-amd64-maven-21"
+          description: "Windows 2022 Maven-21"
+          imageDefinition: jenkins-agent-windows-2022-amd64
+          os: "windows"
+          os_version: "2022"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - docker-windows-2022
+            - win-2022
+            - windows-2022
+            - win-2022-amd64-maven-21
+          javaHome: 'C:/tools/jdk-21'
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -215,7 +215,7 @@ profile::jenkinscontroller::jcasc:
       registryMirror: https://dockerhubmirror.azurecr.io
   agent_images:
     azure_vms_gallery_image:
-      version: 1.94.0
+      version: 2.0.0
       subscription_id: 1311c09f-aee0-4d6c-99a4-392c2b543204
     container_images:
       # All in one image (same as VM templates)


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4124#issue-2335345048:

packer-images version 2.0.0 is now being used.

Added init script to handle javaHome path for Windows SSH agents since default_jdk is no longer used.

Added the following windows SSH AZ VM templates:

cert.ci:
win-2019-maven-17, win-2019-maven-21

trusted.ci
win-2019-maven-17, win-2019-maven-21
win-2022-maven-17, win-2022-maven-21

Fixed labels for windows maven-11 templates.