### PR TITLE
feat(ci.jio) add back the permanent agent s390x forgotten on the new ci.jenkins.io

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -97,6 +97,23 @@ profile::jenkinscontroller::jcasc:
     host: "aws.ci.jenkins.io"
     targetHost: "172.17.0.1" # docker0 interface
     collectBuildLogs: true
+  permanent_agents:
+    s390x-agent:
+      remoteFS: /home/jenkins/agent
+      labels:
+        - s390x
+        - s390xdocker
+      mode: EXCLUSIVE
+      ssh:
+        host: "148.100.84.76"
+        credentialsId: "jenkins-s390x"
+        hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIaGnnWz9Q/MvlscCUZslFxH8JJ01OQ6FXyuQMQWVuNe"
+      envVars:
+        PATH+MAVEN: /home/jenkins/tools/apache-maven-3.9.9/bin
+        JAVA_HOME: "/opt/jdk-17"
+      toolLocation:
+        - home: /home/jenkins/tools/apache-maven-3.9.9
+          key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
   cloud_agents:
     kubernetes:
       ci.jenkins.io-agents-2:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -107,10 +107,10 @@ profile::jenkinscontroller::jcasc:
         credentialsId: "jenkins-s390x"
         hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIaGnnWz9Q/MvlscCUZslFxH8JJ01OQ6FXyuQMQWVuNe"
       envVars:
-        PATH+MAVEN: "/home/jenkins/tools/apache-maven-3.8.7/bin"
+        PATH+MAVEN: /home/jenkins/tools/apache-maven-3.9.9/bin
         JAVA_HOME: "/opt/jdk-17"
       toolLocation:
-        - home: "/home/jenkins/tools/apache-maven-3.8.7"
+        - home: /home/jenkins/tools/apache-maven-3.9.9
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
   cloud_agents:
     ec2:


### PR DESCRIPTION
during the migration from azure to aws, the permanent agent s390x has been forgotten ... here it is back in work.