### PR TITLE
fix(jenkinscontroller) correct JCasC Datadog template to remove deprecated `retryLogs` directive

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/datadog.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/datadog.yaml.erb
@@ -23,8 +23,6 @@ unclassified:
     globalTags: <%= @jcasc['datadog']['globalTags'] ? @jcasc['datadog']['globalTags'] : "controller:" + @jcasc['datadog']['host'] %>
     # Send security events like login, logout, and login failure.
     emitSecurityEvents: <%= @jcasc['datadog']['emitSecurityEvents'] ? @jcasc['datadog']['emitSecurityEvents'] : true %>
-    # Retry sending a log if sending to Datadog fails
-    retryLogs: <%= @jcasc['datadog']['retryLogs'] ? @jcasc['datadog']['retryLogs'] : true %>
     # Refresh Dogstatsd Client when your agent IP changes
     refreshDogstatsdClient: true
     # Cache build runs when calculating pause duration


### PR DESCRIPTION
Part of https://github.com/jenkins-infra/helpdesk/issues/4377#issuecomment-2475717984

Ref. https://github.com/jenkinsci/datadog-plugin/issues/467#issuecomment-2459745096