### PR TITLE
hotfix(jenkinscontroller/clouds-agents) correct Windows EC2 agents syntax error

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -363,7 +363,7 @@ jenkins:
               value: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] %>"
             - key: "PATH"
               value: "<%= $javaHome %>/bin<%= $os == 'windows' ? ";" : ":" %>$PATH"
-            <%- if $os == "windows" %>
+            <%- if $os == "windows" -%>
             - key: "TMP"
               value: "<%= $tempDir %>"
             - key: "TEMP"
@@ -393,7 +393,7 @@ jenkins:
         <%- if $os == 'windows' -%>
         # Double Backslash is required for EC2 plugin as we hackishly use the unix launched for Windows to use OpenSSH
         # And JCasc needs 2 backslashes for a literal backslash.
-        tmpDir: "<%= $tempDir.gsub('/', '\\\\\\\\') %>" <%# Inside ERB instructions, a literal backslash is expressed using 4 backslashes %>
+        tmpDir: "<%= $tempDir.gsub('/', '\\\\\\\\\\\\\\\\') %>" <%# Inside ERB instructions, a literal backslash is expressed using 4 backslashes %>
         <%- else -%>
         tmpDir: "<%= $tempDir %>"
         <%- end -%>


### PR DESCRIPTION
Fixup of #3894

As shown by the Puppet "NoOp" diff (see https://github.com/jenkins-infra/jenkins-infra/pull/3894#issuecomment-2663340961), this PR fixes the 2 following syntax problems on Windows EC2 templates:

- Avoid the empty line before the env var `TMP` 
- Ensure 4 backslashes are written for each directory separator for the Temp Dir