### PR TITLE
Revert "Bump `aws-cli` version to 2.24.2"

### DIFF
--- a/hieradata/clients/agent.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/agent.trusted.ci.jenkins.io.yaml
@@ -90,8 +90,9 @@ profile::updatecenter::rsync_privkey: >
   6sMjkFULhVCmPfc6gPcA8SDAj5lglOw6Rwll6ombiFEvR0Zlm0R9DoLgNq9e
   h7nb5jst5FP+k30uaXYiF0fJ0JtnvrflLg0XRDoJKCRwLhywrNLCO6UwA34F
   yhELTnLcIarOCyO2KKYf5WRC8XGvvlz70=]
+
 profile::buildagent::tools_versions:
-  awscli: 2.24.2
+  awscli: 2.13.32
 accounts:
   kevingrdj:
     ssh_keys:

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -489,7 +489,7 @@ profile::jenkinscontroller::plugins:
   - warnings-ng # Provides integration (UI, jobs) with static analyser and linters
   - workflow-aggregator # Meta-plugin to provide all workflow-(.*) standard plugins
 profile::jenkinscontroller::tools_versions:
-  awscli: 2.24.2
+  awscli: 2.13.32
 profile::jenkinscontroller::kubeconfigs:
   - cluster_name: cijenkinsio-agents-2
     cluster_url: https://A5986B0920D06F1E0CABF431FF7678F9.yl4.us-east-2.eks.amazonaws.com

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -489,9 +489,9 @@ profile::jenkinscontroller::plugins:
   - workflow-aggregator
   - workflow-multibranch
 profile::buildagent::tools_versions:
-  awscli: 2.24.2
+  awscli: 2.13.32
 profile::jenkinscontroller::tools_versions:
-  awscli: 2.24.2
+  awscli: 2.13.32
 profile::jenkinscontroller::kubeconfigs:
   # Case of cluster which user requires a token
   - cluster_name: cijenkinsio-agents-1


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#3871 as I messed up (mixing packer-image and Puppet repositories). My bad.