### PR TITLE
fix(jenkinscontroller/azure-vm-agents) ensure datadog service is restarted on Windows

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -19,7 +19,7 @@ jenkins:
         initScript: |
           # Setup datadog
           (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: <%= @jcasc['datadog_api_key'] %>' | Set-Content C:\ProgramData\Datadog\datadog.yaml
-          & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart
+          & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart-service
 
           # Setup Docker Engine
           @'


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/4316#issuecomment-2571675608, I discovered that our Windows Azure VM agents do not report anything in Datadog: we don't have any metrics or logs reported at all, while it is on Azure VM Linux Agents.

If you check the agent startup logs: you can see we are using a wrong argument for the Datadog's `agent.exe` binary:

![windows-vm-agent-logs](https://github.com/user-attachments/assets/a3a883c3-af9d-4fc3-b8ce-4e10ac2987ef)

=> This PR fixes the issue for the Azure VM init script (no need for EC2, as it is not as code yet). Ref. https://docs.datadoghq.com/agent/basic_agent_usage/windows/?tab=standardinstallation

Tested on EC2 agents with success.




