### PR TITLE
feat(jenkinscontroller/clouds-agents) add initial support for Windows Kubernetes Agents

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -545,14 +545,36 @@ jenkins:
                   value: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][$os]['agentJavaBin'] %>"
               - envVar:
                   key: "JAVA_HOME"
-                  value: "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup']['ubuntu']['javaHome'] %>"
+                  value: "<%= $javaHome %>"
+              <%- if agent['agentEnvPath'] -%>
               - envVar:
                   key: "PATH"
-                  value: "<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup']['ubuntu']['javaHome'] %>/bin:<%= @jcasc['agents_setup']['ubuntu']['path'] %>"
+                  value: "<%= agent['agentEnvPath'] %>"
+              <%- else -%>
+                <%- if $os == 'windows' -%>
+              # TODO: implement custom PATH for Windows
+                <%- else -%>
+              - envVar:
+                  key: "PATH"
+                  value: "<%= $javaHome %>/bin<%= $os == 'windows' ? ";" : ":" %><%= @jcasc['agents_setup'][$os]['path'] %>"
+                <%- end -%>
+              <%- end -%>
               <%- if @jcasc['artifact_caching_proxy'] && @jcasc['artifact_caching_proxy']['enabled'].to_s == "true" && k8s_setup['acpServerId'] -%>
               - envVar:
                   key: "ARTIFACT_CACHING_PROXY_SERVERID"
                   value: "<%= @jcasc['artifact_caching_proxy']['servers'][k8s_setup['acpServerId']]['url'] %>"
+              <%- end -%>
+              <%- if $os == "windows" -%>
+              - envVar:
+                  key: "TMP"
+                  value: "<%= $tempDir %>"
+              - envVar:
+                  key: "TEMP"
+                  value: "<%= $tempDir %>"
+              <%- else -%>
+              - envVar:
+                  key: "TMPDIR"
+                  value: "<%= $tempDir %>"
               <%- end -%>
             livenessProbe:
               failureThreshold: 0
@@ -561,8 +583,16 @@ jenkins:
               successThreshold: 0
               timeoutSeconds: 0
             name: "jnlp"
+            <%- if agent['command'] -%>
+            command: "<%= agent['command'] %>"
+            <%- else -%>
+              <%- if $os == "windows" -%>
+            command: "pwsh.exe -f C:/ProgramData/Jenkins/jenkins-agent.ps1"
+              <%- else -%>
             command: "/usr/local/bin/jenkins-agent"
-            args: ""
+              <%- end -%>
+            <%- end -%>
+            args: "<%= agent['args'] ? agent['args'] : '' -%>"
             resourceLimitCpu: "<%= agent['cpus'] %>"
             resourceLimitMemory: "<%= agent['memory'] %>G"
             resourceRequestCpu: "<%= agent['cpus'] %>"
@@ -599,7 +629,15 @@ jenkins:
               mountPath: "<%= $tempDir %>"
           - emptyDirVolume:
               memory: false
-              mountPath: "/home/jenkins/.m2/repository"
+              <%- if agent['m2Repository'] -%>
+              mountPath: "<%= agent['m2Repository'] %>"
+              <%- else -%>
+                <%- if $os == "windows" -%>
+              mountPath: "C:/Users/<%= @jcasc['agents_setup'][$os]['remoteAdmin'] %>/.m2/repository"
+                <%- else -%>
+              mountPath: "/home/<%= @jcasc['agents_setup'][$os]['remoteAdmin'] %>/.m2/repository"
+                <%- end -%>
+              <%- end -%>
       <%- end -%>
       <%- end -%>
     <%- end -%>

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -205,6 +205,8 @@ profile::jenkinscontroller::jcasc:
       agentJavaBin: 'C:/tools/jdk-17/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
       javaHome: 'C:/tools/jdk-17' # Default JDK provided for builds when no pipeline setup exists
+      # TODO: track with updatecli
+      path: ''
       registryMirror: https://dockerhubmirror.azurecr.io
     ubuntu:
       agentDir: "/home/jenkins/agent"
@@ -214,7 +216,9 @@ profile::jenkinscontroller::jcasc:
       osDiskStorageAccountType: 'Premium_LRS'
       agentJavaBin: '/opt/jdk-17/bin/java'
       agentJavaOpts: '-XX:+PrintCommandLineFlags'
+      m2RepoPath: '/home/jenkins/.m2/repository'
       javaHome: '/opt/jdk-17' # Default JDK provided for builds when no pipeline setup exists
+      # TODO: track with updatecli
       path: '/home/jenkins/.asdf/shims:/home/jenkins/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/local/go/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'
       registryMirror: https://dockerhubmirror.azurecr.io
   agent_images:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -232,6 +232,19 @@ profile::jenkinscontroller::jcasc:
             cpus: 1
             memory: 1
             imagePullSecrets: dockerhub-credential
+          - name: jnlp-maven-21-windows
+            os: windows
+            cpus: 2
+            memory: 4
+            javaHome: 'C:/tools/jdk-21'
+            labels:
+              - maven-21-windows
+            nodeSelector: "role=jenkins-agents"
+            tolerations:
+              - key: "ci.jenkins.io/windows"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
       second-cluster:
         enabled: true
         provider: azure


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4318

This PR requires #3894 (and #3896)

It introduces an initial support for Kubernetes Agents Pod Templates with:

- Java Home env var. determined per OS
- **Only** `PATH` support for non-Windows (should be fixed on a subsequent PR as it requires a bit of exploration on our custom images)
- Explicit setup of the Temp Dirs (both Windows and Linux) ensuring they are mapped to tmpfs Kubernetes volumes
- Set up default Windows command and args (assuming our current jenkins-infra/docker-inbound-agents nanoserver 2019 images), but allow customizing per agent templates (for future changes)
- Support emptyDir volume for the M2 repository (using default user home)


=> This PR provides testing in the Vagrant VM but should NOT change anything on ci.jenkins.io (to ensure we make step by step testing) except adding an env. var `TMPDIR` set to `/tmp` for all the Linux Pod agents.

Gotta disable puppet agent on ci.jenkins.io and run a noop diff before deploying (or provide fix PR)