### PR TITLE
feat(controllers) ensure the jdk and maven labels are present on all controllers

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -154,6 +154,8 @@ profile::jenkinscontroller::jcasc:
             - ubuntu
             - ubuntu-amd64-maven-11
             - ubuntu-22-amd64-maven-11
+            - maven-11
+            - jdk11
           maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
@@ -172,6 +174,8 @@ profile::jenkinscontroller::jcasc:
           labels:
             - ubuntu-amd64-maven-17
             - ubuntu-22-amd64-maven-17
+            - maven-17
+            - jdk17
           javaHome: '/opt/jdk-17'
           maxInstances: 10
           useAsMuchAsPossible: true
@@ -191,6 +195,8 @@ profile::jenkinscontroller::jcasc:
           labels:
             - ubuntu-amd64-maven-21
             - ubuntu-22-amd64-maven-21
+            - maven-21
+            - jdk21
           javaHome: '/opt/jdk-21'
           maxInstances: 10
           useAsMuchAsPossible: true
@@ -213,6 +219,8 @@ profile::jenkinscontroller::jcasc:
             - win-2019
             - windows-2019
             - win-2019-amd64-maven-11
+            - maven-windows
+            - maven-11-windows
           javaHome: 'C:/tools/jdk-11'
           maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
@@ -231,6 +239,7 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - win-2019-amd64-maven-17
+            - maven-17-windows
           javaHome: 'C:/tools/jdk-17'
           maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
@@ -249,6 +258,7 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - win-2019-amd64-maven-21
+            - maven-21-windows
           javaHome: 'C:/tools/jdk-21'
           maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -176,6 +176,8 @@ profile::jenkinscontroller::jcasc:
             - win-2019
             - windows-2019
             - win-2019-amd64-maven-11
+            - maven-windows
+            - maven-11-windows
           javaHome: 'C:/tools/jdk-11'
           maxInstances: 7
           useAsMuchAsPossible: true
@@ -194,6 +196,7 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - win-2019-amd64-maven-17
+            - maven-17-windows
           javaHome: 'C:/tools/jdk-17'
           maxInstances: 7
           useAsMuchAsPossible: true
@@ -212,6 +215,7 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - win-2019-amd64-maven-21
+            - maven-21-windows
           javaHome: 'C:/tools/jdk-21'
           maxInstances: 7
           useAsMuchAsPossible: true


### PR DESCRIPTION
Follow up of #3656 

This PR brings feature parity for pipeline labels between ci.jio, trusted.ci.jio and cert.ci.jio. ensures that the `jdkXX` (for Linux agents), `maven-XX` (Linux agents) and `maven-XX-windows` (Windows agents) labels are met.

Note: trusted.ci still uses windows 2019 machines for these labels. Windows 2022 is only used for specific use cases such as Docker images. We might change in the future, but not now.