### PR TITLE
feat(pkg) stop copying Update Center metadatas to get.jenkins.io and OSUOSL mirrors

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -362,6 +362,7 @@ class profile::jenkinscontroller (
   docker::run { $docker_container_name:
     memory_limit     => $memory_limit,
     image            => "${docker_image}:${docker_tag}",
+    # TODO: cleanup after UC move to Azure + Cloudflare (remove the add-host)
     # This is a "clever" hack to force the init script to pass the numeric UID
     # through on `docker run`. Since passing the string 'jenkins' doesn't
     # actually map the UIDs properly. Using the extra_parameters option because

--- a/dist/profile/manifests/usage.pp
+++ b/dist/profile/manifests/usage.pp
@@ -2,7 +2,7 @@
 # Profile to provision the necessary "usage" host setup
 #
 # A "usage" host is one that will receive anonymized and encrypted usage data
-# from active and cnofigured Jenkins installations around the world.
+# from active and configured Jenkins installations around the world.
 #
 # This usage information is then processed and ultimately finds its way into
 # our "census" data

--- a/dist/profile/templates/mirror-scripts/sync-recent-releases.sh.erb
+++ b/dist/profile/templates/mirror-scripts/sync-recent-releases.sh.erb
@@ -46,7 +46,7 @@ while IFS= read -r release; do
     # Don't print any trace
     set +x
     ## azcopy breaks the while + read loop - https://github.com/Azure/azure-storage-azcopy/issues/974
-    ## so we ensure an empty stding is passed using the ':|' form
+    ## so we ensure an empty stdin is passed using the ':|' form
     : | azcopy copy \
         --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
         --recursive `# Source directory contains at least one subdirectory` \

--- a/dist/profile/templates/mirror-scripts/sync.sh.erb
+++ b/dist/profile/templates/mirror-scripts/sync.sh.erb
@@ -1,19 +1,17 @@
 #!/bin/bash -xe
 HOST=<%= @osuosl_mirroring['username'] %>@<%= @osuosl_mirroring['host'] %>
 BASE_DIR="<%= @release_root %>"
-UPDATES_DIR="<%= @updates_docroot %>"
 RSYNC_ARGS="-rlpDvz"
 SCRIPT_DIR="${PWD}"
 FLAG="${1}"
 
-# This script can be run from a crontab where the PATH is stripped comapred to an interactive/login session
+# This script can be run from a crontab where the PATH is stripped compared to an interactive/login session
 export PATH="${HOME}"/.bin:/usr/local/bin:"${PATH}"
 
 pushd "${BASE_DIR}"
   time rsync "${RSYNC_ARGS}" --chown=jenkins --times --delete-during --delete-excluded --prune-empty-dirs --include-from=<(
     # keep all the plugins
     echo '+ plugins/**'
-    echo '+ updates/**'
     echo '+ art/**'
     echo '+ podcast/**'
     # I think this is a file we create on OSUOSL so dont let that be deleted
@@ -28,26 +26,6 @@ pushd "${BASE_DIR}"
     #shellcheck disable=SC2312
     cat "${SCRIPT_DIR}/rsync.filter"
   ) . "${HOST}:jenkins/"
-popd
-
-echo ">> Syncing the update center to our local mirror"
-
-pushd "${UPDATES_DIR}"
-    # Note: this used to exist in the old script, but we have these
-    # symbolic links in the destination tree, no need to copy them again
-    #
-    #rsync ${RSYNC_ARGS}  *.json* ${BASE_DIR}/updates
-    for uc_version in */update-center.json; do
-      echo ">> Syncing UC version ${uc_version}"
-      uc_version=$(dirname "${uc_version}")
-      rsync "${RSYNC_ARGS}" --chown=<%= @mirror_user %>:<%= @www_common_group %> "${uc_version}"/*.json* "${BASE_DIR}/updates/${uc_version}"
-    done;
-
-    # Ensure that our tool installers get synced
-    rsync "${RSYNC_ARGS}" --chown=<%= @mirror_user %>:<%= @www_common_group %> updates "${BASE_DIR}/updates/"
-
-    echo ">> Syncing UC to primarily OSUOSL mirror"
-    rsync "${RSYNC_ARGS}" --chown=jenkins --delete "${BASE_DIR}/updates/" "${HOST}:jenkins/updates"
 popd
 
 echo ">> Delivering bits to archives.jenkins.io (fallback of get.jenkins.io)"
@@ -90,29 +68,16 @@ if [[ "${FLAG}" = '--full-sync' ]]; then
   fileShareSignedUrl="$(get-fileshare-signed-url.sh)"
   echo ">>> retrieved the file share URL"
 
-  echo ">>> azcopy-ing the JSON files..."
+  echo ">>> azcopy-ing files to get.jenkins.io filesystem..."
   ## azcopy might break the stdin pipelining - https://github.com/Azure/azure-storage-azcopy/issues/974
-  ## so we ensure an empty stding is passed using the ':|' form
+  ## so we ensure an empty stdin is passed using the ':|' form
   : | azcopy copy \
     --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
     --recursive `# Source directory contains at least one subdirectory` \
     --overwrite=ifSourceNewer `# Only overwrite if source is more recent (time comparison)` \
     --log-level=ERROR `# Do not write too much logs (I/O...)` \
-    --include-pattern='*.json' `# First quick pass on the update center JSON files` \
     "${BASE_DIR}/*" "${fileShareSignedUrl}"
-  echo ">>> finished azcopy-ing the JSON files"
-
-  echo ">>> azcopy-ing all the other files..."
-  ## azcopy might break the stdin pipelining - https://github.com/Azure/azure-storage-azcopy/issues/974
-  ## so we ensure an empty stding is passed using the ':|' form
-  : | azcopy copy \
-    --skip-version-check `# Do not check for new azcopy versions (we have updatecli + puppet for this)` \
-    --recursive `# Source directory contains at least one subdirectory` \
-    --overwrite=ifSourceNewer `# Only overwrite if source is more recent (time comparison)` \
-    --log-level=ERROR `# Do not write too much logs (I/O...)` \
-    --exclude-pattern='*.json' `# Second pass with all files except update center JSON files` \
-    "${BASE_DIR}/*" "${fileShareSignedUrl}"
-  echo ">>> finished azcopy-ing all the other files"
+  echo ">>> finished azcopy-ing files to get.jenkins.io filesystem"
 
   # Back to debug mode
   set -x


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4610

Following #3991, there are still some leftovers which we want to remove otherwise the `sync.sh script will fail.