### PR TITLE
feat(ci.jenkins.io) add missing Windows JDK8 ACI label

### DIFF
--- a/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml
@@ -632,6 +632,7 @@ profile::jenkinscontroller::jcasc:
           agentJavaBin: 'C:/openjdk-17/bin/java' # From image jenkins/inbound-agent:jdk17-nanoserver
           labels:
             - maven-windows
+            - maven-8-windows
           usePrivateIP: true
         - name: maven-11-windows
           os: windows


### PR DESCRIPTION
Follow up of #3852 