### PR TITLE
feat(ci.jenkins.io): windows agent new mount point on Z for NVMe

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -436,23 +436,21 @@ jenkins:
                   0 {Write-Output "No RAW disk found."}
                   1 {
                       Write-Output "1 disk found."
-                      New-Item -ItemType Directory -Path "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>"
                       $Disks | Initialize-Disk -PartitionStyle MBR
                       $Disks | New-Partition -UseMaximumSize -MbrType IFS
                       $Partition = Get-Partition -DiskNumber $Disks.Number
                       $Partition | Format-Volume -FileSystem NTFS -Confirm:$false
-                      $Partition | Add-PartitionAccessPath -AccessPath "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>"
+                      $Partition | Add-PartitionAccessPath -AccessPath "Z:"
                       Get-WmiObject Win32_Volume | Format-Table Name, Label, FreeSpace, Capacity
                   }
                   default {
                       Write-Output "$nb.Count disks found."
-                      New-Item -ItemType Directory -Path "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>"
                       $Disks | ForEach-Object -Begin {Get-Date} -Process {
                               Initialize-Disk -PartitionStyle MBR -PassThru -DiskNumber $_.Number
                               New-Partition -UseMaximumSize -MbrType IFS
                               $Partition = Get-Partition -DiskNumber $_.Number
                               $Partition | Format-Volume -FileSystem NTFS -Confirm:$false
-                              $Partition | Add-PartitionAccessPath -AccessPath "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>"
+                              $Partition | Add-PartitionAccessPath -AccessPath "Z:"
                           } -End {Get-Date}
                       Get-WmiObject Win32_Volume | Format-Table Name, Label, FreeSpace, Capacity
                   }
@@ -498,6 +496,13 @@ jenkins:
                 Remove-Item -Path WSMan:\Localhost\listener\listener* -Recurse
                 cmd.exe /c net stop winrm
           <%- end -%>
+
+                ## Setup Docker Engine
+                @'
+                {
+                  "data-root": "Z:/docker"
+                }
+                '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
 
                 # Restart docker engine
                 Restart-Service docker

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -464,6 +464,7 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-8'
+            agentDir: 'Z:/jenkins'
             labels:
               - win-2019-amd64-maven-8
               - maven-8-windows
@@ -479,6 +480,7 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-11'
+            agentDir: 'Z:/jenkins'
             labels:
               - win-2019-amd64-maven-11
               - maven-11-windows
@@ -492,6 +494,7 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-17'
+            agentDir: 'Z:/jenkins'
             labels:
               - win-2019-amd64-maven-17
               # Labels indicating it is the default VM template for Windows 2019 and Windows
@@ -509,6 +512,7 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-17'
+            agentDir: 'Z:/jenkins'
             labels:
               - win-2019-amd64-maven-17-nonspot
             spot: false
@@ -521,6 +525,7 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
+            agentDir: 'Z:/jenkins'
             labels:
               - win-2019-amd64-maven-21
               - maven-21-windows
@@ -534,6 +539,7 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
+            agentDir: 'Z:/jenkins'
             labels:
               - smerle
             spot: true
@@ -546,6 +552,7 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-17'
+            agentDir: 'Z:/jenkins'
             labels:
               - win-2022-amd64-maven-11
               # Labels indicating it is the default VM template for Windows 2022 (but not windows)

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -155,6 +155,7 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
+            agentDir: 'Z:/jenkins'
             labels:
               - docker-windows
               - docker-windows-2019
@@ -168,6 +169,7 @@ profile::jenkinscontroller::jcasc:
             os_version: "2022"
             ebsOptimized: true
             architecture: "amd64"
+            agentDir: 'Z:/jenkins'
             labels:
               - docker-windows-2022
               - win-2022


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4612
we discovered that docker is not able to use folder mounted volume, so we are now using Z: 
and set this as the AgentDir (Remote Fs)