### PR TITLE
feat(ci.jenkins.io): add spot instances versions for ec2 agents

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -393,7 +393,7 @@ profile::jenkinscontroller::jcasc:
         agent_definitions:
           ####
           # x86_64 Linux VMs
-          - description: "Ubuntu 22.04 LTS x86_64 with JDK8 set as default java CLI"
+          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK8 set as default java CLI"
             maxInstances: 50
             instanceType: M6aXlarge # 4 vCPUs / 16 Gb
             os: "ubuntu"
@@ -403,22 +403,10 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-8
             labels:
               - ubuntu-22-amd64-maven8
-            spot: false
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
-            maxInstances: 1
-            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-8
-            labels:
-              - spot-ubuntu-22-amd64-maven8
               - spot
             spot: true
             acpServerId: aws-internal
-          - description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
+          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
             maxInstances: 50
             instanceType: M6aXlarge # 4 vCPUs / 16 Gb
             os: "ubuntu"
@@ -428,21 +416,11 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-11
             labels:
               - ubuntu-22-amd64-maven11
-            spot: false
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
-            maxInstances: 50
-            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-11
-            labels:
-              - spot-ubuntu-22-amd64-maven11
               - spot
             spot: true
             acpServerId: aws-internal
+          ####
+          # Linux VMs jdk17 (default non-spot version for buildPlugin() / docker-*)
           - description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
             maxInstances: 50
             instanceType: M6aXlarge # 4 vCPUs / 16 Gb
@@ -461,6 +439,8 @@ profile::jenkinscontroller::jcasc:
               - linux-amd64
             spot: false
             acpServerId: aws-internal
+          ####
+          # Linux VMs jdk17 (default spot version for buildPlugin() / docker-*)
           - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
             maxInstances: 50
             instanceType: M6aXlarge # 4 vCPUs / 16 Gb
@@ -470,22 +450,10 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: /opt/jdk-17
             labels:
-              - spot-ubuntu-22-amd64-maven17
+              - ubuntu-22-amd64-maven17
               - linux
               - spot
             spot: true
-            acpServerId: aws-internal
-          - description: "Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
-            maxInstances: 50
-            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-21
-            labels:
-              - ubuntu-22-amd64-maven21
-            spot: false
             acpServerId: aws-internal
           - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
             maxInstances: 50
@@ -496,13 +464,13 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: /opt/jdk-21
             labels:
-              - spot-ubuntu-22-amd64-maven21
+              - ubuntu-22-amd64-maven21
               - spot
             spot: true
             acpServerId: aws-internal
           ####
           # arm64 Linux VMs
-          - description: "Ubuntu 22.04 LTS arm64 with JDK17 set as default java CLI"
+          - description: "Spot Ubuntu 22.04 LTS arm64 with JDK17 set as default java CLI"
             maxInstances: 50
             instanceType: T4gXlarge # 4 vCPUs / 16 Gb
             os: "ubuntu"
@@ -516,33 +484,8 @@ profile::jenkinscontroller::jcasc:
               - arm64docker
               - arm64linux
               - linux-arm64
-            spot: false
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS arm64 with JDK17 set as default java CLI"
-            maxInstances: 50
-            instanceType: T4gXlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "arm64"
-            javaHome: /opt/jdk-17
-            labels:
-              - spot-ubuntu-22-arm64-maven17
-              - linux-arm64
               - spot
             spot: true
-            acpServerId: aws-internal
-          - description: "Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
-            maxInstances: 50
-            instanceType: T4gXlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "arm64"
-            javaHome: /opt/jdk-21
-            labels:
-              - ubuntu-22-arm64-maven21
-            spot: false
             acpServerId: aws-internal
           - description: "Spot Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
             maxInstances: 50
@@ -553,7 +496,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "arm64"
             javaHome: /opt/jdk-21
             labels:
-              - spot-ubuntu-22-arm64-maven21
+              - ubuntu-22-arm64-maven21
               - spot
             spot: true
             acpServerId: aws-internal
@@ -574,7 +517,6 @@ profile::jenkinscontroller::jcasc:
               - highram
               - docker-highmem
               - linux-amd64-big
-              ## Spot is not enabled (yet?) in AWS account
               - ubuntu-22-amd64-highmem-nonspot-maven17
               - highmem-nonspot
               - highram-nonspot
@@ -582,6 +524,7 @@ profile::jenkinscontroller::jcasc:
               - linux-amd64-big-nonspot
             spot: false
             acpServerId: aws-internal
+          # High Memory SPOT Linux VMs (ATH mostly)
           - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK17 set as default java CLI"
             maxInstances: 50
             instanceType: M6a2xlarge # 4 vCPUs / 16 Gb
@@ -611,20 +554,6 @@ profile::jenkinscontroller::jcasc:
             labels:
               - ubuntu-22-amd64-highmem-maven21
               # Labels indicating it is the default VM template for high mem x86_64
-              ## Spot is not enabled (yet?) in AWS account
-              - ubuntu-22-amd64-highmem-nonspot-maven21
-            spot: false
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
-            maxInstances: 50
-            instanceType: M6a2xlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-21
-            labels:
-              - spot-ubuntu-22-amd64-highmem-maven21
               - ubuntu-22-amd64-highmem-spot-maven21
               - spot
             spot: true

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -433,8 +433,8 @@ profile::jenkinscontroller::jcasc:
               - ubuntu-22-amd64-maven17
               # Labels indicating it is the default VM template
               - ubuntu
-              - java
               - linux
+              - java
               - docker
               - linux-amd64
             spot: false
@@ -451,7 +451,10 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-17
             labels:
               - ubuntu-22-amd64-maven17
+              - ubuntu
               - linux
+              - java
+              - docker
               - spot
             spot: true
             acpServerId: aws-internal

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -412,9 +412,10 @@ profile::jenkinscontroller::jcasc:
             os_version: "22.04"
             ebsOptimized: true
             architecture: "amd64"
-            javaHome: /opt/jdk-11
+            javaHome: /opt/jdk-8
             labels:
-              - ubuntu-22-amd64-maven11-spot
+              - spot-ubuntu-22-amd64-maven8
+              - spot
             spot: true
             acpServerId: aws-internal
           - description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
@@ -428,6 +429,19 @@ profile::jenkinscontroller::jcasc:
             labels:
               - ubuntu-22-amd64-maven11
             spot: false
+            acpServerId: aws-internal
+          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
+            maxInstances: 50
+            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            os_version: "22.04"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: /opt/jdk-11
+            labels:
+              - spot-ubuntu-22-amd64-maven11
+              - spot
+            spot: true
             acpServerId: aws-internal
           - description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
             maxInstances: 50
@@ -447,6 +461,19 @@ profile::jenkinscontroller::jcasc:
               - linux-amd64
             spot: false
             acpServerId: aws-internal
+          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
+            maxInstances: 50
+            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            os_version: "22.04"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: /opt/jdk-17
+            labels:
+              - spot-ubuntu-22-amd64-maven17
+              - spot
+            spot: true
+            acpServerId: aws-internal
           - description: "Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
             maxInstances: 50
             instanceType: M6aXlarge # 4 vCPUs / 16 Gb
@@ -458,6 +485,19 @@ profile::jenkinscontroller::jcasc:
             labels:
               - ubuntu-22-amd64-maven21
             spot: false
+            acpServerId: aws-internal
+          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
+            maxInstances: 50
+            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            os_version: "22.04"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: /opt/jdk-21
+            labels:
+              - spot-ubuntu-22-amd64-maven21
+              - spot
+            spot: true
             acpServerId: aws-internal
           ####
           # arm64 Linux VMs
@@ -477,6 +517,19 @@ profile::jenkinscontroller::jcasc:
               - linux-arm64
             spot: false
             acpServerId: aws-internal
+          - description: "Spot Ubuntu 22.04 LTS arm64 with JDK17 set as default java CLI"
+            maxInstances: 50
+            instanceType: T4gXlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            os_version: "22.04"
+            ebsOptimized: true
+            architecture: "arm64"
+            javaHome: /opt/jdk-17
+            labels:
+              - spot-ubuntu-22-arm64-maven17
+              - spot
+            spot: true
+            acpServerId: aws-internal
           - description: "Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
             maxInstances: 50
             instanceType: T4gXlarge # 4 vCPUs / 16 Gb
@@ -488,6 +541,19 @@ profile::jenkinscontroller::jcasc:
             labels:
               - ubuntu-22-arm64-maven21
             spot: false
+            acpServerId: aws-internal
+          - description: "Spot Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
+            maxInstances: 50
+            instanceType: T4gXlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            os_version: "22.04"
+            ebsOptimized: true
+            architecture: "arm64"
+            javaHome: /opt/jdk-21
+            labels:
+              - spot-ubuntu-22-arm64-maven21
+              - spot
+            spot: true
             acpServerId: aws-internal
           ####
           # High Memory Linux VMs (ATH mostly)
@@ -514,6 +580,24 @@ profile::jenkinscontroller::jcasc:
               - linux-amd64-big-nonspot
             spot: false
             acpServerId: aws-internal
+          - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK17 set as default java CLI"
+            maxInstances: 50
+            instanceType: M6a2xlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            os_version: "22.04"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: /opt/jdk-17
+            labels:
+              - spot-ubuntu-22-amd64-highmem-maven17
+              - ubuntu-22-amd64-highmem-spot-maven17
+              - highmem-spot
+              - highram-spot
+              - docker-highmem-spot
+              - linux-amd64-big-spot
+              - spot
+            spot: true
+            acpServerId: aws-internal
           - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
             maxInstances: 50
             instanceType: M6a2xlarge # 4 vCPUs / 16 Gb
@@ -528,6 +612,20 @@ profile::jenkinscontroller::jcasc:
               ## Spot is not enabled (yet?) in AWS account
               - ubuntu-22-amd64-highmem-nonspot-maven21
             spot: false
+            acpServerId: aws-internal
+          - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
+            maxInstances: 50
+            instanceType: M6a2xlarge # 4 vCPUs / 16 Gb
+            os: "ubuntu"
+            os_version: "22.04"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: /opt/jdk-21
+            labels:
+              - spot-ubuntu-22-amd64-highmem-maven21
+              - ubuntu-22-amd64-highmem-spot-maven21
+              - spot
+            spot: true
             acpServerId: aws-internal
           ####
           # Windows VMs

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -428,7 +428,6 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: /opt/jdk-17
             labels:
-              - nonspot
               - ubuntu-22-amd64-maven17-nonspot
             spot: false
             acpServerId: aws-internal

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -471,6 +471,7 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-17
             labels:
               - spot-ubuntu-22-amd64-maven17
+              - linux
               - spot
             spot: true
             acpServerId: aws-internal
@@ -527,6 +528,7 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-17
             labels:
               - spot-ubuntu-22-arm64-maven17
+              - linux-arm64
               - spot
             spot: true
             acpServerId: aws-internal

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -403,7 +403,6 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-8
             labels:
               - ubuntu-22-amd64-maven8
-              - spot
             spot: true
             acpServerId: aws-internal
           - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
@@ -416,7 +415,6 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-11
             labels:
               - ubuntu-22-amd64-maven11
-              - spot
             spot: true
             acpServerId: aws-internal
           ####
@@ -430,13 +428,8 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: /opt/jdk-17
             labels:
-              - ubuntu-22-amd64-maven17
-              # Labels indicating it is the default VM template
-              - ubuntu
-              - linux
-              - java
-              - docker
-              - linux-amd64
+              - nonspot
+              - ubuntu-22-amd64-maven17-nonspot
             spot: false
             acpServerId: aws-internal
           ####
@@ -455,7 +448,6 @@ profile::jenkinscontroller::jcasc:
               - linux
               - java
               - docker
-              - spot
             spot: true
             acpServerId: aws-internal
           - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
@@ -468,7 +460,6 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-21
             labels:
               - ubuntu-22-amd64-maven21
-              - spot
             spot: true
             acpServerId: aws-internal
           ####
@@ -487,7 +478,6 @@ profile::jenkinscontroller::jcasc:
               - arm64docker
               - arm64linux
               - linux-arm64
-              - spot
             spot: true
             acpServerId: aws-internal
           - description: "Spot Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
@@ -500,7 +490,6 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-21
             labels:
               - ubuntu-22-arm64-maven21
-              - spot
             spot: true
             acpServerId: aws-internal
           ####
@@ -514,17 +503,8 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: /opt/jdk-17
             labels:
-              - ubuntu-22-amd64-highmem-maven17
-              # Labels indicating it is the default VM template for high mem x86_64
-              - highmem
-              - highram
-              - docker-highmem
-              - linux-amd64-big
-              - ubuntu-22-amd64-highmem-nonspot-maven17
-              - highmem-nonspot
-              - highram-nonspot
               - docker-highmem-nonspot
-              - linux-amd64-big-nonspot
+              - ubuntu-22-amd64-highmem-maven17-nonspot
             spot: false
             acpServerId: aws-internal
           # High Memory SPOT Linux VMs (ATH mostly)
@@ -537,13 +517,13 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: /opt/jdk-17
             labels:
-              - spot-ubuntu-22-amd64-highmem-maven17
-              - ubuntu-22-amd64-highmem-spot-maven17
-              - highmem-spot
-              - highram-spot
-              - docker-highmem-spot
-              - linux-amd64-big-spot
-              - spot
+              - docker-highmem
+              - ubuntu-22-amd64-highmem-maven17
+              # Labels indicating it is the default VM template for high mem x86_64
+              - highmem
+              - highram
+              - docker-highmem
+              - linux-amd64-big
             spot: true
             acpServerId: aws-internal
           - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
@@ -556,9 +536,6 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-21
             labels:
               - ubuntu-22-amd64-highmem-maven21
-              # Labels indicating it is the default VM template for high mem x86_64
-              - ubuntu-22-amd64-highmem-spot-maven21
-              - spot
             spot: true
             acpServerId: aws-internal
           ####


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4598

duplicate vm agent on ec2 as spot instances with specific labels: only those used by buildplugin(), jenkinsci/docker-*, jenkins/core, ATH will exist as non-spot and spot instances.
All the other will be spot only to save cash