### PR TITLE
feat(ci.jenkins.io): remove docker json conf for windows agents

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -462,14 +462,6 @@ jenkins:
                 (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: <%= @jcasc['datadog_api_key'] %>' | Set-Content C:\ProgramData\Datadog\datadog.yaml
                 & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart-service
 
-                ## Setup Docker Engine
-                @'
-                {
-                  "insecure-registries": ["<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>"],
-                  "registry-mirrors": ["http://<%= agent['registryMirror'] ? agent['registryMirror'] : ec2_cloud_setup['registryMirror'] %>"]
-                }
-                '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
-                Restart-Service docker
           <%- if agent['launcher'] && agent['launcher'] == "winrm" -%>
                 ## Setup WinRM
                 # Remove existing listeners


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4584

windows agent doesn't need this conf, windows layer are too big for our transparent proxy and as it's not using the hub.docker it's not usefull for ratelimit