### PR TITLE
feat(openvpn) add 2 routes to the EKS cluster `cijenkinsio-agents-2`

### DIFF
--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -13,7 +13,7 @@ class profile::openvpn (
   Optional[String] $openvpn_dh_pem              = undef,
   Hash $vpn_network                             = {},
   Hash $networks                                = {},
-  Hash[String,String] $allowed_external_ssh_ips = []
+  Hash[String,String] $external_ips_vpn_restricted = []
 ) {
   include stdlib # Required to allow using stlib methods and custom datatypes
   include profile::docker
@@ -182,7 +182,7 @@ class profile::openvpn (
       }
     } else {
       # Allow routing from VPN to the following external (Internet) with outbound SSH (admin restrictions)
-      $allowed_external_ssh_ips.each |String $service_name, String $external_ssh_ip| {
+      $external_ips_vpn_restricted.each |String $service_name, String $external_ssh_ip| {
         $external_ssh_ip_cidr = "${external_ssh_ip}/32"
 
         firewall { "100 allow routing from ${vpn_network['cidr']} to ${service_name} (${external_ssh_ip}) on port 22":

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -283,12 +283,14 @@ limits:
       soft: "65536"
       hard: "65536"
 profile::openvpn::image_tag: 2.4.48
-profile::openvpn::allowed_external_ssh_ips:
+profile::openvpn::external_ips_vpn_restricted:
   pkg.origin.jenkins.io: 52.202.51.185
   census.jenkins.io: 52.202.38.86
   usage.jenkins.io: 52.204.62.78
   archives.jenkins.io: 46.101.121.132
   aws.ci.jenkins.io: 3.146.166.108
+  cijenkinsio-agents-2-ip1: 3.146.156.247
+  cijenkinsio-agents-2-ip2: 3.130.164.212
 profile::updatesite::docroot: /var/www/updates.jenkins.io
 apt::update:frequency: 'daily'
 # vim: ft=yaml ts=2 sw=2 nowrap et

--- a/updatecli/weekly.d/external-ssh-ips.yaml
+++ b/updatecli/weekly.d/external-ssh-ips.yaml
@@ -28,7 +28,7 @@ targets:
     sourceid: aws-ci-jenkins-io
     spec:
       file: hieradata/common.yaml
-      key: $.profile::openvpn::allowed_external_ssh_ips.'aws.ci.jenkins.io'
+      key: $.profile::openvpn::external_ips_vpn_restricted.'aws.ci.jenkins.io'
     scmid: default
 
 actions:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4319

Twin (server-side) of https://github.com/jenkins-infra/docker-openvpn/pull/372

Current endpoint hostname is `BFED49033BB86D3FF1EF8DE8480E024B.gr7.us-east-2.eks.amazonaws.com` which resolve to 2 public IPv4s.