### PR TITLE
feat(jenkinscontroller/clouds) set up proper temp dir on EC2 and factorize code

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -12,8 +12,9 @@ jenkins:
       maxVirtualMachinesLimit: <%= cloudsetup['maxInstances'] %>
       vmTemplates:
     <%- @jcasc['cloud_agents']['azure_vm_agents']['agent_definitions'].each do |agent| -%>
-      - agentWorkspace: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][agent['os'].to_s]['agentDir'] %>"
-        <%- if agent['os'].to_s == 'windows' -%>
+      <%- $os = agent['os'] ? agent['os'] : 'ubuntu' -%>
+      - agentWorkspace: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>"
+        <%- if $os == 'windows' -%>
         executeInitScriptAsRoot: false
         # Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
         initScript: |
@@ -24,7 +25,7 @@ jenkins:
           # Setup Docker Engine
           @'
           {
-            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][agent['os'].to_s]['registryMirror'] %>"]
+            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][$os]['registryMirror'] %>"]
           }
           '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
           Restart-Service docker
@@ -34,7 +35,7 @@ jenkins:
           $jenkinsServerUrl = $args[0] # Always ends with a '/'
           $agentName = $args[1]
           $agentSecret = $args[2]
-          $jenkinsWorkDir = '<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][agent['os'].to_s]['agentDir'] %>'
+          $jenkinsWorkDir = '<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>'
           # Download the service wrapper
           $agentJar =  '{0}jnlpJars/agent.jar' -f $jenkinsServerUrl
 
@@ -47,7 +48,7 @@ jenkins:
           [System.Environment]::SetEnvironmentVariable("ARTIFACT_CACHING_PROXY_SERVERID", "<%= @jcasc['artifact_caching_proxy']['servers'][cloudsetup['acpServerId']]['url'] %>", "Machine")
           $Env:ARTIFACT_CACHING_PROXY_SERVERID = "<%= @jcasc['artifact_caching_proxy']['servers'][cloudsetup['acpServerId']]['url'] %>"
           <%- end -%>
-          $javaHome = "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>"
+          $javaHome = "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] %>"
           [System.Environment]::SetEnvironmentVariable("JAVA_HOME", ^${javaHome}, "Machine")
           [System.Environment]::SetEnvironmentVariable("PATH", $Env:Path + ";^${javaHome}\bin", "Machine")
           $Env:Path += ";^${javaHome}\bin"
@@ -59,7 +60,7 @@ jenkins:
           $wc.DownloadFile('https://raw.githubusercontent.com/Azure/jenkins/master/agents_scripts/jenkins-slave.xml', $configFile)
           # Prepare config
           Write-Output 'Executing agent process...'
-          $configExec = '<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>'
+          $configExec = '<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][$os]['agentJavaBin'] %>'
           $configArgs = '-jnlpUrl "{0}/computer/{1}/jenkins-agent.jnlp" -workDir {2}' -f $jenkinsserverurl, $agentName, $jenkinsWorkDir
           if ($agentSecret) {
               $configArgs += " -secret `"$agentSecret`""
@@ -71,7 +72,7 @@ jenkins:
           & $wrapperExec install
           & $wrapperExec start
           <%- else -%>
-          $javaHome = "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>"
+          $javaHome = "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] %>"
           [System.Environment]::SetEnvironmentVariable("JAVA_HOME", ^${javaHome}, "Machine")
           [System.Environment]::SetEnvironmentVariable("PATH", $Env:Path + ";^${javaHome}\bin", "Machine")
           $Env:Path += ";^${javaHome}\bin"
@@ -102,7 +103,7 @@ jenkins:
           mkdir -p /etc/docker
           cat <<EOF >/etc/docker/daemon.json
           {
-            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][agent['os'].to_s]['registryMirror'] %>"]
+            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][$os]['registryMirror'] %>"]
           }
           EOF
           systemctl daemon-reload
@@ -117,16 +118,16 @@ jenkins:
             export AGENT_SECRET="^${3}"
 
             export USER=jenkins
-            export AGENT_WORKDIR='<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][agent['os'].to_s]['agentDir'] %>'
+            export AGENT_WORKDIR='<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>'
             export AGENT_JAR="^${AGENT_WORKDIR}/agent.jar"
             export AGENT_SECRETFILE="^${AGENT_WORKDIR}/agent-secret"
             export AGENT_URL="^${JENKINS_URL}computer/^${AGENT_NAME}/jenkins-agent.jnlp"
-            export JENKINS_JAVA_OPTS='<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>'
+            export JENKINS_JAVA_OPTS='<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] %>'
             <%- if @jcasc['artifact_caching_proxy'] && @jcasc['artifact_caching_proxy']['enabled'].to_s == "true" && cloudsetup['acpServerId'] -%>
             export ARTIFACT_CACHING_PROXY_SERVERID='<%= @jcasc['artifact_caching_proxy']['servers'][cloudsetup['acpServerId']]['url'] %>'
             <%- end -%>
-            export JAVA_HOME='<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>'
-            export JENKINS_JAVA_BIN='<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>'
+            export JAVA_HOME='<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] %>'
+            export JENKINS_JAVA_BIN='<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][$os]['agentJavaBin'] %>'
 
             mkdir -p "^${AGENT_WORKDIR}"
             chown "^${USER}:^${USER}" "^${AGENT_WORKDIR}"
@@ -163,7 +164,7 @@ jenkins:
           <%- else -%>
 
           # Setup default java for build (not for agent process)
-          export DEFAULT_JDK=<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>
+          export DEFAULT_JDK=<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] %>
           update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
           echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
           <%-end -%>
@@ -195,14 +196,14 @@ jenkins:
         installDocker: false
         installGit: false
         installMaven: false
-        javaPath: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
-        jvmOptions: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
-        labels: "<%= agent['os'].to_s + "-" + agent['os_version'].to_s %> <%= agent['architecture'].to_s %> azure vm <%= agent['labels'].join(' ') %> <%= cloudname %>"
+        javaPath: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][$os]['agentJavaBin'] %>"
+        jvmOptions: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] %>"
+        labels: "<%= $os + "-" + agent['os_version'].to_s %> <%= agent['architecture'].to_s %> azure vm <%= agent['labels'].join(' ') %> <%= cloudname %>"
         location: "<%= agent['location'] %>"
         noOfParallelJobs: 1
-        osDiskSize: <%= agent['osDiskSize'] ? agent['osDiskSize'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskSize'] %>
-        osDiskStorageAccountType: <%= agent['ephemeralOSDisk'] ? "Standard_LRS" : (agent['osDiskStorageAccountType'] ? agent['osDiskStorageAccountType'] : @jcasc['agents_setup'][agent['os'].to_s]['osDiskStorageAccountType']) %>
-        osType: "<%= agent['os'].to_s == "windows" ? 'Windows' : 'Linux' %>"
+        osDiskSize: <%= agent['osDiskSize'] ? agent['osDiskSize'] : @jcasc['agents_setup'][$os]['osDiskSize'] %>
+        osDiskStorageAccountType: <%= agent['ephemeralOSDisk'] ? "Standard_LRS" : (agent['osDiskStorageAccountType'] ? agent['osDiskStorageAccountType'] : @jcasc['agents_setup'][$os]['osDiskStorageAccountType']) %>
+        osType: "<%= $os == "windows" ? 'Windows' : 'Linux' %>"
       <%- if agent['idleTerminationMinutes'] -%>
         retentionStrategy:
           azureVMCloudRetentionStrategy:
@@ -239,13 +240,14 @@ jenkins:
       resourceGroup: "<%= aci_cloud_setup['resourceGroup'] %>"
       templates:
       <%-  @jcasc['cloud_agents']['azure-container-agents']['agent_definitions'].each do |agent| -%>
+        <%- $os = agent['os'] ? agent['os'] : 'ubuntu' -%>
       - command: "<%= agent['command'] %>"
         cpu: "<%= agent['cpus'] %>"
         image: "<%= @jcasc['agent_images']['container_images']['jnlp-' + agent['name'].to_s] %>"
-        label: "<%= agent['os'] %> azure aci container <%= agent['labels'].join(' ') %> <%= aci_cloud_name %>"
+        label: "<%= $os %> azure aci container <%= agent['labels'].join(' ') %> <%= aci_cloud_name %>"
         memory: "<%= agent['memory'] %>"
         name: "aci-<%= agent['name'] %>"
-        osType: "<%= agent['os'] == "windows" ? 'Windows' : 'Linux' %>"
+        osType: "<%= $os == "windows" ? 'Windows' : 'Linux' %>"
         <%- if agent['usePrivateIP'] && aci_cloud_setup['virtualNetworkResourceGroupName'] && aci_cloud_setup['virtualNetworkName'] && aci_cloud_setup['subnetName'] -%>
         privateIpAddress:
           resourceGroup: "<%= aci_cloud_setup['virtualNetworkResourceGroupName'] %>"
@@ -253,13 +255,13 @@ jenkins:
           subnet: "<%= aci_cloud_setup['subnetName'] %>"
         <%- end -%>
         retentionStrategy: "containerOnce"
-        rootFs: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][agent['os'].to_s]['agentDir'] %>"
+        rootFs: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>"
         timeout: 60
         # Please note that envVars are specified differently than permanent or Kubernetes agents
         envVars:
-          <%- agentJavaOpts = agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] -%>
+          <%- agentJavaOpts = agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] -%>
           <%- jenkinsJavaOpts = "" -%>
-          <%- if agent['os'] == "windows" -%>
+          <%- if $os == "windows" -%>
             <%-# On Windows, due to https://github.com/jenkinsci/docker-inbound-agent/pull/227, each flag of the java opts string is wrapped with litteral double quote to avoid powershell interpolation  -%>
             <%- agentJavaOpts.split(' ').each do |optFlag| -%>
               <%- jenkinsJavaOpts += '"' + optFlag + '"' -%>
@@ -272,7 +274,7 @@ jenkins:
             value: >-
               <%= jenkinsJavaOpts %>
           - key: "JENKINS_JAVA_BIN"
-            value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
+            value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][$os]['agentJavaBin'] %>"
           <%- if @jcasc['artifact_caching_proxy'] && @jcasc['artifact_caching_proxy']['enabled'].to_s == "true" && aci_cloud_setup['acpServerId'] -%>
           - key: "ARTIFACT_CACHING_PROXY_SERVERID"
             value: "<%= @jcasc['artifact_caching_proxy']['servers'][aci_cloud_setup['acpServerId']]['url'] %>"
@@ -295,9 +297,11 @@ jenkins:
       useInstanceProfileForCredentials: "<%= ec2_cloud_setup['useInstanceProfileForCredentials'] ? ec2_cloud_setup['useInstanceProfileForCredentials'] : false %>"
       templates:
       <%- ec2_cloud_setup['agent_definitions'].each do |agent| -%>
-        <%- $cloudInitDoneFile = agent['os'].to_s == 'windows' ? "C:/Windows/Temp/.cloud-init.done" : "/tmp/.cloud-init.done" -%>
-        <%- $javaHome = agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] -%>
-      - ami: "<%= @jcasc['agent_images']['ec2_amis'][agent['os'].to_s + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"
+        <%- $os = agent['os'] ? agent['os'] : 'ubuntu' -%>
+        <%- $tempDir = agent['tempDir'] ? agent['tempDir'] : @jcasc['agents_setup'][$os]['tempDir'] -%>
+        <%- $cloudInitDoneFile = "#{$tempDir}/.cloud-init.done" -%>
+        <%- $javaHome = agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] -%>
+      - ami: "<%= @jcasc['agent_images']['ec2_amis'][$os + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"
         amiType:
         <%- if agent['launcher'] && agent['launcher'] == "winrm" -%>
           windowsData:
@@ -320,7 +324,7 @@ jenkins:
         idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] ? agent['idleTerminationMinutes'] : -5 %>"
         # Note: Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
         initScript: |-
-        <%- if agent['os'].to_s == 'windows' -%>
+        <%- if $os == 'windows' -%>
           <%-# No init script if using SSH launcher: the cmd.exe never finishes (most probably an EC2 plugin bug) %>
         <%- else -%>
           #!/bin/sh
@@ -333,9 +337,9 @@ jenkins:
           done
         <%- end -%>
         instanceCapStr: "<%= agent['maxInstances'] %>"
-        javaPath: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaBin'] %>"
-        jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][agent['os'].to_s]['agentJavaOpts'] %>"
-        labelString: "<%= agent['os'] + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['labels'].join(' ') %>"
+        javaPath: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][$os]['agentJavaBin'] %>"
+        jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] %>"
+        labelString: "<%= $os + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['labels'].join(' ') %>"
         launchTimeoutStr: "1000"
         maxTotalUses: 1 # Throw away the VMs after a build: ephemeral machines
         metadataEndpointEnabled: true
@@ -354,15 +358,23 @@ jenkins:
               value: "<%= @jcasc['artifact_caching_proxy']['servers'][agent['acpServerId']]['url'] %>"
             <%- end -%>
             - key: "JAVA_HOME"
-              value: "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>"
+              value: "<%= $javaHome %>"
+            - key: "JENKINS_JAVA_OPTS"
+              value: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] %>"
             - key: "PATH"
-              # javaHome always uses '/' as directory separator on both Unix and Windows
-              # The only difference between OSes is the PATH separator (hence the ternary operator).
-              # Note: the $PATH is the "append" Jenkins syntax in that case
-              value: "<%= $javaHome %>/bin<%= agent['os'].to_s == 'windows' ? ";" : ":" %>$PATH"
+              value: "<%= $javaHome %>/bin<%= $os == 'windows' ? ";" : ":" %>$PATH"
+            <%- if $os == "windows" %>
+            - key: "TMP"
+              value: "<%= $tempDir %>"
+            - key: "TEMP"
+              value: "<%= $tempDir %>"
+            <%- else -%>
+            - key: "TMPDIR"
+              value: "<%= $tempDir %>"
+            <%- end -%>
         numExecutors: 1
-        remoteAdmin: "<%= @jcasc['agents_setup'][agent['os'].to_s]['remoteAdmin'] %>"
-        remoteFS: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][agent['os'].to_s]['agentDir'] %>"
+        remoteAdmin: "<%= @jcasc['agents_setup'][$os]['remoteAdmin'] %>"
+        remoteFS: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>"
         securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
         <%- if agent['spot'] -%>
         spotConfig:
@@ -376,14 +388,20 @@ jenkins:
         - name: "architecture"
           value: "<%= agent['architecture'] %>"
         - name: "os"
-          value: "<%= agent['os'] %>"
+          value: "<%= $os %>"
         tenancy: Default
-        tmpDir: "<%= @jcasc['agents_setup'][agent['os']]['tempDir'] %>"
+        <%- if $os == 'windows' -%>
+        # Double Backslash is required for EC2 plugin as we hackishly use the unix launched for Windows to use OpenSSH
+        # And JCasc needs 2 backslashes for a literal backslash.
+        tmpDir: "<%= $tempDir.gsub('/', '\\\\\\\\') %>" <%# Inside ERB instructions, a literal backslash is expressed using 4 backslashes %>
+        <%- else -%>
+        tmpDir: "<%= $tempDir %>"
+        <%- end -%>
         type: <%= agent['instanceType'] %>
         useEphemeralDevices: true
         # Note: Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
         userData: |-
-        <%- if agent['os'].to_s == 'windows' -%>
+        <%- if $os == 'windows' -%>
           # Requires using YAML for the Windows "Cloud Init" stuff. Multipart upload of a powershell script does not work.
           version: 1.1
           tasks:
@@ -480,7 +498,7 @@ jenkins:
           systemctl restart docker
 
           ## Setup default java for build (not for agent process)
-          export DEFAULT_JDK=<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][agent['os'].to_s]['javaHome'] %>
+          export DEFAULT_JDK=<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] %>
           update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
 
           ## Remove jenkins user from sudoers
@@ -511,6 +529,9 @@ jenkins:
       <%- if k8s_setup['agent_definitions'] -%>
       templates:
       <%- k8s_setup['agent_definitions'].each do |agent| -%>
+        <%- $os = agent['os'] ? agent['os'] : 'ubuntu' -%>
+        <%- $tempDir = agent['tempDir'] ? agent['tempDir'] : @jcasc['agents_setup'][$os]['tempDir'] -%>
+        <%- $javaHome = agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] -%>
         - containers:
           - alwaysPullImage: false
             image: "<%= agent['imageName'] && !agent['imageName'].empty? ? @jcasc['agent_images']['container_images'][agent['imageName']] : @jcasc['agent_images']['container_images'][agent['name']] %>"
@@ -518,10 +539,10 @@ jenkins:
             envVars:
               - envVar:
                   key: "JENKINS_JAVA_OPTS"
-                  value: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup']['ubuntu']['agentJavaOpts'] %>"
+                  value: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] %>"
               - envVar:
                   key: "JENKINS_JAVA_BIN"
-                  value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup']['ubuntu']['agentJavaBin'] %>"
+                  value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][$os]['agentJavaBin'] %>"
               - envVar:
                   key: "JAVA_HOME"
                   value: "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup']['ubuntu']['javaHome'] %>"
@@ -546,7 +567,7 @@ jenkins:
             resourceLimitMemory: "<%= agent['memory'] %>G"
             resourceRequestCpu: "<%= agent['cpus'] %>"
             resourceRequestMemory: "<%= agent['memory'] %>G"
-            workingDir: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup']['ubuntu']['agentDir'] %>"
+            workingDir: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>"
           label: "container kubernetes <%= k8s_name %> <%= agent['labels'] ? agent['labels'].join(' ') : '' %>"
           name: "<%= agent['name'] %>"
           nodeUsageMode: "<%= agent['useAsMuchAsPossible'] == true ? 'NORMAL' : 'EXCLUSIVE' %>"
@@ -575,7 +596,7 @@ jenkins:
           volumes:
           - emptyDirVolume:
               memory: true
-              mountPath: "/tmp"
+              mountPath: "<%= $tempDir %>"
           - emptyDirVolume:
               memory: false
               mountPath: "/home/jenkins/.m2/repository"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -198,8 +198,7 @@ profile::jenkinscontroller::jcasc:
   agents_setup:
     windows:
       agentDir: 'C:/Jenkins/agent'
-      # Double Backslash is required (for EC2 plugin as we hackishly use the unix launched for Windows to use OpenSSH)
-      tempDir: 'C:\\\\Temp'
+      tempDir: 'C:/Windows/Temp'
       remoteAdmin: Administrator
       osDiskSize: 150
       osDiskStorageAccountType: 'Premium_LRS'


### PR DESCRIPTION
While preparing support of Kubernetes Windows Pod agents for https://github.com/jenkins-infra/helpdesk/issues/4318, was blocked by a few code changes worth doing on a distinct preliminary PR, so we can deliver and test it safely without having too much change at a time.

This PR introduces the following changes: 

- In the templatized JCasc clouds, factorize repeated attributes (OS, javahome, tempdir, etc.) when reused multiple times to simplify conditional expressions and avoid weird Puppet errors when dealing with nested maps.
- Change Windows Temp. Dir to `C:/Windows/Temp`.
  - It requires a hack to provide the exact amount of backslashes for the specific case of EC2 Windows with SSH (Unix) Launcher. See comments (as a LOT of backslashes are required), instead of the usual slashes which Windows knows how to use on all other cases
  - It also required setting up explicitly the Unix/Linux/Ubuntu parameterized TMPDIR