### PR TITLE
chore(jenkinsfile_updatecli): Use current node execution context for `jenkins-infra`

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,6 +1,5 @@
-final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
+final String cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 
-// Set pipeline options at the beginning
 properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
     disableConcurrentBuilds(abortPrevious: true),

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -12,11 +12,8 @@ if (cronExpr) {
 node('linux-amd64-docker') {
     timeout(time: 30, unit: 'MINUTES') {
         withCredentials([
-            aws(
-                credentialsId: 'packer-aws-access-key-id', // Needed for aws login
-                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
-                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
-            ),
+            string(credentialsId: 'updatecli-aws-access-key-id', variable: 'AWS_ACCESS_KEY_ID'), // Needed for AWS login
+            string(credentialsId: 'updatecli-aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY'),
             usernamePassword(
                 credentialsId: 'github-app-updatecli-on-jenkins-infra',
                 usernameVariable: 'USERNAME_VALUE', // Mandatory even if not used for GitHub App auth

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -25,12 +25,14 @@ node('linux-amd64-docker') {
                 properties([pipelineTriggers([cron('@daily')])])
                 updatecli(
                     action: 'apply',
-                    config: './updatecli/weekly.d'
+                    config: './updatecli/weekly.d',
+                    runInCurrentAgent: true
                   )
             } else {
                 updatecli(
                     action: 'diff',
-                    config: './updatecli/weekly.d'
+                    config: './updatecli/weekly.d',
+                    runInCurrentAgent: true
                   )
             }
         }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -3,11 +3,9 @@ def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 // Set pipeline options at the beginning
 properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
-    disableConcurrentBuilds(abortPrevious: true)
-])
-if (cronExpr) {
+    disableConcurrentBuilds(abortPrevious: true),
     properties([pipelineTriggers([cron(cronExpr)])])
-}
+])
 
 node('linux-amd64-docker') {
     timeout(time: 30, unit: 'MINUTES') {

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -23,9 +23,15 @@ node('linux-amd64-docker') {
             if (env.BRANCH_IS_PRIMARY) {
                 // Only trigger a daily check on the principal branch
                 properties([pipelineTriggers([cron('@daily')])])
-                updatecli(action: 'apply')
+                updatecli(
+                    action: 'apply',
+                    config: './updatecli/weekly.d'
+                  )
             } else {
-                updatecli(action: 'diff')
+                updatecli(
+                    action: 'diff',
+                    config: './updatecli/weekly.d'
+                  )
             }
         }
     }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -12,7 +12,11 @@ if (cronExpr) {
 node('linux-amd64-docker') {
     timeout(time: 30, unit: 'MINUTES') {
         withCredentials([
-            aws(credentialsId: 'packer-aws-access-key-id'), // needed for aws login
+            aws(
+                credentialsId: 'packer-aws-access-key-id', // Needed for aws login
+                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+            ),
             usernamePassword(
                 credentialsId: 'github-app-updatecli-on-jenkins-infra',
                 usernameVariable: 'USERNAME_VALUE', // Mandatory even if not used for GitHub App auth

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,4 +1,4 @@
-def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
+final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
 
 // Set pipeline options at the beginning
 properties([
@@ -18,21 +18,12 @@ node('linux-amd64-docker') {
                 passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
             )
         ]) {
-            if (env.BRANCH_IS_PRIMARY) {
-                // Only trigger a daily check on the principal branch
-                properties([pipelineTriggers([cron('@daily')])])
-                updatecli(
-                    action: 'apply',
-                    config: './updatecli/weekly.d',
-                    runInCurrentAgent: true
-                  )
-            } else {
-                updatecli(
-                    action: 'diff',
-                    config: './updatecli/weekly.d',
-                    runInCurrentAgent: true
-                  )
-            }
+            final String updatecliAction = env.BRANCH_IS_PRIMARY ? 'apply' : 'diff'
+            updatecli(
+              action: updatecliAction,
+              config: './updatecli/weekly.d',
+              runInCurrentAgent: true
+            )
         }
     }
 }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -12,8 +12,8 @@ if (cronExpr) {
 node('linux-amd64-docker') {
     timeout(time: 30, unit: 'MINUTES') {
         withCredentials([
-            string(credentialsId: 'updatecli-aws-access-key-id', variable: 'AWS_ACCESS_KEY_ID'), // Needed for AWS login
-            string(credentialsId: 'updatecli-aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY'),
+            string(credentialsId: 'packer-aws-access-key-id', variable: 'AWS_ACCESS_KEY_ID'), // Needed for AWS login
+            string(credentialsId: 'packer-aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY'),
             usernamePassword(
                 credentialsId: 'github-app-updatecli-on-jenkins-infra',
                 usernameVariable: 'USERNAME_VALUE', // Mandatory even if not used for GitHub App auth

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,35 +1,31 @@
+def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
+
+// Set pipeline options at the beginning
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '10')),
+    disableConcurrentBuilds(abortPrevious: true)
+])
+if (cronExpr) {
+    properties([pipelineTriggers([cron(cronExpr)])])
+}
+
 node('linux-amd64-docker') {
-    // Set build options and triggers (if required, you can use properties() here)
-    def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
-    // For scripted pipelines, you can set properties as needed:
-    properties([
-        buildDiscarder(logRotator(numToKeepStr: '10')),
-        timeout(time: 30, unit: 'MINUTES'),
-        disableConcurrentBuilds(abortPrevious: true)
-    ])
-    if (cronExpr) {
-        properties([pipelineTriggers([cron(cronExpr)])])
-    }
-
-    // Set AWS environment variables (or any other required ones)
-    // env.AWS_DEFAULT_REGION = 'us-east-2'
-
-    // Use a single withCredentials block to wrap all updatecli calls
-    withCredentials([
-        string(credentialsId: 'packer-aws-access-key-id', variable: 'AWS_ACCESS_KEY_ID'),
-        string(credentialsId: 'packer-aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY'),
-        usernamePassword(
-            credentialsId: 'github-app-updatecli-on-jenkins-infra',
-            usernameVariable: 'USERNAME_VALUE', // Mandatory even if not used for GitHub App auth
-            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
-        )
-    ]) {
-        if (env.BRANCH_IS_PRIMARY) {
-            // Only trigger a daily check on the principal branch
-            properties([pipelineTriggers([cron('@daily')])])
-            updatecli(action: 'apply')
-        } else {
-            updatecli(action: 'diff')
+    timeout(time: 30, unit: 'MINUTES') {
+        withCredentials([
+            aws(credentialsId: 'packer-aws-access-key-id'), // needed for aws login
+            usernamePassword(
+                credentialsId: 'github-app-updatecli-on-jenkins-infra',
+                usernameVariable: 'USERNAME_VALUE', // Mandatory even if not used for GitHub App auth
+                passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
+            )
+        ]) {
+            if (env.BRANCH_IS_PRIMARY) {
+                // Only trigger a daily check on the principal branch
+                properties([pipelineTriggers([cron('@daily')])])
+                updatecli(action: 'apply')
+            } else {
+                updatecli(action: 'diff')
+            }
         }
     }
 }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -4,7 +4,7 @@ final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
 properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
     disableConcurrentBuilds(abortPrevious: true),
-    properties([pipelineTriggers([cron(cronExpr)])])
+    pipelineTriggers([cron(cronExpr)]),
 ])
 
 node('linux-amd64-docker') {

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,60 +1,35 @@
-def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
-
-pipeline {
-  // `docker` and `updatecli` are required
-  agent { label 'linux-amd64-docker' }
-
-  options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
-    timeout(time: 30, unit: 'MINUTES')
-    disableConcurrentBuilds(abortPrevious: true)
-  }
-
-  triggers {
-    cron (cronExpr)
-  }
-
-  environment {
-    AWS_ACCESS_KEY_ID     = credentials('packer-aws-access-key-id')
-    AWS_SECRET_ACCESS_KEY = credentials('packer-aws-secret-access-key')
-    AWS_DEFAULT_REGION    = 'us-east-2'
-  }
-  stages {
-    stage('Check Configuration Update') {
-      when {
-        expression { not { env.BRANCH_IS_PRIMARY } }
-      }
-      // Run updatecli's diff on both push and pull requests (in case a configuration change breaks updatecli)
-      steps {
-        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-          withCredentials([
-            usernamePassword(
-            credentialsId: 'github-app-updatecli-on-jenkins-infra',
-            usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
-            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
-            )
-          ]) {
-            sh 'updatecli version'
-            sh 'updatecli diff --config ./updatecli/weekly.d --values ./updatecli/values.yaml'
-          }
-        }
-      }
-    } // stage
-    stage('Apply Configuration Update') {
-      when {
-        expression { env.BRANCH_IS_PRIMARY }
-      }
-      steps {
-          withCredentials([
-            usernamePassword(
-            credentialsId: 'github-app-updatecli-on-jenkins-infra',
-            usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
-            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
-            )
-          ]) {
-            sh 'updatecli apply --config ./updatecli/weekly.d --values ./updatecli/values.yaml'
-          }
-      }
+node('linux-amd64-docker') {
+    // Set build options and triggers (if required, you can use properties() here)
+    def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
+    // For scripted pipelines, you can set properties as needed:
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '10')),
+        timeout(time: 30, unit: 'MINUTES'),
+        disableConcurrentBuilds(abortPrevious: true)
+    ])
+    if (cronExpr) {
+        properties([pipelineTriggers([cron(cronExpr)])])
     }
-  }
+
+    // Set AWS environment variables (or any other required ones)
+    // env.AWS_DEFAULT_REGION = 'us-east-2'
+
+    // Use a single withCredentials block to wrap all updatecli calls
+    withCredentials([
+        string(credentialsId: 'packer-aws-access-key-id', variable: 'AWS_ACCESS_KEY_ID'),
+        string(credentialsId: 'packer-aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY'),
+        usernamePassword(
+            credentialsId: 'github-app-updatecli-on-jenkins-infra',
+            usernameVariable: 'USERNAME_VALUE', // Mandatory even if not used for GitHub App auth
+            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
+        )
+    ]) {
+        if (env.BRANCH_IS_PRIMARY) {
+            // Only trigger a daily check on the principal branch
+            properties([pipelineTriggers([cron('@daily')])])
+            updatecli(action: 'apply')
+        } else {
+            updatecli(action: 'diff')
+        }
+    }
 }


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/4539#issuecomment-2740495511

We now use scripted pipeline syntax