### PR TITLE
feat(aws.ci.jenkins.io) adding the 2 clouds kub ci.jenkins.io-agents-2 and -bom

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -102,7 +102,9 @@ profile::jenkinscontroller::jcasc:
     kubernetes:
       ci.jenkins.io-agents-2:
         enabled: true
-        acpServerId: azure-aks-internal # will probably be aws-eks-internal
+        ## Note: no URL/credential/CA data as we rely on jenkins' KUBECONFIG to allow EC2 instance profile authentication
+        acpServerId: aws-eks-internal
+        # TODO: track with updatecli
         defaultNamespace: jenkins-agents
         max_capacity: 150 # TODO: Re-evaluate and setup updatecli
         agent_definitions:
@@ -115,7 +117,9 @@ profile::jenkinscontroller::jcasc:
               - jdk8
             cpus: 4
             memory: 12
+            # TODO: factorize and track with updatecli
             nodeSelector: "role=jenkins-agents"
+            # TODO: factorize and track with updatecli
             tolerations:
               - key: "ci.jenkins.io/agents"
                 operator: "Equal"
@@ -129,7 +133,9 @@ profile::jenkinscontroller::jcasc:
               - jdk11
             cpus: 4
             memory: 12
+            # TODO: factorize and track with updatecli
             nodeSelector: "role=jenkins-agents"
+            # TODO: factorize and track with updatecli
             tolerations:
               - key: "ci.jenkins.io/agents"
                 operator: "Equal"
@@ -143,7 +149,9 @@ profile::jenkinscontroller::jcasc:
               - jdk17
             cpus: 4
             memory: 12
+            # TODO: factorize and track with updatecli
             nodeSelector: "role=jenkins-agents"
+            # TODO: factorize and track with updatecli
             tolerations:
               - key: "ci.jenkins.io/agents"
                 operator: "Equal"
@@ -157,7 +165,9 @@ profile::jenkinscontroller::jcasc:
               - jdk21
             cpus: 4
             memory: 12
+            # TODO: factorize and track with updatecli
             nodeSelector: "role=jenkins-agents"
+            # TODO: factorize and track with updatecli
             tolerations:
               - key: "ci.jenkins.io/agents"
                 operator: "Equal"
@@ -172,7 +182,9 @@ profile::jenkinscontroller::jcasc:
               - webbuilder
             cpus: 4
             memory: 12
+            # TODO: factorize and track with updatecli
             nodeSelector: "role=jenkins-agents"
+            # TODO: factorize and track with updatecli
             tolerations:
               - key: "ci.jenkins.io/agents"
                 operator: "Equal"
@@ -185,7 +197,9 @@ profile::jenkinscontroller::jcasc:
               - jnlp-packaging
             cpus: 1
             memory: 1
+            # TODO: factorize and track with updatecli
             nodeSelector: "role=jenkins-agents"
+            # TODO: factorize and track with updatecli
             tolerations:
               - key: "ci.jenkins.io/agents"
                 operator: "Equal"
@@ -198,7 +212,9 @@ profile::jenkinscontroller::jcasc:
               - default
             cpus: 1
             memory: 1
+            # TODO: factorize and track with updatecli
             nodeSelector: "role=jenkins-agents"
+            # TODO: factorize and track with updatecli
             tolerations:
               - key: "ci.jenkins.io/agents"
                 operator: "Equal"
@@ -206,7 +222,9 @@ profile::jenkinscontroller::jcasc:
                 effect: "NoSchedule"
       ci.jenkins.io-agents-2-bom:
         enabled: true
-        acpServerId: azure-aks-internal # will probably be aws-eks-internal
+        ## Note: no URL/credential/CA data as we rely on jenkins' KUBECONFIG to allow EC2 instance profile authentication
+        acpServerId: aws-eks-internal
+        # TODO: track with updatecli
         defaultNamespace: jenkins-agents-bom
         max_capacity: 150 # TODO: Re-evaluate and setup updatecli
         agent_definitions:
@@ -217,7 +235,9 @@ profile::jenkinscontroller::jcasc:
               - maven-bom
             cpus: 4
             memory: 12
+            # TODO: factorize and track with updatecli
             nodeSelector: "role=jenkins-agents-bom"
+            # TODO: factorize and track with updatecli
             tolerations:
               - key: "ci.jenkins.io/agents"
                 operator: "Equal"

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -99,6 +99,132 @@ profile::jenkinscontroller::jcasc:
     targetHost: "172.17.0.1" # docker0 interface
     collectBuildLogs: true
   cloud_agents:
+    kubernetes:
+      ci.jenkins.io-agents-2:
+        enabled: true
+        defaultNamespace: jenkins-agents
+        max_capacity: 150 # TODO: Re-evaluate and setup updatecli
+        agent_definitions:
+          - name: jnlp-maven-8
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-8
+            labels:
+              - maven
+              - maven-8
+              - jdk8
+            cpus: 4
+            memory: 12
+            nodeSelector: "role=jenkins-agents"
+            tolerations:
+              - key: "ci.jenkins.io/agents"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+          - name: jnlp-maven-11
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-11
+            labels:
+              - maven-11
+              - jdk11
+            cpus: 4
+            memory: 12
+            nodeSelector: "role=jenkins-agents"
+            tolerations:
+              - key: "ci.jenkins.io/agents"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+          - name: jnlp-maven-17
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-17
+            labels:
+              - maven-17
+              - jdk17
+            cpus: 4
+            memory: 12
+            nodeSelector: "role=jenkins-agents"
+            tolerations:
+              - key: "ci.jenkins.io/agents"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+          - name: jnlp-maven-21
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-21
+            labels:
+              - maven-21
+              - jdk21
+            cpus: 4
+            memory: 12
+            nodeSelector: "role=jenkins-agents"
+            tolerations:
+              - key: "ci.jenkins.io/agents"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+          - name: jnlp-webbuilder
+            agentJavaBin: /opt/java/openjdk/bin/java
+            javaHome: /opt/java/openjdk
+            labels:
+              - node
+              - ruby
+              - webbuilder
+            cpus: 4
+            memory: 12
+            nodeSelector: "role=jenkins-agents"
+            tolerations:
+              - key: "ci.jenkins.io/agents"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+          - name: jnlp-packaging
+            javaHome: /opt/jdk-17
+            labels:
+              - packaging
+              - jnlp-packaging
+            cpus: 1
+            memory: 1
+            nodeSelector: "role=jenkins-agents"
+            tolerations:
+              - key: "ci.jenkins.io/agents"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+          - name: jnlp
+            agentJavaBin: /opt/java/openjdk/bin/java
+            javaHome: /opt/java/openjdk
+            labels:
+              - default
+            cpus: 1
+            memory: 1
+            nodeSelector: "role=jenkins-agents"
+            tolerations:
+              - key: "ci.jenkins.io/agents"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+      ci.jenkins.io-agents-2-bom:
+        enabled: true
+        defaultNamespace: jenkins-agents-bom
+        max_capacity: 150 # TODO: Re-evaluate and setup updatecli
+        agent_definitions:
+          - name: jnlp-maven-bom
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-17
+            labels:
+              - maven-bom
+            cpus: 4
+            memory: 12
+            nodeSelector: "role=jenkins-agents-bom"
+            tolerations:
+              - key: "ci.jenkins.io/agents"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+              - key: "ci.jenkins.io/bom"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
     ec2:
       aws-us-east-2:
         region: us-east-2

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -102,6 +102,7 @@ profile::jenkinscontroller::jcasc:
     kubernetes:
       ci.jenkins.io-agents-2:
         enabled: true
+        acpServerId: azure-aks-internal # will probably be aws-eks-internal
         defaultNamespace: jenkins-agents
         max_capacity: 150 # TODO: Re-evaluate and setup updatecli
         agent_definitions:
@@ -205,6 +206,7 @@ profile::jenkinscontroller::jcasc:
                 effect: "NoSchedule"
       ci.jenkins.io-agents-2-bom:
         enabled: true
+        acpServerId: azure-aks-internal # will probably be aws-eks-internal
         defaultNamespace: jenkins-agents-bom
         max_capacity: 150 # TODO: Re-evaluate and setup updatecli
         agent_definitions:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -240,6 +240,29 @@ profile::jenkinscontroller::jcasc:
         url: SuperSecretThatShouldBeEncryptedInProduction
         defaultNamespace: jenkins-agents
         # No agent definitions (to test an empty cloud)
+      third-cluster:
+        enabled: true
+        provider: aws
+        defaultNamespace: jenkins-agents-bom
+        max_capacity: 150 # TODO: Re-evaluate and setup updatecli
+        agent_definitions:
+          - name: jnlp-maven-bom
+            imageName: jnlp-maven-all-in-one
+            javaHome: /opt/jdk-17
+            labels:
+              - maven-bom
+            cpus: 4
+            memory: 12
+            nodeSelector: "role=jenkins-agents-bom"
+            tolerations:
+              - key: "ci.jenkins.io/agents"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+              - key: "ci.jenkins.io/bom"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
     azure_vm_agents:
       clouds:
         azure-vms:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -240,29 +240,6 @@ profile::jenkinscontroller::jcasc:
         url: SuperSecretThatShouldBeEncryptedInProduction
         defaultNamespace: jenkins-agents
         # No agent definitions (to test an empty cloud)
-      third-cluster:
-        enabled: true
-        provider: aws
-        defaultNamespace: jenkins-agents-bom
-        max_capacity: 150 # TODO: Re-evaluate and setup updatecli
-        agent_definitions:
-          - name: jnlp-maven-bom
-            imageName: jnlp-maven-all-in-one
-            javaHome: /opt/jdk-17
-            labels:
-              - maven-bom
-            cpus: 4
-            memory: 12
-            nodeSelector: "role=jenkins-agents-bom"
-            tolerations:
-              - key: "ci.jenkins.io/agents"
-                operator: "Equal"
-                value: "true"
-                effect: "NoSchedule"
-              - key: "ci.jenkins.io/bom"
-                operator: "Equal"
-                value: "true"
-                effect: "NoSchedule"
     azure_vm_agents:
       clouds:
         azure-vms:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4317#issuecomment-2596123203

need to provide aws cli to the jenkins controller container and the correct ~/.kube/config file (done in #3831 and #3833 )


This PR provide the configuration for 2 new Kubernetes clouds with empty URL/CA data/Credentials (relying on kubeconfig).


Tested manually with success