### PR TITLE
chore(updatecli) track EKS public IPs for ci.jenkins.io-agents-2

### DIFF
--- a/updatecli/weekly.d/external-ssh-ips.yaml
+++ b/updatecli/weekly.d/external-ssh-ips.yaml
@@ -20,6 +20,26 @@ sources:
       # Outbound IPs are also public "inbound" IPs for EC2 instances
       # The 2nd element is the IPv4 (1st is IPv6)
       key: .aws\.ci\.jenkins\.io.outbound_ips.controller.[1]
+  aws-ci-jenkins-io-agents-2-hostname:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: .aws\.ci\.jenkins\.io.cijenkinsio-agents-2.cluster_endpoint
+    transformers:
+      # DNS only works on the hostname
+      - trimprefix: 'https://'
+  aws-ci-jenkins-io-agents-2-ip-1:
+    kind: shell
+    dependson:
+      - aws-ci-jenkins-io-agents-2-hostname
+    spec:
+      command: dig +short {{ source "aws-ci-jenkins-io-agents-2-hostname" }} | head -n1
+  aws-ci-jenkins-io-agents-2-ip-2:
+    kind: shell
+    dependson:
+      - aws-ci-jenkins-io-agents-2-hostname
+    spec:
+      command: dig +short {{ source "aws-ci-jenkins-io-agents-2-hostname" }} | tail -n1
 
 targets:
   aws-ci-jenkins-io:
@@ -29,6 +49,22 @@ targets:
     spec:
       file: hieradata/common.yaml
       key: $.profile::openvpn::external_ips_vpn_restricted.'aws.ci.jenkins.io'
+    scmid: default
+  cijenkinsio-agents-2-ip1:
+    name: Update aws-ci-jenkins-io-agents-2-ip-1 public IP in the YAML configuration of our OpenVPN CLI
+    kind: yaml
+    sourceid: aws-ci-jenkins-io-agents-2-ip-1
+    spec:
+      file: hieradata/common.yaml
+      key: $.profile::openvpn::external_ips_vpn_restricted.'cijenkinsio-agents-2-ip1'
+    scmid: default
+  cijenkinsio-agents-2-ip2:
+    name: Update aws-ci-jenkins-io-agents-2-ip-2 public IP in the YAML configuration of our OpenVPN CLI
+    kind: yaml
+    sourceid: aws-ci-jenkins-io-agents-2-ip-2
+    spec:
+      file: hieradata/common.yaml
+      key: $.profile::openvpn::external_ips_vpn_restricted.'cijenkinsio-agents-2-ip2'
     scmid: default
 
 actions:

--- a/updatecli/weekly.d/external-ssh-ips.yaml
+++ b/updatecli/weekly.d/external-ssh-ips.yaml
@@ -33,13 +33,13 @@ sources:
     dependson:
       - aws-ci-jenkins-io-agents-2-hostname
     spec:
-      command: dig +short {{ source "aws-ci-jenkins-io-agents-2-hostname" }} | head -n1
+      command: dig +short {{ source "aws-ci-jenkins-io-agents-2-hostname" }} | sort `# sorting is required as dig result is unordered` | head -n1
   aws-ci-jenkins-io-agents-2-ip-2:
     kind: shell
     dependson:
       - aws-ci-jenkins-io-agents-2-hostname
     spec:
-      command: dig +short {{ source "aws-ci-jenkins-io-agents-2-hostname" }} | tail -n1
+      command: dig +short {{ source "aws-ci-jenkins-io-agents-2-hostname" }} | sort `# sorting is required as dig result is unordered` |tail -n1
 
 targets:
   aws-ci-jenkins-io:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4319#issuecomment-2560130548

This PR is inspired by https://github.com/jenkins-infra/docker-openvpn/commit/9adb2923700b9a4b01c0dea8793be73bae3eefe2 but also includes the [hotfix using sorting](https://github.com/jenkins-infra/docker-openvpn/commit/0935868db78c92b8fa08ac51f859d42298ef87e8)