### PR TITLE
fix(aws.ci.jio) update ACP LB

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -89,7 +89,7 @@ profile::jenkinscontroller::jcasc:
       aws-internal:
         name: AWS (Internal) Artifact Caching Proxy
         # TODO: maintain with updatecli
-        url: http://k8s-artifact-artifact-3956ce141b-9dd8bf0a8c925c79.elb.us-east-2.amazonaws.com:8080/
+        url: http://k8s-artifact-artifact-f340ad86c3-70787fedaeca6b4d.elb.us-east-2.amazonaws.com:8080/
       aws-eks-internal:
         name: AWS (EKS Internal) Artifact Caching Proxy
         # TODO: maintain with updatecli


### PR DESCRIPTION
tests on the new AWS.CI shows that the LB hostname has changed.
as per https://github.com/jenkins-infra/helpdesk/issues/4315#issuecomment-2656008534

TODO: track with updatecli