### PR TITLE
feat(jenkinscontroller/aws.ci.jenkins.io) add back ec2 cloud

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -3,13 +3,21 @@ def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 pipeline {
   // `docker` and `updatecli` are required
   agent { label 'linux-amd64-docker' }
+
   options {
     buildDiscarder(logRotator(numToKeepStr: '10'))
     timeout(time: 30, unit: 'MINUTES')
     disableConcurrentBuilds(abortPrevious: true)
   }
+
   triggers {
     cron (cronExpr)
+  }
+
+  environment {
+    AWS_ACCESS_KEY_ID     = credentials('packer-aws-access-key-id')
+    AWS_SECRET_ACCESS_KEY = credentials('packer-aws-secret-access-key')
+    AWS_DEFAULT_REGION    = 'us-east-2'
   }
   stages {
     stage('Check Configuration Update') {

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -80,8 +80,8 @@ jenkins:
         executeInitScriptAsRoot: true
         # Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
         initScript: |
-          #!/bin/sh
-          set -eux
+          #!/bin/bash
+          set -eux -o pipefail
 
           # Setup Datadog service
           (
@@ -211,7 +211,7 @@ jenkins:
         retentionStrategy: "azureVMCloudOnce"
       <%- end -%>
         shutdownOnIdle: false
-        spotInstance: <%= cloudsetup['disableSpot'] ? false : (agent['spot'] ? true : false) %>
+        spotInstance: false # TODO: add spot support (inbound)
         templateDesc: "Dynamically provisioned <%= agent['description'] %> machine"
         templateDisabled: false
         templateName: "<%= agent['name'] %>"
@@ -311,12 +311,12 @@ jenkins:
         ebsEncryptRootVolume: DEFAULT
         ebsOptimized: false
         hostKeyVerificationStrategy: ACCEPT_NEW
-        idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] ? agent['idleTerminationMinutes'] : 1 %>"
+        idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] ? agent['idleTerminationMinutes'] : -5 %>"
         instanceCapStr: "<%= agent['maxInstances'] %>"
         jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
         labelString: "<%= agent['os'] + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['labels'].join(' ') %>"
         launchTimeoutStr: "1000"
-        maxTotalUses: 1 # Throw away the VMs after a build
+        maxTotalUses: 1 # Throw away the VMs after a build: ephemeral machines
         minimumNumberOfInstances: 0
         minimumNumberOfSpareInstances: 0
         mode: <%= agent['useAsMuchAsPossible'] == true ? 'NORMAL' : 'EXCLUSIVE' %>
@@ -343,17 +343,64 @@ jenkins:
         type: <%= agent['instanceType'] %>
         tmpDir: "<%= @jcasc['agents_setup'][agent['os']]['tempDir'] %>"
         useEphemeralDevices: true
-        <%- if agent['userData'] && !agent['userData'].empty? -%>
-        userData: |
-          <%- agent['userData'].each do |line| -%>
-            <%= line %>
-          <%- end -%>
+        # Note: Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
+        initScript: |-
+        <%- if agent['os'].to_s == 'windows' -%>
+
+          ## Setup datadog
+          (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: <%= @jcasc['datadog_api_key'] %>' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+          & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart
+
+          ## Setup Docker Engine
+          @'
+          {
+            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][agent['os'].to_s]['registryMirror'] %>"]
+          }
+          '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
+          Restart-Service docker
+        <%- else -%>
+          #!/bin/bash
+          set -eux -o pipefail
+
+          ## Setup Datadog service
+          (
+            systemctl stop datadog-agent.service
+            mkdir -p /var/log/datadog /etc/datadog-agent
+            sed 's/api_key:.*/api_key: <%= @jcasc['datadog_api_key'] %>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+            sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+            chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+            chmod 640 /etc/datadog-agent/datadog.yaml
+            chown dd-agent:dd-agent /var/log/datadog
+            chmod 770 /var/log/datadog
+            systemctl daemon-reload
+            systemctl enable datadog-agent.service
+            systemctl start datadog-agent.service
+          ) 2>&1 | tee /var/log/agent-init-datadog.log
+
+          ## Setup Docker Engine
+          mkdir -p /etc/docker
+          cat <<EOF >/etc/docker/daemon.json
+          {
+            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][agent['os'].to_s]['registryMirror'] %>"]
+          }
+          EOF
+          systemctl daemon-reload
+          systemctl restart docker
+
+          ## Setup default java for build (not for agent process)
+          export DEFAULT_JDK=<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>
+          update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+
+          ## Remove jenkins user from sudoers
+          rm -f /etc/sudoers.d/90-cloud-init-users
         <%- end -%>
         nodeProperties:
         - envVars:
             env:
             - key: "ARTIFACT_CACHING_PROXY_PROVIDER"
               value: "aws"
+            - key: "JAVA_HOME"
+              value: "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>"
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -283,7 +283,7 @@ jenkins:
   <%- if @jcasc['cloud_agents']['ec2'] && !@jcasc['cloud_agents']['ec2'].empty? -%>
     <%- @jcasc['cloud_agents']['ec2'].each do |ec2_cloud_name, ec2_cloud_setup| -%>
   - amazonEC2:
-      cloudName: <%= ec2_cloud_name %>
+      name: <%= ec2_cloud_name %>
       credentialsId: "<%= ec2_cloud_setup['credentialsId'] %>"
       <%- $maxEC2Vms = 0; ec2_cloud_setup['agent_definitions'].each do |agent| -%>
         <%- $maxEC2Vms = agent['maxInstances'] + $maxEC2Vms -%>
@@ -295,7 +295,6 @@ jenkins:
       templates:
       <%- ec2_cloud_setup['agent_definitions'].each do |agent| -%>
       - ami: "<%= @jcasc['agent_images']['ec2_amis'][agent['os'].to_s + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"
-        amiOwners: "200564066411"
         amiType:
           unixData:
             <%-# Windows VM agent are not supported yet: https://issues.jenkins.io/browse/JENKINS-69304 -%>

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -289,9 +289,10 @@ jenkins:
         <%- $maxEC2Vms = agent['maxInstances'] + $maxEC2Vms -%>
       <%- end -%>
       instanceCapStr: "<%= $maxEC2Vms %>"
+      noDelayProvisioning: true
       region: "<%= ec2_cloud_setup['region'] %>"
       sshKeysCredentialsId: "<%= ec2_cloud_setup['sshKeysCredentialsId'] %>"
-      useInstanceProfileForCredentials: false
+      useInstanceProfileForCredentials: "<%= ec2_cloud_setup['useInstanceProfileForCredentials'] ? ec2_cloud_setup['useInstanceProfileForCredentials'] : false %>"
       templates:
       <%- ec2_cloud_setup['agent_definitions'].each do |agent| -%>
       - ami: "<%= @jcasc['agent_images']['ec2_amis'][agent['os'].to_s + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -280,6 +280,83 @@ jenkins:
       <%- end -%>
     <%- end -%>
   <%- end -%>
+  <%- if @jcasc['cloud_agents']['ec2'] && !@jcasc['cloud_agents']['ec2'].empty? -%>
+    <%- @jcasc['cloud_agents']['ec2'].each do |ec2_cloud_name, ec2_cloud_setup| -%>
+  - amazonEC2:
+      cloudName: <%= ec2_cloud_name %>
+      credentialsId: "<%= ec2_cloud_setup['credentialsId'] %>"
+      <%- $maxEC2Vms = 0; ec2_cloud_setup['agent_definitions'].each do |agent| -%>
+        <%- $maxEC2Vms = agent['maxInstances'] + $maxEC2Vms -%>
+      <%- end -%>
+      instanceCapStr: "<%= $maxEC2Vms %>"
+      region: "<%= ec2_cloud_setup['region'] %>"
+      sshKeysCredentialsId: "<%= ec2_cloud_setup['sshKeysCredentialsId'] %>"
+      useInstanceProfileForCredentials: false
+      templates:
+      <%- ec2_cloud_setup['agent_definitions'].each do |agent| -%>
+      - ami: "<%= @jcasc['agent_images']['ec2_amis'][agent['os'].to_s + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"
+        amiOwners: "200564066411"
+        amiType:
+          unixData:
+            <%-# Windows VM agent are not supported yet: https://issues.jenkins.io/browse/JENKINS-69304 -%>
+            <%- if agent['os'].to_s != 'windows' -%>
+            slaveCommandPrefix: "PATH=<%= scope.call_function('dirname', [agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup']['ubuntu']['agentJavaBin']]) %>:<%= @jcasc['agents_setup']['ubuntu']['path'] %>"
+            <%- end -%>
+            sshPort: "22"
+        associatePublicIp: true
+        connectBySSHProcess: false
+        connectionStrategy: PUBLIC_DNS
+        deleteRootOnTermination: true
+        description: "<%= agent['description'] %>"
+        ebsEncryptRootVolume: DEFAULT
+        ebsOptimized: false
+        hostKeyVerificationStrategy: ACCEPT_NEW
+        idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] ? agent['idleTerminationMinutes'] : 1 %>"
+        instanceCapStr: "<%= agent['maxInstances'] %>"
+        jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
+        labelString: "<%= agent['os'] + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['labels'].join(' ') %>"
+        launchTimeoutStr: "1000"
+        maxTotalUses: 1 # Throw away the VMs after a build
+        minimumNumberOfInstances: 0
+        minimumNumberOfSpareInstances: 0
+        mode: <%= agent['useAsMuchAsPossible'] == true ? 'NORMAL' : 'EXCLUSIVE' %>
+        monitoring: false
+        numExecutors: 1
+        remoteAdmin: "<%= @jcasc['agents_setup'][agent['os'].to_s]['remoteAdmin'] %>"
+        remoteFS: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][agent['os'].to_s]['agentDir'] %>"
+        securityGroups: "ci-agents"
+        <%- if agent['spot'] -%>
+        spotConfig:
+          fallbackToOndemand: true
+          useBidPrice: false
+        <%- end -%>
+        stopOnTerminate: false
+        t2Unlimited: false
+        tags:
+        - name: "architecture"
+          value: "<%= agent['architecture'] %>"
+        - name: "os"
+          value: "<%= agent['os'] %>"
+        - name: "jenkins"
+          value: "ci.jenkins.io"
+        tenancy: Default
+        type: <%= agent['instanceType'] %>
+        tmpDir: "<%= @jcasc['agents_setup'][agent['os']]['tempDir'] %>"
+        useEphemeralDevices: true
+        <%- if agent['userData'] && !agent['userData'].empty? -%>
+        userData: |
+          <%- agent['userData'].each do |line| -%>
+            <%= line %>
+          <%- end -%>
+        <%- end -%>
+        nodeProperties:
+        - envVars:
+            env:
+            - key: "ARTIFACT_CACHING_PROXY_PROVIDER"
+              value: "aws"
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
   <%- if @jcasc['cloud_agents']['kubernetes'] && !@jcasc['cloud_agents']['kubernetes'].empty? -%>
     <%- @jcasc['cloud_agents']['kubernetes'].each do |k8s_name, k8s_setup| -%>
     <%- if k8s_setup['enabled'].to_s == "true" -%>

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -89,6 +89,24 @@ profile::jenkinscontroller::jcasc:
     host: "aws.ci.jenkins.io"
     targetHost: "172.17.0.1" # docker0 interface
     collectBuildLogs: true
+  cloud_agents:
+    ec2:
+      aws-us-east-2:
+        region: us-east-2
+        credentialsId: "aws-credentials-jenkins-ci"
+        sshKeysCredentialsId: "ec2-agent-ssh"
+        agent_definitions:
+          - description: "ARM64 ubuntu 22.04"
+            maxInstances: 5
+            instanceType: A1Xlarge # 4 vCPUs / 8 Gb
+            os: "ubuntu"
+            os_version: "22.04"
+            architecture: "arm64"
+            labels:
+              - ubuntu
+              - arm64docker
+              - arm64linux
+            spot: true
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor # Provides ANSI color in the UI when checking log outputs

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -192,7 +192,8 @@ profile::jenkinscontroller::jcasc:
   agents_setup:
     windows:
       agentDir: 'C:/Jenkins/agent'
-      tempDir: 'C:/Temp'
+      # Double Backslash is required (for EC2 plugin as we hackishly use the unix launched for Windows to use OpenSSH)
+      tempDir: 'C:\\\\Temp'
       remoteAdmin: Administrator
       osDiskSize: 150
       osDiskStorageAccountType: 'Premium_LRS'
@@ -212,6 +213,12 @@ profile::jenkinscontroller::jcasc:
       path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
       registryMirror: https://dockerhubmirror.azurecr.io
   agent_images:
+    ec2_amis:
+      ubuntu-22.04-amd64: "ami-0bd6642923953e087"
+      windows-2019-amd64: "ami-0df4e33d473d4899e"
+      ubuntu-22.04-arm64: ami-0f126d4f0052d12b6
+      # Empty until https://github.com/jenkins-infra/packer-images/pull/442 is merged
+      windows-2022-amd64: "ami-0a78169098a3f340d"
     azure_vms_gallery_image:
       version: 2.14.0
       subscription_id: 1311c09f-aee0-4d6c-99a4-392c2b543204

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -60,7 +60,45 @@ profile::jenkinscontroller::jcasc:
               - node
               - webbuilder
               - ruby
-            imagePullSecrets: dockerhub-credentials
+            imagePullSecrets: dockerhub-credential
+    ec2:
+      aws-us-east-2:
+        region: us-east-2
+        credentialsId: "aws-credentials-jenkins-ci"
+        sshKeysCredentialsId: "ec2-agent-ssh-2021-06"
+        agent_definitions:
+          - description: "Ubuntu 20.04 LTS datadog"
+            maxInstances: 1
+            instanceType: T3Xlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            os_version: "20.04"
+            architecture: "amd64"
+            labels:
+              - ec2_datadog
+            useAsMuchAsPossible: false
+            userData: &datadogInitUserData
+              - "#!/bin/bash"
+              - "sed 's/api_key:.*/api_key: tokeepsecret' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml"
+              - "sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml"
+              - mkdir /var/log/datadog
+              - chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+              - chmod 640 /etc/datadog-agent/datadog.yaml
+              - chown dd-agent:dd-agent /var/log/datadog
+              - chmod 770 /var/log/datadog
+              - systemctl restart datadog-agent.service
+              - rm -f /etc/sudoers.d/90-cloud-init-users
+          - description: "Windows 2022"
+            maxInstances: 5
+            instanceType: A1Xlarge # 4 vCPUs / 8 Gb
+            os: "windows"
+            os_version: "2022"
+            architecture: "arm64"
+            labels:
+              - windows
+            useAsMuchAsPossible: false
+            spot: false
+            userData: *datadogInitUserData
+    imagePullSecrets: dockerhub-credentials
     azure_vm_agents:
       clouds:
         azure-vms:
@@ -73,6 +111,7 @@ profile::jenkinscontroller::jcasc:
           virtualNetworkName: "prod-jenkins-public-prod"
           virtualNetworkResourceGroupName: "prod-jenkins-public-prod"
           subnetName: "ci.j-agents-vm"
+      resource_group: eastus-cijenkinsio
       agent_definitions:
         - name: "ubuntu-20"
           description: "Ubuntu 20.04 LTS"
@@ -138,6 +177,7 @@ profile::jenkinscontroller::plugins:
   - configuration-as-code
   - credentials
   - credentials-binding
+  - ec2
   - github-branch-source
   - kubernetes
   - ldap

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -408,6 +408,7 @@ profile::jenkinscontroller::plugins:
   - credentials-binding
   - datadog
   - docker-workflow
+  - ec2
   - embeddable-build-status
   - git-client
   - git

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -113,6 +113,23 @@ profile::jenkinscontroller::jcasc:
         - home: "/home/jenkins/tools/apache-maven-3.8.7"
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
   cloud_agents:
+    ec2:
+      aws-us-east-2:
+        region: us-east-2
+        credentialsId: "aws-credentials-jenkins-ci"
+        sshKeysCredentialsId: "ec2-agent-ssh"
+        agent_definitions:
+          - description: "ARM64 ubuntu 22.04"
+            maxInstances: 5
+            instanceType: A1Xlarge # 4 vCPUs / 8 Gb
+            os: "ubuntu"
+            os_version: "22.04"
+            architecture: "arm64"
+            labels:
+              - ubuntu
+              - arm64docker
+              - arm64linux
+            spot: true
     kubernetes:
       first-cluster:
         enabled: true

--- a/updatecli/weekly.d/jenkinscontroller-agents.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents.yaml
@@ -1,0 +1,137 @@
+---
+name: Bump packer agent templates version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  packerImageVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkins-infra"
+      repository: "packer-images"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+  getLatestInboundAllInOneContainerImageX86:
+    kind: dockerdigest
+    name: Get digest of the jenkinsciinfra/jenkins-agent-ubuntu-22.04 image
+    dependson:
+      - packerImageVersion
+    spec:
+      image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04"
+      tag: '{{ source "packerImageVersion"}}'
+      architecture: amd64
+  getLatestInboundAllInOneContainerImageARM:
+    kind: dockerdigest
+    name: Get digest of the jenkinsciinfra/jenkins-agent-ubuntu-22.04 image
+    dependson:
+      - packerImageVersion
+    spec:
+      image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04"
+      tag: '{{ source "packerImageVersion"}}'
+      architecture: arm64
+  getLatestInboundJDK11ContainerImage:
+    kind: dockerdigest
+    spec:
+      image: "jenkins/inbound-agent"
+      tag: "latest-jdk11"
+      architecture: amd64
+  getLatestUbuntuAgentAMIArm64:
+    kind: aws/ami
+    dependson:
+      - packerImageVersion
+    spec:
+      region: us-east-2
+      sortby: creationDateDesc
+      filters:
+        - name: "name"
+          values: "jenkins-agent-ubuntu-22.04-arm64-*"
+        - name: "tag:build_type"
+          values: "prod"
+        - name: "tag:version"
+          values: '{{ source "packerImageVersion" }}'
+  getWindowsVMAgentsDiskSize:
+    kind: file
+    dependson:
+      - packerImageVersion
+    spec:
+      file: 'https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source `packerImageVersion` }}/locals.pkr.hcl'
+      # matchpattern can only retrieve the full line. A transformer is required after to strip the unused content
+      matchpattern: 'windows_disk_size_gb = (.*)'
+    transformers:
+      ## Retrieve only the integer (ignore whitespaces, comments, etc.)
+      - findsubmatch:
+          pattern: 'windows_disk_size_gb = (\d*)'
+          captureindex: 1
+
+conditions:
+  checkAllInOneContainerImages:
+    disablesourceinput: true
+    name: Check that x86 and arm64 all in one images are different
+    kind: shell
+    spec:
+      command: test {{ source "getLatestInboundAllInOneContainerImageX86" }} != {{ source "getLatestInboundAllInOneContainerImageARM" }}
+
+targets:
+  setWindowsVMAgentDiskSize:
+    sourceid: getWindowsVMAgentsDiskSize
+    name: "Change the Azure VM agents disk size"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agents_setup.windows.osDiskSize"
+    scmid: default
+  setAzureGalleryImageVersion:
+    sourceid: packerImageVersion
+    name: "Bump Azure Gallery Image Version"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.azure_vms_gallery_image.version"
+    scmid: default
+  setInboundAllInOneContainerImage:
+    sourceid: getLatestInboundAllInOneContainerImageX86
+    name: "Bump container agent image jenkinsciinfra/jenkins-agent-ubuntu-22.04 (AllInOne) for x86"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp-maven-all-in-one"
+    transformers:
+      - addprefix: "jenkinsciinfra/jenkins-agent-ubuntu-22.04@"
+    scmid: default
+  setInboundJDK11ContainerImage:
+    sourceid: getLatestInboundJDK11ContainerImage
+    name: "Bump container agent image jenkins/inbound-agent (JDK11)"
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: "profile::jenkinscontroller::jcasc.agent_images.container_images.jnlp"
+    transformers:
+      - addprefix: "jenkins/inbound-agent@"
+    scmid: default
+  setUbuntuAgentAMIArm64:
+    name: "Bump AMI ID for Ubuntu ARM64 agents"
+    kind: yaml
+    sourceid: getLatestUbuntuAgentAMIArm64
+    spec:
+      file: hieradata/common.yaml
+      key: 'profile::jenkinscontroller::jcasc.agent_images.ec2_amis.ubuntu-22\.04-arm64'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump packer agent templates version to {{ source "packerImageVersion" }}
+    spec:
+      labels:
+        - dependencies


### PR DESCRIPTION
This PR reverts https://github.com/jenkins-infra/jenkins-infra/pull/2955, adding back the support of ec2 clouds for https://github.com/jenkins-infra/helpdesk/issues/4316

It fixes/changes a few configuration items:
- Correct cloud name JCasc directive which has changed since #2955
- Disable spot (as it requires inbound: not yet)
- Changes userData to init script with Windows support
  - Using the same code as for azure VMs


Note: the `updatecli` process is failing due a missing credential: will be fixed in a subsequent PR


It's a first step to avoid a tedious initial config on aws.ci.jenkins.io. It has been tested on the local vagrant VM but still need some work