### PR TITLE
chore(updatecli) fix packer image disk size tracking

### DIFF
--- a/updatecli/weekly.d/jenkinscontroller-agents-windows-vm-disk-size.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents-windows-vm-disk-size.yaml
@@ -27,7 +27,7 @@ sources:
       - packerImageVersion
     spec:
       file: 'https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source `packerImageVersion` }}/locals.pkr.hcl'
-      path: locals.windows_disk_size_gb
+      path: locals.disk_size_gb
 
 targets:
   setWindowsVMAgentDiskSize:


### PR DESCRIPTION
This PR fixes the `updatecli` manifest tracking the VM agent disk size as the source attribute name changed in https://github.com/jenkins-infra/helpdesk/issues/4354