### PR TITLE
feat(ci.jenkins.io) restart docker engine on windows after NVMe mount

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -499,6 +499,9 @@ jenkins:
                 cmd.exe /c net stop winrm
           <%- end -%>
 
+                # Restart docker engine
+                Restart-Service docker
+
                 # Ensure Jenkins controller does not start the agent in process in its workspace until we are ready
                 Start-Service sshd
 


### PR DESCRIPTION
following #3996 and #3998 we still need a restart of docker after NVMe mount