### PR TITLE
feat(ci.jio): Add EC2 plugin for VM agents

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -691,6 +691,7 @@ profile::jenkinscontroller::plugins:
   - datadog # Datadog plugin
   - dark-theme # Dark theme
   - docker-workflow # Provides the "withDockerContainer" pipeline keyword
+  - ec2
   - embeddable-build-status # https://github.com/jenkins-infra/helpdesk/issues/3013
   - git # Used for... git
   - git-forensics # Discovering reference builds, used in buildPlugin

--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -691,7 +691,7 @@ profile::jenkinscontroller::plugins:
   - datadog # Datadog plugin
   - dark-theme # Dark theme
   - docker-workflow # Provides the "withDockerContainer" pipeline keyword
-  - ec2
+  - ec2 # For Jenkins EC2 VM agents
   - embeddable-build-status # https://github.com/jenkins-infra/helpdesk/issues/3013
   - git # Used for... git
   - git-forensics # Discovering reference builds, used in buildPlugin


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4316#issue-2554224678

We added the [EC2 Jenkins plugin](https://plugins.jenkins.io/ec2/) for ci.jenkins.io controller