### PR TITLE
fix(jenkinscontroller/clouds) EC2 Ubuntu: do not remove 'ubuntu' passwordless sudo permissions

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -502,9 +502,6 @@ jenkins:
           export DEFAULT_JDK=<%= agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] %>
           update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
 
-          ## Remove jenkins user from sudoers
-          rm -f /etc/sudoers.d/90-cloud-init-users
-
           ## Mark cloud init finished (cloud-init status --wait might not report all errors)
           touch "<%= $cloudInitDoneFile %>"
         <%- end -%>


### PR DESCRIPTION
Ref (private link only available to admins) https://github.com/jenkins-infra/runbooks/pull/93#discussion_r1984868922

While on Azure, we remove the `jenkins` user from passwordless sudoers (created by the VM connection system), on AWS EC2 it behaves differently and we want to keep `ubuntu` in the passwordless `sudoers`.
As such we should NOT delete the `/etc/sudoers.d/90-cloud-init-users` during the cloud init phase of EC2 VM agents.

- `ubuntu` passwordless sudoers is created by the packer-image process (ref. https://github.com/jenkins-infra/packer-images/blob/d4de8881ffd19d0e09decc90bc3c4867a46976f6/build-jenkins-agent-ubuntu.pkr.hcl#L8) and never cleaned up
- The JCasc configuration for EC2 agents:
  - Tells the controller to SSH with the `jenkins` user which is NOT admin (no sudoers permissions at all): https://github.com/jenkins-infra/jenkins-infra/blob/15245e52bac1852281ec4e820b2c6fdaa9a4644b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb#L375 => https://github.com/jenkins-infra/jenkins-infra/blob/15245e52bac1852281ec4e820b2c6fdaa9a4644b/hieradata/common.yaml#L211
  - As such the `initScript` attribute only waits for cloud init to complete: no admin-related operation
  - **However** we perform admin tasks (such as datadog agent or Docker configurations) as admin user through the cloud-init process which is run as `root` during the VM boot phase (ref. `userData` attribute in https://github.com/jenkins-infra/jenkins-infra/blob/15245e52bac1852281ec4e820b2c6fdaa9a4644b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb#L402). The last steps of this "userdata" is to delete `/etc/sudoers.d/90-cloud-init-users` which we historically did in Azure where `jenkins` was defined as an admin by Azure Cloud Init system:

```
# On an EC2 VM Agent with 'userData' NOT deleting the file /etc/sudoers.d/90-cloud-init-users
$ whoami 
ubuntu
$ sudo su - 
$ whoami
root

$ cat /etc/sudoers.d/90-cloud-init-users
# Created by cloud-init v. 24.4.1-0ubuntu0~22.04.1 on Wed, 05 Mar 2025 12:45:36 +0000

# User rules for ubuntu
ubuntu ALL=(ALL) NOPASSWD:ALL

$ grep -rI 'jenkins' /etc/sudoers*
# No entries
$ grep -rI 'ubuntu' /etc/sudoers*
/etc/sudoers.d/90-cloud-init-users:# Created by cloud-init v. 24.4.1-0ubuntu0~22.04.1 on Wed, 05 Mar 2025 12:45:36 +0000
/etc/sudoers.d/90-cloud-init-users:# User rules for ubuntu
/etc/sudoers.d/90-cloud-init-users:ubuntu ALL=(ALL) NOPASSWD:ALL
```

