### PR TITLE
hotfix(openvpn) pass TUN device for recent kernel + Docker CE

### DIFF
--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -43,7 +43,7 @@ class profile::openvpn (
       # TODO: replace by a conversion from profile network cidr
       "OPENVPN_SERVER_NETMASK=${vpn_network['netmask']}",
     ],
-    extra_parameters => ['--restart=always --cap-add=NET_ADMIN'],
+    extra_parameters => ['--restart=always --cap-add=NET_ADMIN --device=/dev/net/tun'],
     net              => 'host',
     require          => [Docker::Image[$image]],
   }

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -267,7 +267,7 @@ r10k::webhook::config::github_secret: "justapassword"
 usage_ssh_pubkey: "AAAAB3NzaC1yc2EAAAADAQABAAACAQD66Xfd/5HgBkc6lGGqCrhJ/LBIWOTQ5BRcGEnSKH/Ij4vlVI42bHTusZ/y2lJZ+CUE04kDqWD1WG/Rhv9YjShlotlpv+Ig8JqCzpbkMXuEsrWgXp4BO0D0NeLeZkza2isG9NqqXHAJj6ck7MvKkH56PCjzBru9C3+DTa6CgXy6KtMV9vFSqeD9JCn8p9fdeArIGHJk7li1fSCNoTYVq+P3/Jh9YHk1pLQbp9nOg4fz2DjSsdi/VfzMCW4XVTzatOv/e2dFkz2sNdsXEpxWZoLUDgBSgMU1Agiyphmuc+FfZsjkmLO03bvO1fC7BVJtYHoRSuNnJbMKpkOnDa8l0bpQz6NxF1PB3znfHBm/TZVJX4XhJK7Bqi46Rkyo564kjd3+DRII6n3ziBgDVezQwvvB0b5lyxH6+Ysu6nsmwaV8wnsuolPQXUIUTbOjcJ1iN0acESfOX8mGAbv0K3RVpA3vV+7fXioylO+cG6szzDVLOC3z1ltVO+3vV2iWGMfdEQvJzC5uuOrSZYG7FuRvY6NyZINIt4vthkKPJW3QL+flS4fnqYrzj006jo1rNwZlQytc0uPT3qQJ07iF06oAvHlUuUNgQUO4FPvCAkiIFcpXZpo4jB00JYBcXpCB+OtOiBzgyiRq40l34htR3Hs2skY8e9F8Z9XTpPw2aaS0OjrE6w=="
 usage_ssh_privkey: "usage_ssh_privkey"
 # Full version of the Ubuntu package used for Docker CE as per apt-cache output
-docker::version: 5:27.3.1-1~ubuntu.22.04~jammy
+docker::version: 5:27.4.0-1~ubuntu.22.04~jammy
 # This file storage and the storage account are defined in https://github.com/jenkins-infra/azure/blob/main/get.jenkins.io.tf
 azure::getjenkinsio::storageaccount: "overridewithstorageaccountname"
 azure::getjenkinsio::fileshare: "overridewithfilestoragename"


### PR DESCRIPTION
This PR fixes the OpenVPN error:

```
ERROR: Cannot open TUN/TAP dev /dev/net/tun: Operation not permitted
```

caused by recent updates of kernel + [Docker CE 27.4.0](https://docs.docker.com/engine/release-notes/27/#2740).

It now passed the TUN virtual device directly to the container... as a device