### PR TITLE
feat(ci.jenkins.io): change type for ubuntu machines

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -495,7 +495,7 @@ profile::jenkinscontroller::jcasc:
           # High Memory Linux VMs (ATH mostly)
           - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK17 set as default java CLI"
             maxInstances: 50
-            instanceType: M5dn2xlarge # 4 vCPUs / 32 Gb / nvme 300Go
+            instanceType: M5dn2xlarge # 8 vCPUs / 32 Gb / nvme 300Go
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -509,7 +509,7 @@ profile::jenkinscontroller::jcasc:
           # High Memory SPOT Linux VMs (ATH mostly)
           - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK17 set as default java CLI"
             maxInstances: 50
-            instanceType: M5dn2xlarge # 4 vCPUs / 32 Gb / nvme 300Go
+            instanceType: M5dn2xlarge # 8 vCPUs / 32 Gb / nvme 300Go
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -527,7 +527,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
             maxInstances: 50
-            instanceType: M5dn2xlarge # 4 vCPUs / 32 Gb / nvme 300Go
+            instanceType: M5dn2xlarge # 8 vCPUs / 32 Gb / nvme 300Go
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -525,7 +525,7 @@ profile::jenkinscontroller::jcasc:
               - linux-amd64-big
             spot: true
             acpServerId: aws-internal
-          - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
+          - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
             maxInstances: 50
             instanceType: M5dn2xlarge # 8 vCPUs / 32 Gb / nvme 300Go
             os: "ubuntu"

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -395,7 +395,7 @@ profile::jenkinscontroller::jcasc:
           # x86_64 Linux VMs
           - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK8 set as default java CLI"
             maxInstances: 50
-            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
+            instanceType: M5dnXlarge # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -407,7 +407,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
             maxInstances: 50
-            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
+            instanceType: M5dnXlarge # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -421,7 +421,7 @@ profile::jenkinscontroller::jcasc:
           # Linux VMs jdk17 (default non-spot version for buildPlugin() / docker-*)
           - description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
             maxInstances: 50
-            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
+            instanceType: M5dnXlarge # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -435,7 +435,7 @@ profile::jenkinscontroller::jcasc:
           # Linux VMs jdk17 (default spot version for buildPlugin() / docker-*)
           - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
             maxInstances: 50
-            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
+            instanceType: M5dnXlarge # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -451,7 +451,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
             maxInstances: 50
-            instanceType: M6aXlarge # 4 vCPUs / 16 Gb
+            instanceType: M5dnXlarge # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -495,7 +495,7 @@ profile::jenkinscontroller::jcasc:
           # High Memory Linux VMs (ATH mostly)
           - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK17 set as default java CLI"
             maxInstances: 50
-            instanceType: M6a2xlarge # 4 vCPUs / 16 Gb
+            instanceType: M5dn2xlarge # 4 vCPUs / 32 Gb / nvme 300Go
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -509,7 +509,7 @@ profile::jenkinscontroller::jcasc:
           # High Memory SPOT Linux VMs (ATH mostly)
           - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK17 set as default java CLI"
             maxInstances: 50
-            instanceType: M6a2xlarge # 4 vCPUs / 16 Gb
+            instanceType: M5dn2xlarge # 4 vCPUs / 32 Gb / nvme 300Go
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -527,7 +527,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
             maxInstances: 50
-            instanceType: M6a2xlarge # 4 vCPUs / 16 Gb
+            instanceType: M5dn2xlarge # 4 vCPUs / 32 Gb / nvme 300Go
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4598 and https://github.com/jenkins-infra/helpdesk/issues/4597
we change to spot instance that are less interrupt as spot AND got a nvme disk : 

from  `m6a.xlarge`
```
ON-DEMAND
Instance name On-Demand  hourly rate vCPU Memory Storage     Network performance 
m6a.xlarge       $0.1728.      4.       16 GiB.   EBS Only.  Up to 12500 Megabit

SPOT
Instance Type  Linux/UNIX Usage Windows Usage   Instance Family
m6a.xlarge	     $0.0732	                $0.2013	             General Purpose - Current Generation

Instance Type vCPU Memory GiB Savings over On-Demand Frequency of interruption
m6a.xlarge	     4	    16	            59%	                                5-10%
```

to `M5dnXlarge`
```
ON-DEMAND
Instance name On-Demand  hourly rate vCPU Memory  Storage                      Network performance 
m5dn.xlarge.    $0.272                             4        16 GiB     1 x 150 NVMe SSD    Up to 25 Gigabit

SPOT
Instance Type  Linux/UNIX Usage Windows Usage   Instance Family
m5dn.xlarge	$0.0859	                $0.2112	             General Purpose - Current Generation

Instance Type vCPU Memory GiB Savings over On-Demand Frequency of interruption
m5dn.xlarge	4	16	64%	\<5%
```

same for the `m6a.2xlarge` to `M5dn2xlarge`
```
Instance Type vCPU Memory GiB Savings over On-Demand Frequency of interruption
m6a.2xlarge	8	32	52%	15-20%

Instance name On-Demand hourly rate vCPU Memory Storage    Network performance
m6a.2xlarge     $0.3456                            8       32 GiB.   EBS Only. Up to 12500 Megabit

Instance Type  vCPU. Memory GiB. Savings over On-Demand. Frequency of interruption
m5dn.2xlarge	 8	     32	            56%	                                <5%

Instance name On-Demand hourly rate vCPU Memory Storage                      Network performance
m5dn.2xlarge   $0.544                             8.        32 GiB.  1 x 300 NVMe SSD.   Up to 25 Gigabit
```