### PR TITLE
chore(updatecli) track agents EC2 AMI IDs for Windows 2019 and 2022

### DIFF
--- a/updatecli/weekly.d/jenkinscontroller-agents-packer-agent-all-in-one.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-agents-packer-agent-all-in-one.yaml
@@ -49,6 +49,34 @@ sources:
           values: "prod"
         - name: "tag:version"
           values: '{{ source "packerImageVersion" }}'
+  getLatestWindows2019AgentAMIx86:
+    kind: aws/ami
+    dependson:
+      - packerImageVersion
+    spec:
+      region: us-east-2
+      sortby: creationDateDesc
+      filters:
+        - name: "name"
+          values: "jenkins-agent-windows-2019-amd64-*"
+        - name: "tag:build_type"
+          values: "prod"
+        - name: "tag:version"
+          values: '{{ source "packerImageVersion" }}'
+  getLatestWindows2022AgentAMIx86:
+    kind: aws/ami
+    dependson:
+      - packerImageVersion
+    spec:
+      region: us-east-2
+      sortby: creationDateDesc
+      filters:
+        - name: "name"
+          values: "jenkins-agent-windows-2022-amd64-*"
+        - name: "tag:build_type"
+          values: "prod"
+        - name: "tag:version"
+          values: '{{ source "packerImageVersion" }}'
 
   getLatestInboundAllInOneContainerImageX86:
     kind: dockerdigest
@@ -81,7 +109,7 @@ conditions:
 targets:
   setAzureGalleryImageVersion:
     sourceid: packerImageVersion
-    name: "Bump Azure Gallery Image Version"
+    name: Bump Azure Gallery Image Version
     kind: yaml
     spec:
       file: hieradata/common.yaml
@@ -89,7 +117,7 @@ targets:
     scmid: default
   setInboundAllInOneContainerImage:
     sourceid: getLatestInboundAllInOneContainerImageX86
-    name: "Bump container agent image jenkinsciinfra/jenkins-agent-ubuntu-22.04 (AllInOne) for x86"
+    name: Bump container agent image jenkinsciinfra/jenkins-agent-ubuntu-22.04 (AllInOne) for x86
     kind: yaml
     spec:
       file: hieradata/common.yaml
@@ -99,7 +127,7 @@ targets:
     scmid: default
   setUbuntuAgentAMIx86:
     sourceid: getLatestUbuntuAgentAMIx86
-    name: "Set AMI ID for the Ubuntu x86 Image"
+    name: Set AMI ID for the Ubuntu x86 Image
     kind: yaml
     spec:
       file: hieradata/common.yaml
@@ -107,11 +135,27 @@ targets:
     scmid: default
   setUbuntuAgentAMIArm64:
     sourceid: getLatestUbuntuAgentAMIArm64
-    name: "Set AMI ID for the Ubuntu x86 Image"
+    name: Set AMI ID for the Ubuntu x86 Image
     kind: yaml
     spec:
       file: hieradata/common.yaml
       key: $.profile::jenkinscontroller::jcasc.agent_images.ec2_amis.'ubuntu-22.04-arm64'
+    scmid: default
+  setWindows2019AgentAMIx86:
+    sourceid: getLatestWindows2019AgentAMIx86
+    name: Set AMI ID for the Windows 2019 x86 Image
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: $.profile::jenkinscontroller::jcasc.agent_images.ec2_amis.windows-2019-amd64
+    scmid: default
+  setWindows2022AgentAMIx86:
+    sourceid: getLatestWindows2022AgentAMIx86
+    name: Set AMI ID for the Windows 2019 x86 Image
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: $.profile::jenkinscontroller::jcasc.agent_images.ec2_amis.windows-2022-amd64
     scmid: default
 
 actions:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4316

This PR tracks the EC2 AMI IDs for the Windows agents.
Once merged, it should open a new automatic PR to bump ALL kind of agents to the freshly released [2.18.0](https://github.com/jenkins-infra/packer-images/releases/tag/2.18.0) version of packer images, including the Windows AMI IDs.
Quick "sanity check": the AMI should be updated with the quotes removed in this automatic PR.