### PR TITLE
fix(windows/userdata): need to separate path from filename for new-item

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -465,7 +465,9 @@ jenkins:
           <%- end -%>
 
                 ## Mark cloud init finished (cloud-init status --wait might not report all errors)
-                New-Item -Path . -Name "<%= $cloudInitDoneFile %>" -ItemType "file" -Value "Cloud Init "
+                New-Item -Path  "<%= $cloudInitDoneFile.split('/')[0...-1].join('/') %>" -Name "<%= $cloudInitDoneFile.split('/')[-1] %>" -ItemType "file" -Value "Cloud Init "
+
+
         <%- else -%>
           #!/bin/sh
           set -eux


### PR DESCRIPTION
while playing with the userData for https://github.com/jenkins-infra/helpdesk/issues/4568 

I saw this error: 
```
New-Item : The given path's format is not supported.                                                                                                                            
At C:\Windows\system32\config\systemprofile\AppData\Local\Temp\EC2Launch3900531650\UserScript.ps1:28 char:1                                                                     
+ New-Item -Path . -Name "C:/Windows/Temp/.cloud-init.done" -ItemType " ...                                                                                                     
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                         
    + CategoryInfo          : NotSpecified: (:) [New-Item], NotSupportedException                                                                                               
    + FullyQualifiedErrorId : System.NotSupportedException,Microsoft.PowerShell.Commands.NewItemCommand  
```

this was tested in vagrant:

```
      ## Mark cloud init finished (cloud-init status --wait might not report all errors)
      New-Item -Path  "C:/Windows/Temp" -Name ".cloud-init.done" -ItemType "file" -Value "Cloud Init "
```