### PR TITLE
fix(archives) fix apache vhosts to ensure apache logs rotation and use proper mime type for HPI files

### DIFF
--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -16,6 +16,12 @@ class profile::archives (
   $apache_owner     = 'www-data'
   $apache_group     = $apache_owner
 
+  $archives_fqdn = 'archives.jenkins.io'
+  $archives_legacy_fqdn = 'archives.jenkins-ci.org'
+
+  $apache_log_dir_fqdn = "/var/log/apache2/${archives_fqdn}"
+  $apache_log_dir_legacy_fqdn = "/var/log/apache2/${archives_legacy_fqdn}"
+
   ## Manage mirrorsync user and its home directory
   #
   user { 'mirrorsync':
@@ -77,105 +83,115 @@ class profile::archives (
     ensure => present,
   }
 
-  file { $archives_dir:
-    ensure  => directory,
-    owner   => $apache_owner,
-    group   => $apache_group,
-    mode    => '0775',
-    require => Package['httpd'],
-  }
-
-  file { '/var/log/apache2/archives.jenkins-ci.org':
-    ensure => directory,
-    owner  => $apache_owner,
-    group  => $apache_group,
-  }
-
-  file { '/var/log/apache2/archives.jenkins.io':
-    ensure => directory,
-    owner  => $apache_owner,
-    group  => $apache_group,
+  # Create apache dirs
+  [$archives_dir, $apache_log_dir_fqdn,$apache_log_dir_legacy_fqdn].each |String $dir| {
+    file { $dir:
+      ensure  => directory,
+      owner   => $apache_owner,
+      group   => $apache_group,
+      mode    => '0775',
+      require => Package['httpd'],
+    }
   }
 
   apache::mod { 'bw':
     require => Package['libapache2-mod-bw'],
   }
 
-  apache::vhost { 'archives.jenkins-ci.org unsecure':
-    servername                   => 'archives.jenkins-ci.org',
+  apache::vhost { "${archives_legacy_fqdn} unsecure":
+    servername                   => $archives_legacy_fqdn,
     use_servername_for_filenames => true,
     use_port_for_filenames       => true,
     vhost_name                   => '*',
     port                         => 80,
     docroot                      => $archives_dir,
-    access_log                   => false,
-    error_log_file               => 'archives.jenkins-ci.org/error.log',
-    log_level                    => 'warn',
-    custom_fragment              => template("${module_name}/archives/vhost.conf"),
+
+    access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_legacy_fqdn}/access_unsecured.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_legacy_fqdn}/error_unsecured.log.%Y%m%d%H%M%S 604800",
+
+    redirect_status              => 'permanent',
+    redirect_dest                => "https://${archives_legacy_fqdn}/",
+
     options                      => ['FollowSymLinks', 'MultiViews', 'Indexes'],
     notify                       => Service['apache2'],
-    require                      => [File['/var/log/apache2/archives.jenkins-ci.org'],
+    require                      => [
+      File[$apache_log_dir_legacy_fqdn],
       File[$archives_dir],
-    Apache::Mod['bw']],
+      Apache::Mod['bw']
+    ],
   }
 
-  apache::vhost { 'archives.jenkins-ci.org':
-    servername                   => 'archives.jenkins-ci.org',
+  apache::vhost { $archives_legacy_fqdn:
+    servername                   => $archives_legacy_fqdn,
     use_servername_for_filenames => true,
     use_port_for_filenames       => true,
     port                         => 443,
     ssl                          => true,
     docroot                      => $archives_dir,
-    access_log                   => false,
-    error_log_file               => 'archives.jenkins-ci.org/error.log',
-    log_level                    => 'warn',
-    custom_fragment              => template("${module_name}/archives/vhost.conf"),
+
+    access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_legacy_fqdn}/access.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_legacy_fqdn}/error.log.%Y%m%d%H%M%S 604800",
 
     notify                       => Service['apache2'],
-    require                      => File['/var/log/apache2/archives.jenkins-ci.org'],
+    require                      => [
+      File[$apache_log_dir_legacy_fqdn],
+      File[$archives_dir],
+      Apache::Mod['bw']
+    ],
   }
 
-  apache::vhost { 'archives.jenkins.io unsecured':
+  apache::vhost { "${archives_fqdn} unsecured":
     # redirect non-SSL to SSL
-    servername                   => 'archives.jenkins.io',
+    servername                   => $archives_fqdn,
     use_servername_for_filenames => true,
     use_port_for_filenames       => true,
     port                         => 80,
     docroot                      => $archives_dir,
-    redirect_status              => 'temp',
-    redirect_dest                => 'https://archives.jenkins.io/',
+
+    access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_fqdn}/access_unsecured.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_fqdn}/error_unsecured.log.%Y%m%d%H%M%S 604800",
+
+    redirect_status              => 'permanent',
+    redirect_dest                => "https://${archives_fqdn}/",
+    require                      => [
+      File[$apache_log_dir_fqdn],
+      File[$archives_dir],
+      Apache::Mod['bw']
+    ],
   }
 
-  apache::vhost { 'archives.jenkins.io':
-    servername                   => 'archives.jenkins.io',
+  apache::vhost { $archives_fqdn:
+    servername                   => $archives_fqdn,
     use_servername_for_filenames => true,
     use_port_for_filenames       => true,
     port                         => 443,
     ssl                          => true,
     docroot                      => $archives_dir,
-    access_log                   => false,
-    error_log_file               => 'archives.jenkins.io/error.log',
-    log_level                    => 'warn',
-    custom_fragment              => template("${module_name}/archives/vhost.conf"),
+
+    access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_fqdn}/access.log.%Y%m%d%H%M%S 604800",
+    error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_fqdn}/error.log.%Y%m%d%H%M%S 604800",
 
     notify                       => Service['apache2'],
-    require                      => File['/var/log/apache2/archives.jenkins-ci.org'],
+    require                      => [
+      File[$apache_log_dir_fqdn],
+      File[$archives_dir],
+      Apache::Mod['bw']
+    ],
   }
 
   # We can only acquire certs in production due to the way the letsencrypt
   # challenge process works
   if (($environment == 'production') and ($facts['vagrant'] != '1')) {
-    letsencrypt::certonly { 'archives.jenkins.io':
-      domains => ['archives.jenkins.io','archives.jenkins-ci.org'],
-      plugin  => 'apache',
-    }
-    Apache::Vhost <| title == 'archives.jenkins.io' |> {
-      ssl_key       => '/etc/letsencrypt/live/archives.jenkins.io/privkey.pem',
-      ssl_cert      => '/etc/letsencrypt/live/archives.jenkins.io/fullchain.pem',
-    }
-    Apache::Vhost <| title == 'archives.jenkins-ci.org' |> {
-      ssl_key       => '/etc/letsencrypt/live/archives.jenkins.io/privkey.pem',
-      ssl_cert      => '/etc/letsencrypt/live/archives.jenkins.io/fullchain.pem',
+    [$archives_fqdn, $archives_legacy_fqdn].each |String $domain| {
+      letsencrypt::certonly { $domain:
+        domains => [$domain],
+        plugin  => 'apache',
+      }
+
+      Apache::Vhost <| title == $domain |> {
+        ssl_key         => "/etc/letsencrypt/live/${domain}/privkey.pem",
+        ssl_cert        => "/etc/letsencrypt/live/${domain}/fullchain.pem",
+      }
     }
   }
 

--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -354,6 +354,7 @@ export AZURE_STORAGE_KEY=${lookup('azure::getjenkinsio::storagekey')}
     error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_legacy_fqdn}/error_unsecured.log.%Y%m%d%H%M%S 604800",
     redirect_status              => 'permanent',
     redirect_dest                => ['https://pkg.jenkins.io/'],
+
     # Due to fastly caching on the target domain, it is required to force re-establishing TLS connection to new domain (HTTP/2 tries to reuse connection thinking it is the same server)
     custom_fragment              => 'Protocols http/1.1',
     require                      => File[$pkg_docroot],

--- a/dist/profile/templates/archives/vhost.conf
+++ b/dist/profile/templates/archives/vhost.conf
@@ -1,1 +1,0 @@
-CustomLog "|/usr/bin/rotatelogs -p /usr/local/bin/compress-rotatelogs.sh -t /var/log/apache2/archives.jenkins-ci.org/access.log.%Y%m%d%H%M%S 604800" reverseproxy_combined

--- a/hieradata/clients/archives.do.jenkins.io.yaml
+++ b/hieradata/clients/archives.do.jenkins.io.yaml
@@ -7,3 +7,11 @@ profile::archives::rsync_hosts_allow:
   - 46.101.121.132 # archives.do.jenkins.io
 # Per-host Datadog configuration
 datadog_agent::host: "archives.do.jenkins.io"
+apache::mime_types_additional:
+  AddHandler:
+    type-map: 'var'
+  AddType:
+    'text/html': '.shtml'
+    'application/octet-stream': '.hpi .jpi'
+  AddOutputFilter:
+    INCLUDES: '.shtml'


### PR DESCRIPTION
This PR fixes the `archives.jenkins.io` Apache's configuration with two major changes:

- Ensure that logs are properly written and rotated: https://github.com/jenkins-infra/helpdesk/issues/4613
- Fix the mime type for HPI to use `application/octet-stream`: https://github.com/jenkins-infra/helpdesk/issues/3270