### PR TITLE
 feat(azcopy) switch from binary to APT package to track version from GitHub repository in semver format

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -272,7 +272,7 @@ docker::version: 5:27.4.0-1~ubuntu.22.04~jammy
 azure::getjenkinsio::storageaccount: "overridewithstorageaccountname"
 azure::getjenkinsio::fileshare: "overridewithfilestoragename"
 azure::getjenkinsio::storagekey: "overridewithstoragekey"
-profile::azcopy::azcopy_version: 10.27.1-20241113
+profile::azcopy::azcopy_version: 10.27.1
 profile::azcopy::az_cli_version: 2.67.0
 profile::mirrorbits::mirrorbits_version: v0.5.1
 profile::datadog_pluginsite_check::sites:

--- a/hieradata/env/production.yaml
+++ b/hieradata/env/production.yaml
@@ -11,7 +11,8 @@ azure::getjenkinsio::fileshare: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxgg
 azure::getjenkinsio::storagekey: ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAreO1nGjp5BkiRgsWIp6zTRj8hAZcoaZXH6FhgyLtxVel8hd/tmjmRYdwxeHOMmgEn4mMj+0hRdQHyBaarHQeOjR+7k+iU6JHTvGN9Sktf/1AmhWpm8dP3WFBGGjg/vtFU9XCTJJcjGa/WEyoK2WqeP0seRXRF6hQ7IJGCbCcEtkuqZNYMm5Ow4z7k9kebS/U24nvC3SnVUjK60VBUev3CKXaCUDF+moElWS9ZFT7k2j+r9lAQ6xlQwmwC2VSN+wXCOKX0D2EAzVSDxJ/ledgl72QnRLc/tWj/lD+XWy5y24oZS5ZF4sf/YxMi1LAVq/DjcYWdxbf+HFXODjcUo/ufjCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQvLEEb5diJAhC0w0QwljlDoBgvctqNJEVhnTgHdyUIeITWEbtywcHt2Kf3ngePljvIzOkIykPp8kjVsYy4iTBse5nkleLm8wH2Hhz0fcfYkLEjI4OMEJmmKacwkamTw+NAK8wHmUL6UeM5KCIvXxA0n2T]
 
 # SSH keys used for inter-machine accesses
-osuosl_mirroring::privkey: >
+osuosl_mirroring::privkey: |
+  >
   ENC[PKCS7,MIIH/QYJKoZIhvcNAQcDoIIH7jCCB+oCAQAxggEhMIIBHQIBAD
   AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAV+V7n9zWF1EplI1GDR7fJRm/uH
   LxKPdzfmzzFdNZtYoYjJoTXS8Stm3hoNb+E4H5TWOmGu6NBh9C47PL7sYfoP
@@ -59,7 +60,8 @@ osuosl_mirroring::privkey: >
   EK+xGtTs6tkov7HKKCizr2t2MoqZKi6Fk5YnWHnyb2K2HS7d3S3ghM4AMUap
   vpNPqMjpDA189GtI9IHY1DeIv/tLbMbEupKg9musp6]
 
-archives_jenkins_io_mirroring::privkey: >
+archives_jenkins_io_mirroring::privkey: |
+  >
   ENC[PKCS7,MIIH/QYJKoZIhvcNAQcDoIIH7jCCB+oCAQAxggEhMIIBHQIBAD
   AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAM/4JE7cVeWM97wYS9NFUAeLxoD
   Hn3xE/hJp5xCOlsKn2APO3h5qS9LdzUaOabD9Xjbnc9V4o3eUkfJscfvvxbr

--- a/spec/classes/profile/azcopy_spec.rb
+++ b/spec/classes/profile/azcopy_spec.rb
@@ -1,9 +1,8 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe 'profile::azcopy' do
-
-  it { is_expected.to contain_exec('Install azcopy') }
-  it { is_expected.to contain_package('curl') }
-  it { is_expected.to contain_package('tar') }
-  it { is_expected.to contain_package('azure-cli') }
+describe "profile::azcopy" do
+  it { is_expected.to contain_package("azcopy") }
+  it { is_expected.to contain_package("curl") }
+  it { is_expected.to contain_package("tar") }
+  it { is_expected.to contain_package("azure-cli") }
 end

--- a/updatecli/weekly.d/azcopy.yaml
+++ b/updatecli/weekly.d/azcopy.yaml
@@ -15,12 +15,14 @@ scms:
 
 sources:
   lastReleaseVersion:
-    kind: shell
-    name: Get the latest `azcopy` (full) version
+    kind: githubrelease
+    name: Get the latest `azcopy` version
     spec:
-      command: bash -c 'basename "$(dirname "$(curl https://aka.ms/downloadazcopy-v10-linux --write-out "%{redirect_url}" --output /dev/null --silent --fail --show-error)" )"'
+      owner: Azure
+      repository: azure-storage-azcopy
+      token: "{{ requiredEnv .github.token }}"
     transformers:
-      - trimprefix: 'release-'
+      - trimprefix: v
 
 targets:
   updateHieradataVersion:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4438

Microsoft now provides native packages for both x86_64 but also aarch64 so we can use them!

Notes:
- The Updatecli manifest is fixed to track the semantic version. The check mentions a change in the diff, but since it is part of the PR, nothing is expected to change
- Added a chore YAML formatting in hierdata
- Once merged, we'll have to check result in both pkg and agent.trusted VMs