### PR TITLE
fix(ci.jenkins.io) disable Windows Container agents (for JDK11, 17 and 21) in favor of Windows VM Agents

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -551,6 +551,7 @@ profile::jenkinscontroller::jcasc:
             - win-2019
             - windows-2019
             - win-2019-amd64-maven-11
+            - maven-11-windows
           javaHome: 'C:/tools/jdk-11'
           maxInstances: 50
           useAsMuchAsPossible: true
@@ -569,6 +570,7 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - win-2019-amd64-maven-17
+            - maven-17-windows
           javaHome: 'C:/tools/jdk-17'
           maxInstances: 50
           useAsMuchAsPossible: true
@@ -587,6 +589,7 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - win-2019-amd64-maven-21
+            - maven-21-windows
           javaHome: 'C:/tools/jdk-21'
           maxInstances: 50
           useAsMuchAsPossible: true
@@ -640,7 +643,7 @@ profile::jenkinscontroller::jcasc:
           memory: 8
           agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
           labels:
-            - maven-11-windows
+            - maven-11-windows-disabled
           usePrivateIP: true
         - name: maven-17-windows
           os: windows
@@ -649,7 +652,7 @@ profile::jenkinscontroller::jcasc:
           memory: 8
           agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
           labels:
-            - maven-17-windows
+            - maven-17-windows-disabled
           usePrivateIP: true
         - name: maven-21-windows
           os: windows
@@ -658,7 +661,7 @@ profile::jenkinscontroller::jcasc:
           memory: 8
           agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
           labels:
-            - maven-21-windows
+            - maven-21-windows-disabled
           usePrivateIP: true
   artifact_caching_proxy:
     enabled: true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4490