### PR TITLE
feat(trusted.ci.jenkins.io) remove blueocean plugin from puppet manifest

### DIFF
--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -282,7 +282,6 @@ profile::jenkinscontroller::jcasc:
 profile::jenkinscontroller::plugins:
   - ansicolor
   - azure-vm-agents
-  - blueocean
   - build-timeout
   - buildtriggerbadge
   - cloudbees-folder


### PR DESCRIPTION
as per jenkins-infra/helpdesk#4400 removing the puppet installation of the plugin blueocean on the jenkins controller trusted.ci.jenkins.io