### PR TITLE
feat(jenkins-controllers): adding an automatic label for spot and nonspot agents

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -345,7 +345,7 @@ jenkins:
         instanceCapStr: "<%= agent['maxInstances'] %>"
         javaPath: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][$os]['agentJavaBin'] %>"
         jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] %>"
-        labelString: "<%= $os + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['labels'].join(' ') %>"
+        labelString: "<%= $os + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['spot'] ? 'spot' : 'nonspot' %> <%= agent['labels'].join(' ') %>"
         launchTimeoutStr: "1000"
         maxTotalUses: 1 # Throw away the VMs after a build: ephemeral machines
         metadataEndpointEnabled: true

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -471,7 +471,7 @@ profile::jenkinscontroller::jcasc:
   artifacts_manager:
     type: s3
     region: us-east-2
-    storage_name: SuperBucketName
+    storage_name: superbucketname
   datadog:
     host: "vagrant.local"
     targetHost: "172.18.0.1" # docker0 interface in vagrant is non standard (because docker in docker)


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4598

setting an automated label to use within shared pipeline library