### PR TITLE
fix(agent.trusted.ci.jenkins.io) correct SSH client config to ensure it uses the old VM for updates.jio

### DIFF
--- a/dist/profile/manifests/updatecenter.pp
+++ b/dist/profile/manifests/updatecenter.pp
@@ -34,7 +34,12 @@ class profile::updatecenter (
       target  => "${home_dir}/.ssh/config",
       order   => '99',
       content => "
+Host aws.updates.jenkins.io
+  IdentityFile ${rsync_privkeyfile}
+Host pkg.origin.jenkins.io
+  IdentityFile ${rsync_privkeyfile}
 Host updates.jenkins.io
+  HostName aws.updates.jenkins.io
   IdentityFile ${rsync_privkeyfile}
 ",
     }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649