### PR TITLE
feat(aws.ci.jenkins.io) temporarily uses the aws.ci.jenkins.io hostname to validate inbound agents

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -17,8 +17,8 @@ profile::jenkinscontroller::anonymous_access: false
 profile::jenkinscontroller::admin_ldap_groups:
   - admins
   - jenkins-admins
-profile::jenkinscontroller::ci_fqdn: 'ci.jenkins.io'
-profile::jenkinscontroller::ci_resource_domain: 'assets.ci.jenkins.io'
+profile::jenkinscontroller::ci_fqdn: 'aws.ci.jenkins.io'
+profile::jenkinscontroller::ci_resource_domain: 'assets.aws.ci.jenkins.io'
 profile::jenkinscontroller::letsencrypt: true
 profile::jenkinscontroller::docker_image: 'jenkins/jenkins'
 profile::jenkinscontroller::docker_tag: 'lts-jdk17'


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4315 and https://github.com/jenkins-infra/helpdesk/issues/4317