### PR TITLE
fix(profile::letsencrypt) add missing cffi package dependency and bump certbot-apache to `3.3.0`

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -4,7 +4,7 @@ class profile::letsencrypt (
   String $plugin = '',
   Hash $dns_azure = {},
   # TODO: track with updatecli
-  String $certbot_version = '3.1.0',
+  String $certbot_version = '3.3.0',
   # TODO: track with updatecli
   String $certbot_dnsazure_version = '2.6.1',
   Stdlib::Absolutepath $certbot_bin = '/usr/local/bin/certbot'
@@ -45,7 +45,7 @@ class profile::letsencrypt (
   }
   $python_weight       = regsubst($python_certbot_version, '\.','')
 
-  ['python3', 'python3-pip', "python${python_certbot_version}", 'libaugeas0'].each | $package_name | {
+  ['python3', 'python3-pip', "python${python_certbot_version}", 'libaugeas0', 'python3-cffi-backend', 'python3-cffi'].each | $package_name | {
     package { $package_name:
       ensure => 'installed',
     }


### PR DESCRIPTION
- Using `cffi` native packages ensure pyhton installation of `certbot` is faster and does not requires many unused build dependencies
- Bumping to latest version (`3.3.0`)  to solve some transitive dependency constraint errors


Should fix the error

```
Collecting python-augeas
  Using cached python-augeas-1.1.0.tar.gz (93 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [38 lines of output]
      Traceback (most recent call last):
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/lib/python3/dist-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 174, in prepare_metadata_for_build_wheel
          self.run_setup()
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 267, in run_setup
          super(_BuildMetaLegacyBackend,
        File "/usr/lib/python3/dist-packages/setuptools/build_meta.py", line 158, in run_setup
          exec(compile(code, __file__, 'exec'), locals())
        File "setup.py", line 16, in <module>
          setup(name=name,
        File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 153, in setup
          return distutils.core.setup(**attrs)
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 109, in setup
          _setup_distribution = dist = klass(attrs)
        File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 459, in __init__
          _Distribution.__init__(
        File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 293, in __init__
          self.finalize_options()
        File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 837, in finalize_options
          ep(self)
        File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 858, in _finalize_setup_keywords
          ep.load()(self, ep.name, value)
        File "/tmp/pip-build-env-vrup2t_y/normal/local/lib/python3.10/dist-packages/cffi/setuptools_ext.py", line 216, in cffi_modules
          add_cffi_module(dist, cffi_module)
        File "/tmp/pip-build-env-vrup2t_y/normal/local/lib/python3.10/dist-packages/cffi/setuptools_ext.py", line 49, in add_cffi_module
          execfile(build_file_name, mod_vars)
        File "/tmp/pip-build-env-vrup2t_y/normal/local/lib/python3.10/dist-packages/cffi/setuptools_ext.py", line 25, in execfile
          exec(code, glob, glob)
        File "augeas/ffi.py", line 3, in <module>
          ffi = FFI()
        File "/tmp/pip-build-env-vrup2t_y/normal/local/lib/python3.10/dist-packages/cffi/api.py", line 54, in __init__
          raise Exception("Version mismatch: this is the 'cffi' package version %s, located in %r.  When we import the top-level '_cffi_backend' extension module, we get version %s, located in %r.  The two versions should be equal; check your installation." % (
      Exception: Version mismatch: this is the 'cffi' package version 1.17.1, located in '/tmp/pip-build-env-vrup2t_y/normal/local/lib/python3.10/dist-packages/cffi/api.py'.  When we import the top-level '_cffi_backend' extension module, we get version 1.15.0, located in '/usr/lib/python3/dist-packages/_cffi_backend.cpython-310-aarch64-linux-gnu.so'.  The two versions should be equal; check your installation.
      [end of output]
```