### PR TITLE
fix(letsencrypt) use latest `certbot` pip package (`3.x`) and get rid of snapd

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -34,7 +34,6 @@ mod 'puppetlabs-docker', '6.1.0'
 
 # Package Managers
 mod 'puppetlabs-apt', '9.0.2'
-mod 'rootexpert-snap', '1.1.0'
 
 # Apache and its dependencies
 mod 'puppetlabs-apache', '9.1.2'

--- a/spec/classes/profile/apache_misc_spec.rb
+++ b/spec/classes/profile/apache_misc_spec.rb
@@ -1,51 +1,49 @@
-require 'spec_helper'
+require "spec_helper"
 
-
-describe 'profile::apachemisc' do
+describe "profile::apachemisc" do
   let(:facts) do
     {
-      :rspec_hieradata_fixture => 'profile_apachemisc',
+      :rspec_hieradata_fixture => "profile_apachemisc",
     }
   end
 
-  shared_examples 'apachemisc' do
-    it { expect(subject).to contain_class 'apache' }
-    it { expect(subject).to contain_package 'apache2-utils' }
+  shared_examples "apachemisc" do
+    it { expect(subject).to contain_class "apache" }
+    it { expect(subject).to contain_package "apache2-utils" }
 
-    it { expect(subject).to contain_file '/etc/apache2/conf.d/00-reverseproxy_combined' }
-    it { expect(subject).to contain_file '/etc/apache2/conf.d/other-vhosts-access-log' }
+    it { expect(subject).to contain_file "/etc/apache2/conf.d/00-reverseproxy_combined" }
+    it { expect(subject).to contain_file "/etc/apache2/conf.d/other-vhosts-access-log" }
   end
 
-  context 'with no class parameters' do
-    it_behaves_like 'apachemisc'
+  context "with no class parameters" do
+    it_behaves_like "apachemisc"
 
-    it { should_not contain_file '/var/www/.ssh' }
+    it { should_not contain_file "/var/www/.ssh" }
   end
 
-  context 'with SSH access enabled' do
+  context "with SSH access enabled" do
     let(:params) do
       {
         :ssh_enabled => true,
       }
     end
 
-    it_behaves_like 'apachemisc'
+    it_behaves_like "apachemisc"
   end
 
-  context 'provide Apache/mod_proxy support' do
-    it { expect(subject).to contain_apache__mod 'proxy' }
-    it { expect(subject).to contain_apache__mod 'proxy_http' }
+  context "provide Apache/mod_proxy support" do
+    it { expect(subject).to contain_apache__mod "proxy" }
+    it { expect(subject).to contain_apache__mod "proxy_http" }
   end
 
-  it 'restrict SSL versions by default' do
-    expect(subject).to contain_class('apache::mod::ssl').with({
-      :ssl_protocol => ['all', '-SSLv3'],
+  it "restrict SSL versions by default" do
+    expect(subject).to contain_class("apache::mod::ssl").with({
+      :ssl_protocol => ["all", "-SSLv3"],
     })
   end
 
-
-  context 'mod_status support' do
-    it { expect(subject).to contain_class 'apache::mod::status' }
-    it { expect(subject).to contain_file '/somewhere/apache.d/conf.yaml' }
+  context "mod_status support" do
+    it { expect(subject).to contain_class "apache::mod::status" }
+    it { expect(subject).to contain_file "/somewhere/apache.d/conf.yaml" }
   end
 end

--- a/spec/classes/profile/letsencrypt_spec.rb
+++ b/spec/classes/profile/letsencrypt_spec.rb
@@ -1,92 +1,94 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe 'profile::letsencrypt' do
-  context 'default setup uses HTTP-01 with staging' do
+certbot_version = "3.1.0"
+certbot_dns_azure_version = "2.6.1"
+
+describe "profile::letsencrypt" do
+  context "default setup uses HTTP-01 with staging" do
     it {
-      expect(subject).to contain_package('python3.10')
-      expect(subject).to contain_package('python3-pip')
-      expect(subject).to contain_package('libaugeas0')
+      expect(subject).to contain_package("python3.10")
+      expect(subject).to contain_package("python3-pip")
+      expect(subject).to contain_package("libaugeas0")
 
-      expect(subject).to contain_exec('Install certbot').with({
-        :command => '/usr/bin/python3.10 -m pip install --upgrade pyopenssl certbot==1.32.0 acme==1.32.0',
+      expect(subject).to contain_exec("Install certbot").with({
+        :command => "/usr/bin/python3.10 -m pip install --upgrade certbot==#{certbot_version}",
       })
 
-      expect(subject).to contain_exec('Install certbot-apache plugin').with({
-        :command => '/usr/bin/python3.10 -m pip install --upgrade certbot-apache==1.32.0',
-        :unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet apache',
+      expect(subject).to contain_exec("Install certbot-apache plugin").with({
+        :command => "/usr/bin/python3.10 -m pip install --upgrade --use-pep517 certbot-apache==#{certbot_version}",
+        :unless => "/usr/bin/python3.10 -m pip list | /bin/grep --word-regexp certbot-apache | /bin/grep #{certbot_version}",
       })
 
-      expect(subject).to contain_class('letsencrypt').with_config({
-        'email'                => 'tyler@monkeypox.org',
-        'server'               => 'https://acme-staging-v02.api.letsencrypt.org/directory',
-        'authenticator'        => 'apache',
-        'preferred-challenges' => 'http',
-        'deploy-hook'          => 'systemctl reload apache2',
-      }).with_package_ensure('absent').with_configure_epel(false)
-      expect(subject).to contain_file('/etc/letsencrypt/azure.ini').with({
-        :ensure  => 'absent',
+      expect(subject).to contain_class("letsencrypt").with_config({
+        "email" => "tyler@monkeypox.org",
+        "server" => "https://acme-staging-v02.api.letsencrypt.org/directory",
+        "authenticator" => "apache",
+        "preferred-challenges" => "http",
+        "deploy-hook" => "systemctl reload apache2",
+      }).with_package_ensure("absent").with_configure_epel(false)
+      expect(subject).to contain_file("/etc/letsencrypt/azure.ini").with({
+        :ensure => "absent",
       })
-      expect(subject).to contain_cron('certbot-renew-all').with({
+      expect(subject).to contain_cron("certbot-renew-all").with({
         :command => "bash -c 'date && /usr/local/bin/certbot renew' >>/var/log/certbot-renew-all.log 2>&1",
-        :user    => 'root',
-        :hour    => 6,
+        :user => "root",
+        :hour => 6,
       })
     }
   end
 
-  context 'custom setup with Azure DNS-01 challenge and production environment' do
-    let(:environment) { 'production' }
+  context "custom setup with Azure DNS-01 challenge and production environment" do
+    let(:environment) { "production" }
     let(:params) do
       {
-        :plugin => 'dns-azure',
+        :plugin => "dns-azure",
         :dns_azure => {
           :sp_client_id => "sp-app-id",
           :sp_client_secret => "token",
           :tenant_id => "tenant-id",
           :zones => {
             :localhost => "/subscriptions/xxx/AzureDNS/localhost",
-            :"app.localhost" =>  "/subscriptions/xxx/AzureDNS/localhost",
+            :"app.localhost" => "/subscriptions/xxx/AzureDNS/localhost",
           },
         },
       }
     end
 
     it {
-      expect(subject).to contain_package('python3.10')
-      expect(subject).to contain_package('python3-pip')
+      expect(subject).to contain_package("python3.10")
+      expect(subject).to contain_package("python3-pip")
 
-      expect(subject).to contain_exec('Install certbot').with({
-        :command => '/usr/bin/python3.10 -m pip install --upgrade pyopenssl certbot==1.32.0 acme==1.32.0',
+      expect(subject).to contain_exec("Install certbot").with({
+        :command => "/usr/bin/python3.10 -m pip install --upgrade certbot==#{certbot_version}",
       })
 
-      expect(subject).not_to contain_exec('Install certbot-apache plugin').with({
-        :command => '/usr/bin/python3.10 -m pip install --upgrade certbot-apache==1.32.0',
-        :unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet apache',
+      expect(subject).not_to contain_exec("Install certbot-apache plugin").with({
+        :command => "/usr/bin/python3.10 -m pip install --upgrade certbot-apache==#{certbot_version}",
       })
 
-      expect(subject).to contain_exec('Install certbot-dns-azure plugin').with({
-        :command => '/usr/bin/python3.10 -m pip install --upgrade certbot-dns-azure',
-        :unless  => '/usr/local/bin/certbot plugins --text 2>&1 | /bin/grep --quiet dns-azure',
+      expect(subject).to contain_exec("Install certbot-dns-azure plugin").with({
+        :command => "/usr/bin/python3.10 -m pip install --upgrade certbot-dns-azure==#{certbot_dns_azure_version}",
+        :unless => "/usr/bin/python3.10 -m pip list | /bin/grep --word-regexp certbot-dns-azure | /bin/grep #{certbot_dns_azure_version}",
       })
 
-      expect(subject).to contain_file('/etc/letsencrypt/azure.ini').with({
-        :ensure  => 'file',
-        :owner   => 'root',
-        :group   => 'root',
-        :mode    => '0600',
+      expect(subject).to contain_file("/etc/letsencrypt/azure.ini").with({
+        :ensure => "file",
+        :owner => "root",
+        :group => "root",
+        :mode => "0600",
       })
-      expect(subject).to contain_class('letsencrypt').with_config({
-        'email'                => 'tyler@monkeypox.org',
-        'server'               => 'https://acme-v02.api.letsencrypt.org/directory', # Due to production environment set up
-        'authenticator'        => 'dns-azure',
-        'preferred-challenges' => 'dns',
-        'dns-azure-config'     => '/etc/letsencrypt/azure.ini',
-        'deploy-hook'          => 'systemctl reload apache2',
-      }).with_package_ensure('absent').with_configure_epel(false)
+      expect(subject).to contain_class("letsencrypt").with_config({
+        "email" => "tyler@monkeypox.org",
+        "server" => "https://acme-v02.api.letsencrypt.org/directory", # Due to production environment set up
+        "authenticator" => "dns-azure",
+        "preferred-challenges" => "dns",
+        "dns-azure-config" => "/etc/letsencrypt/azure.ini",
+        "deploy-hook" => "systemctl reload apache2",
+      }).with_package_ensure("absent").with_configure_epel(false)
     }
 
-    it 'should specify the custom config + DNS-01 setup for letsencrypt' do
-      expect(subject).to contain_class('letsencrypt')
+    it "should specify the custom config + DNS-01 setup for letsencrypt" do
+      expect(subject).to contain_class("letsencrypt")
     end
   end
 end

--- a/spec/classes/profile/letsencrypt_spec.rb
+++ b/spec/classes/profile/letsencrypt_spec.rb
@@ -1,6 +1,8 @@
 require "spec_helper"
 
+# TODO: track with updatecli
 certbot_version = "3.1.0"
+# TODO: track with updatecli
 certbot_dns_azure_version = "2.6.1"
 
 describe "profile::letsencrypt" do


### PR DESCRIPTION
This PR fixes the errors described in https://github.com/jenkins-infra/helpdesk/issues/4315#issuecomment-2602877603

It introduces the following changes:

- Certbot is bumped from `1.32.0` to `3.1.0` (or "latest" on 18.04 and 20.04)
- Certbot DNS Azure plugin bumped to `2.6.1` and installed all the time
- Certbot Apache plugin bumped to `3.1.0`  (or "latest" on 18.04 and 20.04) and installed all the time
- Remove all SnapD Puppet providers, profiles and related code leftover

Tested with success on:

- Vagrant and Ubuntu 22.04 locally
- Vagrant and Ubuntu 18.04 locally
- On the aws.ci.jenkins.io, cert.ci.jenkins.io and pkg.origin.jenkins.io:
  - In NoOp Puppet
  - In Puppet Agent
  - Then ran a `cerbot renew-all --dry-run --force-renewal` 