### PR TITLE
feat(aws.ci.jenkins.io + jenkinscontroller) optionally install `aws` CLI in the Jenkins container + enable it on aws.ci

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -179,3 +179,5 @@ profile::jenkinscontroller::plugins:
   - timestamper # Allow showing timestamp on build logs
   - warnings-ng # Provides integration (UI, jobs) with static analyser and linters
   - workflow-aggregator # Meta-plugin to provide all workflow-(.*) standard plugins
+profile::jenkinscontroller::tools_versions:
+  awscli: 2.13.32

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -490,3 +490,5 @@ profile::jenkinscontroller::plugins:
   - workflow-multibranch
 profile::buildagent::tools_versions:
   awscli: 2.13.32
+profile::jenkinscontroller::tools_versions:
+  awscli: 2.13.32

--- a/spec/classes/profile/jenkinscontroller_spec.rb
+++ b/spec/classes/profile/jenkinscontroller_spec.rb
@@ -1,7 +1,7 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe 'profile::jenkinscontroller' do
-  let(:fqdn) { 'rspec.jenkins.io' }
+describe "profile::jenkinscontroller" do
+  let(:fqdn) { "rspec.jenkins.io" }
   let(:params) do
     {
       :ci_fqdn => fqdn,
@@ -9,156 +9,131 @@ describe 'profile::jenkinscontroller' do
   end
   let(:facts) do
     {
-      :rspec_hieradata_fixture => 'profile_jenkinscontroller',
+      :rspec_hieradata_fixture => "profile_jenkinscontroller",
     }
   end
 
-  context 'Jenkins configuration' do
-    it { is_expected.to contain_user('jenkins').with(
-        'ensure' => 'present',
-        'home'   => '/var/lib/jenkins'
+  context "Jenkins configuration" do
+    it {
+      is_expected.to contain_user("jenkins").with(
+        "ensure" => "present",
+        "home" => "/var/lib/jenkins",
       )
     }
 
-    it { is_expected.to contain_group('jenkins').with(
-        'ensure' => 'present',
+    it {
+      is_expected.to contain_group("jenkins").with(
+        "ensure" => "present",
       )
     }
 
     # https://issues.jenkins-ci.org/browse/INFRA-916
-    context 'as a Docker container' do
-      it { expect(subject).to contain_file('/var/lib/jenkins').with_ensure('directory') }
-      it { expect(subject).to contain_class 'profile::docker' }
+    context "as a Docker container" do
+      it { expect(subject).to contain_file("/var/lib/jenkins").with_ensure("directory") }
+      it { expect(subject).to contain_class "profile::docker" }
 
-      it 'should define a suitable docker::run' do
-        expect(subject).to contain_docker__run('jenkins').with({
+      it "should define a suitable docker::run" do
+        expect(subject).to contain_docker__run("jenkins").with({
           :pull_on_start => true,
-          :volumes => ['/var/lib/jenkins:/var/jenkins_home'],
+          :volumes => ["/var/lib/jenkins:/var/jenkins_home:rw"],
         })
       end
     end
 
-    context 'Init groovy script' do
-      it { is_expected.to contain_file('/var/lib/jenkins/init.groovy.d').with(
-          'ensure' => 'directory',
-          'purge'  => 'true',
-          'recurse' => 'true'
+    context "Init groovy script" do
+      it {
+        is_expected.to contain_file("/var/lib/jenkins/init.groovy.d").with(
+          "ensure" => "directory",
+          "purge" => "true",
+          "recurse" => "true",
         )
       }
       context "By default: Init Groovy directory" do
-        it { is_expected.not_to contain_file('/var/lib/jenkins/init.groovy.d/enable-ssh-port.groovy')}
-        it { is_expected.not_to contain_file('/var/lib/jenkins/init.groovy.d/set-up-git.groovy')}
+        it { is_expected.not_to contain_file("/var/lib/jenkins/init.groovy.d/enable-ssh-port.groovy") }
+        it { is_expected.not_to contain_file("/var/lib/jenkins/init.groovy.d/set-up-git.groovy") }
       end
     end
 
-    context 'JCasC' do
-      it { is_expected.to contain_file('/var/lib/jenkins/casc.d').with('ensure' => 'directory')}
-      it { is_expected.to contain_file('/var/lib/jenkins/casc.d/clouds.yaml')}
-      it { expect(subject).to contain_exec('install-plugin-configuration-as-code') }
-      it { expect(subject).to contain_exec('perform-jcasc-reload') }
-      it { expect(subject).to contain_exec('safe-restart-jenkins') }
+    context "JCasC" do
+      it { is_expected.to contain_file("/var/lib/jenkins/casc.d").with("ensure" => "directory") }
+      it { is_expected.to contain_file("/var/lib/jenkins/casc.d/clouds.yaml") }
+      it { expect(subject).to contain_exec("install-plugin-configuration-as-code") }
+      it { expect(subject).to contain_exec("perform-jcasc-reload") }
+      it { expect(subject).to contain_exec("safe-restart-jenkins") }
     end
   end
 
-  context 'JNLP' do
-    it 'should open the JNLP port in the firewall' do
-      expect(subject).to contain_firewall('803 Expose JNLP port').with({
+  context "JNLP" do
+    it "should open the JNLP port in the firewall" do
+      expect(subject).to contain_firewall("803 Expose JNLP port").with({
         :dport => 50000,
-        :proto => 'tcp',
-        :action => 'accept',
+        :proto => "tcp",
+        :action => "accept",
       })
     end
   end
 
-
-  context 'with letsencrypt => false' do
-    let(:environment) { 'production' }
+  context "with awscli in the container" do
+    let(:fqdn) { "rspec.jenkins.io" }
     let(:params) do
       {
         :ci_fqdn => fqdn,
-        :letsencrypt => false,
+        :tools_versions => {
+          :awscli => "2.13.0",
+        },
+      }
+    end
+    let(:facts) do
+      {
+        :rspec_hieradata_fixture => "profile_jenkinscontroller",
       }
     end
 
-    it { should_not contain_class 'profile::letsencrypt' }
-    it { should_not contain_letsencrypt__certonly(fqdn) }
+    it "should install the unzip package as a requirement to install the aws CLI" do
+      expect(subject).to contain_package("unzip")
+    end
+
+    it "should mount the aws CLI installation directory in the container with an updated PATH" do
+      expect(subject).to contain_docker__run("jenkins").with({
+        :pull_on_start => true,
+        :volumes => ["/var/lib/jenkins:/var/jenkins_home:rw", "/var/awscli:/var/awscli:ro"],
+        :env => [
+          "HOME=/var/jenkins_home",
+          "USER=jenkins",
+          "JAVA_OPTS=-server -Xlog:gc*=info,ref*=debug,ergo*=trace,age*=trace:file=/var/jenkins_home/gc/gc.log::filecount=5,filesize=40M -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UnlockDiagnosticVMOptions -Duser.home=/var/jenkins_home -Djenkins.install.runSetupWizard=false -Djenkins.model.Jenkins.slaveAgentPort=50000 -Dhudson.model.WorkspaceCleanupThread.retainForDays=2 -Dorg.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep.USE_WATCHING=true -Dcasc.jenkins.config=/var/jenkins_home/casc.d         -Dcasc.reload.token=SuperSecretThatShouldBeEncryptedInProduction",
+          "JENKINS_OPTS=--httpKeepAliveTimeout=60000",
+          "LANG=C.UTF-8",
+          "PATH=/var/awscli/v2/current/bin/:/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        ],
+      })
+    end
   end
 
-
-  context 'apache configuration' do
-    let(:environment) { 'production' }
+  context "with plugins" do
     let(:params) do
       {
-        :ci_fqdn => fqdn,
-        :letsencrypt => true,
-      }
-    end
-    it { expect(subject).to contain_class 'apache' }
-    it { expect(subject).to contain_class 'profile::apachemisc' }
-    it { expect(subject).to contain_class 'profile::letsencrypt' }
-    it { expect(subject).to contain_class 'apache::mod::proxy' }
-    it { expect(subject).to contain_class 'apache::mod::headers' }
-
-    context 'vhosts' do
-      it 'should contain a vhost with ssl' do
-        expect(subject).to contain_apache__vhost(fqdn).with({
-          :servername => fqdn,
-          :port => 443,
-        })
-      end
-
-      it 'should contain a vhost that promotes non-SSL to SSL' do
-        expect(subject).to contain_apache__vhost("#{fqdn} unsecured").with({
-          :servername => fqdn,
-          :port => 80,
-          :redirect_status => 'permanent',
-          :redirect_dest => "https://#{fqdn}/",
-        })
-      end
-    end
-
-    context 'when running in production' do
-      let(:environment) { 'production' }
-
-      it { expect(subject).to contain_letsencrypt__certonly(fqdn) }
-
-      it 'should configure the letsencrypt ssl keys on the vhost' do
-        expect(subject).to contain_apache__vhost(fqdn).with({
-          :servername => fqdn,
-          :port => 443,
-          :ssl_key => "/etc/letsencrypt/live/#{fqdn}/privkey.pem",
-          :ssl_cert => "/etc/letsencrypt/live/#{fqdn}/fullchain.pem",
-        })
-      end
-    end
-  end
-
-  context 'with plugins' do
-    let(:params) do
-      {
-        :plugins => ['workflow-aggregator',]
+        :plugins => ["workflow-aggregator"],
       }
     end
 
-    it { expect(subject).to contain_profile__jenkinsplugin('workflow-aggregator') }
-    it { expect(subject).to contain_exec('install-plugin-workflow-aggregator') }
+    it { expect(subject).to contain_profile__jenkinsplugin("workflow-aggregator") }
+    it { expect(subject).to contain_exec("install-plugin-workflow-aggregator") }
   end
 
-  context 'firewall rules' do
-    it { expect(subject).to contain_class 'profile::firewall' }
+  context "firewall rules" do
+    it { expect(subject).to contain_class "profile::firewall" }
 
-    it 'should ensure nothing talks directly to Jenkins' do
-      expect(subject).to contain_firewall('801 Allow Jenkins web access only on localhost').with({
+    it "should ensure nothing talks directly to Jenkins" do
+      expect(subject).to contain_firewall("801 Allow Jenkins web access only on localhost").with({
         :dport => 8080,
         :action => :accept,
-        :iniface => 'lo',
+        :iniface => "lo",
       })
 
-      expect(subject).to contain_firewall('802 Block external Jenkins web access').with({
+      expect(subject).to contain_firewall("802 Block external Jenkins web access").with({
         :dport => 8080,
         :action => :drop,
       })
-
     end
   end
 end


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4317#issuecomment-2597785218

Usage: for Kubernetes credential-less auth. from EC2 


Tested locally with Vagrant with 2 cases:

- Without the tools_version enabled in hieradata: no changes (nominal case for existing controllers)
- With the tools_version enabled in hieradata: the `docker exec -ti jenkins aws --version` commands works as expected in this case

Notes:

- Requires cleaning up aws.ci.jenkins.io before merging
- Need a subsequent PR with `updatecli` to bump the CLI version (we already have a manifest for build agents which also installs `aws` CLI but not in a container, hence not creating a profile. Might need refactoring the Puppet code to get the same version on both (or maybe not)