### PR TITLE
Revert "feat(aws.ci.jenkins.io): enabling windows container and remove labels from ec2 VMs"

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -230,8 +230,10 @@ profile::jenkinscontroller::jcasc:
             agentJavaBin: 'C:/openjdk-17/bin/java'
             javaHome: 'C:/tools/jdk-8'
             labels:
-              - maven-windows
-              - maven-8-windows
+              - maven-8-windows-test
+              # TODO: uncomment when ready and remove label "-test" above
+              # - maven-windows
+              # - maven-8-windows
             nodeSelector: "role=jenkins-agents,kubernetes.io/arch=amd64,kubernetes.io/os=windows"
             tolerations:
               - key: "ci.jenkins.io/agents"
@@ -249,7 +251,9 @@ profile::jenkinscontroller::jcasc:
             agentJavaBin: 'C:/openjdk-17/bin/java'
             javaHome: 'C:/tools/jdk-11'
             labels:
-              - maven-11-windows
+              - maven-11-windows-test
+              # TODO: uncomment when ready and remove label "-test" above
+              # - maven-11-windows
             nodeSelector: "role=jenkins-agents,kubernetes.io/arch=amd64,kubernetes.io/os=windows"
             tolerations:
               - key: "ci.jenkins.io/agents"
@@ -267,7 +271,9 @@ profile::jenkinscontroller::jcasc:
             agentJavaBin: 'C:/openjdk-17/bin/java'
             javaHome: 'C:/tools/jdk-17'
             labels:
-              - maven-17-windows
+              - maven-17-windows-test
+              # TODO: uncomment when ready and remove label "-test" above
+              # - maven-17-windows
             nodeSelector: "role=jenkins-agents,kubernetes.io/arch=amd64,kubernetes.io/os=windows"
             tolerations:
               - key: "ci.jenkins.io/agents"
@@ -285,7 +291,9 @@ profile::jenkinscontroller::jcasc:
             agentJavaBin: 'C:/openjdk-17/bin/java'
             javaHome: 'C:/tools/jdk-21'
             labels:
-              - maven-21-windows
+              - maven-21-windows-test
+              # TODO: uncomment when ready and remove label "-test" above
+              # - maven-21-windows
             nodeSelector: "role=jenkins-agents,kubernetes.io/arch=amd64,kubernetes.io/os=windows"
             tolerations:
               - key: "ci.jenkins.io/agents"
@@ -479,6 +487,8 @@ profile::jenkinscontroller::jcasc:
             javaHome: 'C:/tools/jdk-8'
             labels:
               - win-2019-amd64-maven-8
+              - maven-8-windows
+              - maven-windows
             spot: false
             acpServerId: aws-internal
           ## TODO: deprecate JDK11 Windows?
@@ -492,6 +502,7 @@ profile::jenkinscontroller::jcasc:
             javaHome: 'C:/tools/jdk-11'
             labels:
               - win-2019-amd64-maven-11
+              - maven-11-windows
             spot: false
             acpServerId: aws-internal
           - description: "Windows 2019 x86_64 with JDK17"
@@ -510,6 +521,7 @@ profile::jenkinscontroller::jcasc:
               - windows
               - win-2019
               - windows-2019
+              - maven-17-windows
             spot: false
             acpServerId: aws-internal
           - description: "Windows 2019 x86_64 with JDK21"
@@ -522,6 +534,7 @@ profile::jenkinscontroller::jcasc:
             javaHome: 'C:/tools/jdk-21'
             labels:
               - win-2019-amd64-maven-21
+              - maven-21-windows
             spot: false
             acpServerId: aws-internal
           - description: "Windows 2022 x86_64 with JDK17"


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#3909

we move back to VMs as the windows container need more work to be trustfully.
see https://github.com/jenkins-infra/helpdesk/issues/4554