### PR TITLE
feat(jenkinscontroller) allow additional FQDN with full TLS support (Let's Encrypt) redirecting to main CI FQDN or as aliases (usually VM hostnames)

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -17,6 +17,7 @@ class profile::jenkinscontroller (
   Boolean $anonymous_access                    = false,
   Array $admin_ldap_groups                     = ['admins'],
   Stdlib::Fqdn $ci_fqdn                        = '',
+  Hash $additional_fqdns                       = {},
   String $ci_resource_domain                   = '',
   String $docker_image                         = 'jenkins/jenkins',
   String $docker_tag                           = 'lts-jdk17',
@@ -73,7 +74,9 @@ class profile::jenkinscontroller (
   $script_dir = '/usr/share/jenkins'
   $groovy_d = "${jenkins_home}/init.groovy.d"
   $docroot = "/var/www/${ci_fqdn}"
-  $apache_log_dir = "/var/log/apache2/${ci_fqdn}"
+
+  $all_fqdns = ($additional_fqdns.keys() << $ci_fqdn )
+  $apache_log_dirs = $all_fqdns.map |$fqdn| { "/var/log/apache2/${fqdn}" }
 
   group { 'jenkins':
     ensure => present,
@@ -408,9 +411,11 @@ class profile::jenkinscontroller (
     ],
   }
 
-  file { [$apache_log_dir, $docroot]:
-    ensure  => directory,
-    require => Package['httpd'],
+  ($apache_log_dirs << $docroot).each | $dir | {
+    file { $dir:
+      ensure  => directory,
+      require => Package['httpd'],
+    }
   }
 
   file { "${docroot}/empty.json" :
@@ -480,6 +485,7 @@ RewriteRule (.*)/api/xml(/|$)(.*) /empty.xml
     require                      => [
       Docker::Run[$docker_container_name],
       File[$docroot],
+      File["/var/log/apache2/${ci_fqdn}"],
       # We need our installation to be secure before we allow access
       File[$groovy_d],
     ],
@@ -488,8 +494,8 @@ RewriteRule (.*)/api/xml(/|$)(.*) /empty.xml
     ssl                          => true,
     docroot                      => $docroot,
 
-    access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir}/access.log.%Y%m%d%H%M%S 86400",
-    error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 86400",
+    access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t /var/log/apache2/${ci_fqdn}/access.log.%Y%m%d%H%M%S 86400",
+    error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t /var/log/apache2/${ci_fqdn}/error.log.%Y%m%d%H%M%S 86400",
     proxy_preserve_host          => true,
     allow_encoded_slashes        => 'on',
     custom_fragment              => "${ci_fqdn_x_forwarded_host}
@@ -506,9 +512,77 @@ ${custom_fragment_api_paths}
     docroot                      => $docroot,
     redirect_status              => 'permanent',
     redirect_dest                => "https://${ci_fqdn}/",
-    error_log_file               => "${ci_fqdn}/error_unsecured.log",
-    access_log_pipe              => '/dev/null',
+
+    access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t /var/log/apache2/${ci_fqdn}/access_unsecured.log.%Y%m%d%H%M%S 86400",
+    error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t /var/log/apache2/${ci_fqdn}/error_unsecured.log.%Y%m%d%H%M%S 86400",
     require                      => Apache::Vhost[$ci_fqdn],
+  }
+
+  # Create additional FQDN vhosts (aliases, legacy hostnames, etc.)
+  $additional_fqdns.keys().each | $fqdn | {
+    if $additional_fqdns[$fqdn].get('isalias', false) {
+      apache::vhost { $fqdn:
+        servername                   => $fqdn,
+        use_servername_for_filenames => true,
+        use_port_for_filenames       => true,
+        require                      => [
+          Apache::Vhost[$ci_fqdn],
+          File[$docroot],
+          File["/var/log/apache2/${fqdn}"],
+        ],
+        port                         => 443,
+        override                     => ['All'],
+        ssl                          => true,
+        docroot                      => $docroot,
+
+        access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t /var/log/apache2/${fqdn}/access.log.%Y%m%d%H%M%S 86400",
+        error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t /var/log/apache2/${fqdn}/error.log.%Y%m%d%H%M%S 86400",
+        proxy_preserve_host          => true,
+        allow_encoded_slashes        => 'on',
+        custom_fragment              => "
+RequestHeader set X-Forwarded-Host \"${fqdn}\"
+${base_custom_fragment}
+${custom_fragment_api_paths}
+",
+      }
+    } else {
+      apache::vhost { $fqdn:
+        servername                   => $fqdn,
+        use_servername_for_filenames => true,
+        use_port_for_filenames       => true,
+        require                      => [
+          Apache::Vhost[$ci_fqdn],
+          File[$docroot],
+          File["/var/log/apache2/${fqdn}"],
+        ],
+        port                         => 443,
+        ssl                          => true,
+        docroot                      => $docroot,
+        redirect_status              => 'permanent',
+        redirect_dest                => "https://${ci_fqdn}/",
+
+        access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t /var/log/apache2/${fqdn}/access.log.%Y%m%d%H%M%S 86400",
+        error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t /var/log/apache2/${fqdn}/error.log.%Y%m%d%H%M%S 86400",
+      }
+    }
+
+    # Enforced HTTP to HTTPS redirection
+    apache::vhost { "${fqdn} unsecured":
+      servername                   => $fqdn,
+      use_servername_for_filenames => true,
+      use_port_for_filenames       => true,
+      port                         => 80,
+      docroot                      => $docroot,
+      redirect_status              => 'permanent',
+      redirect_dest                => "https://${fqdn}/",
+
+      access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t /var/log/apache2/${fqdn}/access_unsecured.log.%Y%m%d%H%M%S 86400",
+      error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t /var/log/apache2/${fqdn}/error_unsecured.log.%Y%m%d%H%M%S 86400",
+      require                      => [
+        Apache::Vhost[$fqdn],
+        File["/var/log/apache2/${fqdn}"],
+      ],
+    }
   }
 
   firewall { '801 Allow Jenkins web access only on localhost':
@@ -570,8 +644,8 @@ RequestHeader set X-Forwarded-Host \"${ci_resource_domain}\"
       ssl                          => true,
       docroot                      => $docroot,
 
-      access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir}/access.log.%Y%m%d%H%M%S 86400",
-      error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir}/error.log.%Y%m%d%H%M%S 86400",
+      access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_assets}/access.log.%Y%m%d%H%M%S 86400",
+      error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_assets}/error.log.%Y%m%d%H%M%S 86400",
       proxy_preserve_host          => true,
       allow_encoded_slashes        => 'on',
       custom_fragment              => "${ci_resource_domain_x_forwarded_host}
@@ -617,6 +691,21 @@ ${custom_fragment_api_paths}
       Apache::Vhost <| title == $ci_resource_domain |> {
         ssl_key       => "/etc/letsencrypt/live/${ci_resource_domain}/privkey.pem",
         ssl_cert      => "/etc/letsencrypt/live/${ci_resource_domain}/fullchain.pem",
+      }
+    }
+
+    $additional_fqdns.keys().each | $fqdn | {
+      # Request a multi-domain certificate (uses Subject Alternate Name)
+      letsencrypt::certonly { $fqdn:
+        domains       => [$fqdn],
+        plugin        => $letsencrypt_plugin,
+        custom_plugin => $letsencrypt_custom_plugin,
+        manage_cron   => false,
+      }
+
+      Apache::Vhost <| title == $fqdn |> {
+        ssl_key       => "/etc/letsencrypt/live/${fqdn}/privkey.pem",
+        ssl_cert      => "/etc/letsencrypt/live/${fqdn}/fullchain.pem",
       }
     }
   }

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -16,6 +16,10 @@ profile::jenkinscontroller::admin_ldap_groups:
   - jenkins-admins
 profile::jenkinscontroller::ci_fqdn: 'ci.jenkins.io'
 profile::jenkinscontroller::ci_resource_domain: 'assets.ci.jenkins.io'
+profile::jenkinscontroller::additional_fqdns:
+  aws.ci.jenkins.io:
+    isalias: true
+  ci.jenkins-ci.org:
 profile::jenkinscontroller::letsencrypt: true
 profile::jenkinscontroller::docker_image: 'jenkins/jenkins'
 profile::jenkinscontroller::docker_tag: 'lts-jdk17'

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -30,6 +30,10 @@ archives_jenkins_io_mirroring::privkey: |
   -----END RSA PRIVATE KEY-----
 profile::jenkinscontroller::ci_fqdn: 'localhost'
 profile::jenkinscontroller::ci_resource_domain: 'assets.localhost'
+profile::jenkinscontroller::additional_fqdns:
+  foo.localhost:
+    isalias: true
+  legacy.localhost:
 profile::jenkinscontroller::proxy_port: 443
 profile::jenkinscontroller::groovy_init_enabled: false
 profile::jenkinscontroller::memory_limit: '14g'


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4606
Also improves operations such as https://github.com/jenkins-infra/helpdesk/issues/4620

This change allows specifying additional FQDNs on the VM hosting a Jenkins controller.
These FQDN are either:

- A permanent rediection to the main CI FQDN (default). For example: `ci.jenkins-ci.org` is expected to redirect permanently to `ci.jenkins.io`
- An alias to the main CI FQDN (requires the key `isalias` set to `true`). For example: `aws.ci.jenkins.io` is an alkias without redirection to ci.jenkins.io. Useful to test new VMs while keeping the main CI FQDN as a top level CNAME.

These additional FQDN also provide their own Let's Encrypt certificate when in production. Not using SANs to support older HTTP client and avoid managing certificates per subdomain.


Note: this PR also fixes:
- The non HTTPS FQDN to log (and rotate logs) in a distinct apache directory than the main FQDN for clarity
- The "assets" secondary FQDN (only used on ci.jenkins.io) to log (and rotate logs) in a distinct apache directory than the main FQDN for clarity

----

Tested with vagrant: 
- foo.localhost does NOT redirect to localhost, but instead serves the CI page
- legacy.localhost DOES redirect to localhost

