### PR TITLE
hotfix(aws.ci.jenkins.io) use correct windows version (2019)

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -116,7 +116,7 @@ profile::jenkinscontroller::jcasc:
             maxInstances: 5
             instanceType: T3aXlarge # 4 vCPUs / 16 Gb
             os: "windows"
-            os_version: "2022"
+            os_version: "2019"
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4316#issuecomment-2557149767

Fixup of #3804