### PR TITLE
feat(jenkins-controllers/kubernetes-clouds): provide the ability to add a prefix for docker images (usage of ECR)

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -533,7 +533,7 @@ jenkins:
         <%- $javaHome = agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] -%>
         - containers:
           - alwaysPullImage: false
-            image: "<%= agent['imageName'] && !agent['imageName'].empty? ? @jcasc['agent_images']['container_images'][agent['imageName']] : @jcasc['agent_images']['container_images'][agent['name']] %>"
+            image: "<%= k8s_setup['imageNamePrefix'] ? k8s_setup['imageNamePrefix'] : ""%><%= agent['imageName'] && !agent['imageName'].empty? ? @jcasc['agent_images']['container_images'][agent['imageName']] : @jcasc['agent_images']['container_images'][agent['name']] %>"
             # Please note that envVars are specified differently than permanent or ACI agents
             envVars:
               - envVar:

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -301,6 +301,8 @@ profile::jenkinscontroller::jcasc:
         ## Note: no URL/credential/CA data as we rely on jenkins' KUBECONFIG to allow EC2 instance profile authentication
         acpServerId: aws-eks-internal
         # TODO: track with updatecli
+        imageNamePrefix: "326712726440.dkr.ecr.us-east-2.amazonaws.com/docker-hub/"
+        # TODO: track with updatecli
         defaultNamespace: jenkins-agents-bom
         ## TODO: check if it's needed with EKS and karpenter
         max_capacity: 150 # TODO: Re-evaluate and setup updatecli

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -103,6 +103,7 @@ profile::jenkinscontroller::jcasc:
         enabled: true
         ## Note: no URL/credential/CA data as we rely on jenkins' KUBECONFIG to allow EC2 instance profile authentication
         acpServerId: aws-eks-internal
+        # TODO: track with updatecli
         imageNamePrefix: "326712726440.dkr.ecr.us-east-2.amazonaws.com/docker-hub/"
         # TODO: track with updatecli
         defaultNamespace: jenkins-agents

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -103,6 +103,7 @@ profile::jenkinscontroller::jcasc:
         enabled: true
         ## Note: no URL/credential/CA data as we rely on jenkins' KUBECONFIG to allow EC2 instance profile authentication
         acpServerId: aws-eks-internal
+        imageNamePrefix: "326712726440.dkr.ecr.us-east-2.amazonaws.com/docker-hub/"
         # TODO: track with updatecli
         defaultNamespace: jenkins-agents
         max_capacity: 150 # TODO: Re-evaluate and setup updatecli

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -175,6 +175,7 @@ profile::jenkinscontroller::jcasc:
         url: SuperSecretThatShouldBeEncyptedInProduction
         defaultNamespace: jenkins-agents
         acpServerId: internal
+        imageNamePrefix: "urltobeprovided.amazonaws.com/docker-hub/"
         agent_definitions:
           - name: jnlp-maven-bom
             imageName: jnlp-maven-all-in-one


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4321

allow prefixing image name to be able to use the new ECR