### PR TITLE
feat(jenkinscontroller): templating registry-mirrors for docker for aws

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -405,7 +405,8 @@ jenkins:
                 ## Setup Docker Engine
                 @'
                 {
-                  "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][agent['os'].to_s]['registryMirror'] %>"]
+                  "insecure-registries": ["<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>],
+                  "registry-mirrors": ["http://<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>"]
                 }
                 '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
                 Restart-Service docker
@@ -471,7 +472,8 @@ jenkins:
           mkdir -p /etc/docker
           cat <<EOF >/etc/docker/daemon.json
           {
-            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : (ec2_cloud_setup['registryMirror'] ? ec2_cloud_setup['registryMirror'] : @jcasc['agents_setup'][agent['os'].to_s]['registryMirror']) %>"]
+            "insecure-registries": ["<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>],
+            "registry-mirrors": ["http://<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>"]
           }
           EOF
           systemctl daemon-reload

--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -405,7 +405,7 @@ jenkins:
                 ## Setup Docker Engine
                 @'
                 {
-                  "insecure-registries": ["<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>],
+                  "insecure-registries": ["<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>"],
                   "registry-mirrors": ["http://<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>"]
                 }
                 '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
@@ -472,7 +472,7 @@ jenkins:
           mkdir -p /etc/docker
           cat <<EOF >/etc/docker/daemon.json
           {
-            "insecure-registries": ["<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>],
+            "insecure-registries": ["<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>"],
             "registry-mirrors": ["http://<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>"]
           }
           EOF

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -258,6 +258,7 @@ profile::jenkinscontroller::jcasc:
         securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
         # TODO: maintain with updatecli
         subnetId: "subnet-0138ee90cd53d58f7"
+        # TODO: maintain with updatecli
         registryMirror: "k8s-hubmirro-hubmirro-f5b8613a86-574b882e7a7e93d0.elb.us-east-2.amazonaws.com:5000"
         agent_definitions:
           ####

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -258,6 +258,7 @@ profile::jenkinscontroller::jcasc:
         securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
         # TODO: maintain with updatecli
         subnetId: "subnet-0138ee90cd53d58f7"
+        registryMirror: "k8s-hubmirro-hubmirro-f5b8613a86-574b882e7a7e93d0.elb.us-east-2.amazonaws.com:5000"
         agent_definitions:
           ####
           # x86_64 Linux VMs

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -121,6 +121,7 @@ profile::jenkinscontroller::jcasc:
         associatePublicIp: false
         securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
         subnetId: "subnet-0138ee90cd53d58f7"
+        registryMirror: "urltodockerproxy:5000"
         agent_definitions:
           - description: "ARM64 ubuntu 22.04"
             maxInstances: 5


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4321#issuecomment-2646302147

allow aws.ci.jenkins.io Puppet configuration to be set to specific docker registry mirror url.