### PR TITLE
fix(jenkinscontroller/aws.ci.jio) correct EC2 configuration to allow using private subnet with on-demande instances

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -281,6 +281,7 @@ jenkins:
     <%- end -%>
   <%- end -%>
   <%- if @jcasc['cloud_agents']['ec2'] && !@jcasc['cloud_agents']['ec2'].empty? -%>
+    <%- $cloudInitDoneFile = "/tmp/.cloud-init.done" -%>
     <%- @jcasc['cloud_agents']['ec2'].each do |ec2_cloud_name, ec2_cloud_setup| -%>
   - amazonEC2:
       name: <%= ec2_cloud_name %>
@@ -298,53 +299,73 @@ jenkins:
       - ami: "<%= @jcasc['agent_images']['ec2_amis'][agent['os'].to_s + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"
         amiType:
           unixData:
-            <%-# Windows VM agent are not supported yet: https://issues.jenkins.io/browse/JENKINS-69304 -%>
-            <%- if agent['os'].to_s != 'windows' -%>
-            slaveCommandPrefix: "PATH=<%= scope.call_function('dirname', [agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup']['ubuntu']['agentJavaBin']]) %>:<%= @jcasc['agents_setup']['ubuntu']['path'] %>"
-            <%- end -%>
             sshPort: "22"
-        associatePublicIp: true
+        associatePublicIp: "<%= agent['associatePublicIp'] ? agent['associatePublicIp'] : (ec2_cloud_setup['associatePublicIp'] ? ec2_cloud_setup['associatePublicIp'] : "false" ) %>"
         connectBySSHProcess: false
-        connectionStrategy: PUBLIC_DNS
+        connectionStrategy: "<%= agent['associatePublicIp'] || ec2_cloud_setup['associatePublicIp'] ? "PUBLIC_DNS" : "PRIVATE_IP" %>"
         deleteRootOnTermination: true
         description: "<%= agent['description'] %>"
         ebsEncryptRootVolume: DEFAULT
-        ebsOptimized: false
+        ebsOptimized: "<%= agent['ebsOptimized'] ? "true" : "false" %>"
+        # TODO: allow customization
         hostKeyVerificationStrategy: ACCEPT_NEW
         idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] ? agent['idleTerminationMinutes'] : -5 %>"
+        # Note: Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
+        initScript: |-
+        <%- if agent['os'].to_s == 'windows' -%>
+        <%- else -%>
+          #!/bin/sh
+          set -eEux -o pipefail
+
+          # Wait for cloud init (run in background as root user from 'userData') to finish successfully
+          until [ -e "<%= $cloudInitDoneFile %>%" ]; do
+            sleep 1
+          done
+        <%- end -%>
         instanceCapStr: "<%= agent['maxInstances'] %>"
+        javaPath: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
         jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
         labelString: "<%= agent['os'] + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['labels'].join(' ') %>"
         launchTimeoutStr: "1000"
         maxTotalUses: 1 # Throw away the VMs after a build: ephemeral machines
+        metadataEndpointEnabled: true
+        metadataHopsLimit: 1
+        metadataSupported: true
+        metadataTokensRequired: true
         minimumNumberOfInstances: 0
         minimumNumberOfSpareInstances: 0
         mode: <%= agent['useAsMuchAsPossible'] == true ? 'NORMAL' : 'EXCLUSIVE' %>
         monitoring: false
+        nodeProperties:
+        - envVars:
+            env:
+            - key: "ARTIFACT_CACHING_PROXY_PROVIDER"
+              value: "aws"
+            - key: "JAVA_HOME"
+              value: "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>"
         numExecutors: 1
         remoteAdmin: "<%= @jcasc['agents_setup'][agent['os'].to_s]['remoteAdmin'] %>"
         remoteFS: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][agent['os'].to_s]['agentDir'] %>"
-        securityGroups: "ci-agents"
+        securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
         <%- if agent['spot'] -%>
         spotConfig:
           fallbackToOndemand: true
           useBidPrice: false
         <%- end -%>
         stopOnTerminate: false
+        subnetId: "<%= agent['subnetId'] ? agent['subnetId'] : (ec2_cloud_setup['subnetId'] ? ec2_cloud_setup['subnetId'] : "") %>%"
         t2Unlimited: false
         tags:
         - name: "architecture"
           value: "<%= agent['architecture'] %>"
         - name: "os"
           value: "<%= agent['os'] %>"
-        - name: "jenkins"
-          value: "ci.jenkins.io"
         tenancy: Default
-        type: <%= agent['instanceType'] %>
         tmpDir: "<%= @jcasc['agents_setup'][agent['os']]['tempDir'] %>"
+        type: <%= agent['instanceType'] %>
         useEphemeralDevices: true
         # Note: Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
-        initScript: |-
+        userData: |-
         <%- if agent['os'].to_s == 'windows' -%>
 
           ## Setup datadog
@@ -381,7 +402,7 @@ jenkins:
           mkdir -p /etc/docker
           cat <<EOF >/etc/docker/daemon.json
           {
-            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][agent['os'].to_s]['registryMirror'] %>"]
+            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : (ec2_cloud_setup['registryMirror'] ? ec2_cloud_setup['registryMirror'] : @jcasc['agents_setup'][agent['os'].to_s]['registryMirror']) %>"]
           }
           EOF
           systemctl daemon-reload
@@ -393,14 +414,10 @@ jenkins:
 
           ## Remove jenkins user from sudoers
           rm -f /etc/sudoers.d/90-cloud-init-users
+
+          ## Mark cloud init finished (cloud-init status --wait might not report all errors)
+          touch "<%= $cloudInitDoneFile %>%"
         <%- end -%>
-        nodeProperties:
-        - envVars:
-            env:
-            - key: "ARTIFACT_CACHING_PROXY_PROVIDER"
-              value: "aws"
-            - key: "JAVA_HOME"
-              value: "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>"
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -95,18 +95,23 @@ profile::jenkinscontroller::jcasc:
         region: us-east-2
         useInstanceProfileForCredentials: true
         sshKeysCredentialsId: "ec2-agent-ssh"
+        associatePublicIp: false
+        securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
+        subnetId: "subnet-0138ee90cd53d58f7"
         agent_definitions:
           - description: "ARM64 ubuntu 22.04"
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
             os: "ubuntu"
             os_version: "22.04"
+            ebsOptimized: true
             architecture: "arm64"
+            javaHome: /opt/jdk-21
             labels:
               - ubuntu
               - arm64docker
               - arm64linux
-            spot: true
+            spot: false
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor # Provides ANSI color in the UI when checking log outputs

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -116,20 +116,25 @@ profile::jenkinscontroller::jcasc:
     ec2:
       aws-us-east-2:
         region: us-east-2
-        credentialsId: "aws-credentials-jenkins-ci"
+        useInstanceProfileForCredentials: true
         sshKeysCredentialsId: "ec2-agent-ssh"
+        associatePublicIp: false
+        securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
+        subnetId: "subnet-0138ee90cd53d58f7"
         agent_definitions:
           - description: "ARM64 ubuntu 22.04"
             maxInstances: 5
             instanceType: A1Xlarge # 4 vCPUs / 8 Gb
             os: "ubuntu"
             os_version: "22.04"
+            ebsOptimized: true
             architecture: "arm64"
+            javaHome: /opt/jdk-21
             labels:
               - ubuntu
               - arm64docker
               - arm64linux
-            spot: true
+            spot: false
     kubernetes:
       first-cluster:
         enabled: true


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4316

This PR changes the `jenkinscontroller` profile to:

- Support private subnet, along with private IP connections and public IP management (distinct settings to support many use cases we had or could have)
- Run the agent "admin" setup with cloudinit (as root, during the boot sequence, before requiring any connection)
- Ensure that agent initialization only starts when the cloudinit phase is finished (using a temp file as token as the cloud-init CLI may not report expected errors)
- Make `ebsOptimized` a parameterized option as some instance types do not support it when using local NVMe disk
- Add Agent java bin specification to ensure we can specify a version distinct from the agent's JAVA build version (new since we last used EC2)
- Removed SSH (spots) or Windows agents setups for now (one step at a time)
- Set up metadata default attribute raw (might need disabling them soon)


Applying all of these settings on aws.ci.jio to allow testing again from the current manual (working) setup. Also add it to vagrant hieradata as I tested the template changes on it.