### PR TITLE
feat(ci.jenkins.io) add initial set of Kubernetes Windows agents for Maven JDK8, 11, 17 and 21 in testing mode

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -220,6 +220,67 @@ profile::jenkinscontroller::jcasc:
                 operator: "Equal"
                 value: "true"
                 effect: "NoSchedule"
+          - name: jnlp-maven-8-windows
+            os: windows
+            cpus: 2
+            memory: 4
+            javaHome: 'C:/tools/jdk-8'
+            labels:
+              - maven-8-windows-test
+              # TODO: uncomment when ready and remove label "-test" above
+              # - maven-windows
+              # - maven-8-windows
+            nodeSelector: "role=jenkins-agents,kubernetes.io/arch=amd64,kubernetes.io/os=windows"
+            tolerations:
+              - key: "ci.jenkins.io/windows-2019"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+          - name: jnlp-maven-11-windows
+            os: windows
+            cpus: 2
+            memory: 4
+            javaHome: 'C:/tools/jdk-11'
+            labels:
+              - maven-11-windows-test
+              # TODO: uncomment when ready and remove label "-test" above
+              # - maven-11-windows
+            nodeSelector: "role=jenkins-agents,kubernetes.io/arch=amd64,kubernetes.io/os=windows"
+            tolerations:
+              - key: "ci.jenkins.io/windows-2019"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+          - name: jnlp-maven-17-windows
+            os: windows
+            cpus: 2
+            memory: 4
+            javaHome: 'C:/tools/jdk-17'
+            labels:
+              - maven-17-windows-test
+              # TODO: uncomment when ready and remove label "-test" above
+              # - maven-17-windows
+            nodeSelector: "role=jenkins-agents,kubernetes.io/arch=amd64,kubernetes.io/os=windows"
+            tolerations:
+              - key: "ci.jenkins.io/windows-2019"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
+          - name: jnlp-maven-21-windows
+            os: windows
+            cpus: 2
+            memory: 4
+            javaHome: 'C:/tools/jdk-21'
+            labels:
+              - maven-21-windows-test
+              # TODO: uncomment when ready and remove label "-test" above
+              # - maven-21-windows
+            nodeSelector: "role=jenkins-agents,kubernetes.io/arch=amd64,kubernetes.io/os=windows"
+            tolerations:
+              - key: "ci.jenkins.io/windows-2019"
+                operator: "Equal"
+                value: "true"
+                effect: "NoSchedule"
       ci.jenkins.io-agents-2-bom:
         enabled: true
         ## Note: no URL/credential/CA data as we rely on jenkins' KUBECONFIG to allow EC2 instance profile authentication

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -222,8 +222,8 @@ profile::jenkinscontroller::jcasc:
                 effect: "NoSchedule"
           - name: jnlp-maven-8-windows
             os: windows
-            cpus: 2
-            memory: 4
+            cpus: 4
+            memory: 12
             javaHome: 'C:/tools/jdk-8'
             labels:
               - maven-8-windows-test
@@ -238,8 +238,8 @@ profile::jenkinscontroller::jcasc:
                 effect: "NoSchedule"
           - name: jnlp-maven-11-windows
             os: windows
-            cpus: 2
-            memory: 4
+            cpus: 4
+            memory: 12
             javaHome: 'C:/tools/jdk-11'
             labels:
               - maven-11-windows-test
@@ -253,8 +253,8 @@ profile::jenkinscontroller::jcasc:
                 effect: "NoSchedule"
           - name: jnlp-maven-17-windows
             os: windows
-            cpus: 2
-            memory: 4
+            cpus: 4
+            memory: 12
             javaHome: 'C:/tools/jdk-17'
             labels:
               - maven-17-windows-test
@@ -268,8 +268,8 @@ profile::jenkinscontroller::jcasc:
                 effect: "NoSchedule"
           - name: jnlp-maven-21-windows
             os: windows
-            cpus: 2
-            memory: 4
+            cpus: 4
+            memory: 12
             javaHome: 'C:/tools/jdk-21'
             labels:
               - maven-21-windows-test


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4318

This PR updates ci.jenkins.io by adding 4 new pod templates for Windows containers.

Notes: 

-The expected "final" labels are commented. There is one unique label per template (`maven-XX-windows-test`)  to allow testing without risking existing pipelines to pick these new template while not fully tested.
- These new templates define Windows containers: as per [the EKS documentation for Windows pods](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#windows-support-pod-deployment), they have 2 mandatory node selectors (os and arch) along with the "agent" one
- Tolerations are set up to both the "agent" role (to avoid scheduling on the "applications" nodes where the registry, datadog and ACP are running) AND also set up with "windows-2019". In theory, EKS + Karpenter should be able to tell between Windows 2019 and Windows 2022 nodes, but better safe than sorry.