### PR TITLE
fix(controller.ci.jenkins.io) more Azure VM agents label corrections

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -516,7 +516,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: inbound
           location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          instanceType: Standard_D4pds_v5 # 4 vCPUS / 16 Gb / Max 100 Gb OsCacheDisk local storage (150 temp)
           ephemeralOSDisk: true
           osDiskSize: 100 # https://github.com/jenkinsci/azure-vm-agents-plugin/issues/349
           architecture: arm64
@@ -526,6 +526,8 @@ profile::jenkinscontroller::jcasc:
             - arm64docker
             - arm64linux
             - linux-arm64
+            # Labels to support the "nonspot" usage used in retries (as current Azure subscription does not allow using spot)
+            - ubuntu-22-arm64-maven17-nonspot
           javaHome: /opt/jdk-17
           maxInstances: 50
           useAsMuchAsPossible: true
@@ -544,6 +546,8 @@ profile::jenkinscontroller::jcasc:
           architecture: arm64
           labels:
             - ubuntu-22-arm64-maven21
+            # Labels to support the "nonspot" usage used in retries (as current Azure subscription does not allow using spot)
+            - ubuntu-22-arm64-maven21-nonspot
           javaHome: /opt/jdk-21
           maxInstances: 50
           useAsMuchAsPossible: true

--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -374,7 +374,7 @@ profile::jenkinscontroller::jcasc:
         ####
         # x86_64 Linux VMs
         ####
-        - name: ubuntu-22-amd64-maven11
+        - name: ubuntu-22-amd64-maven8
           description: "Ubuntu 22.04 LTS x86_64 with JDK8 set as default java CLI"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
           os: ubuntu
@@ -386,9 +386,9 @@ profile::jenkinscontroller::jcasc:
           ephemeralOSDisk: true
           architecture: amd64
           labels:
-            - ubuntu-22-amd64-maven11
+            - ubuntu-22-amd64-maven8
             # Labels to support the "nonspot" usage used in retries (as current Azure subscription does not allow using spot)
-            - ubuntu-22-amd64-maven11-nonspot
+            - ubuntu-22-amd64-maven8-nonspot
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: azureadmin


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4620#issuecomment-2783339203

Fixup of #4030 

- Use arm64 instance for Azure VM Linux Maven 17 + add arm64 nonspot support to get rid of the error:

```
com.microsoft.azure.vmagent.exceptions.AzureCloudException: Deployment Failed: Microsoft.Compute/virtualMachines:ubuntu-22-arm64-maven17-97bd00 - BadRequest - Cannot create a VM of size 'Standard_D4ads_v5' because this VM size only supports a CPU Architecture of 'x64', but an image or disk with CPU Architecture 'Arm64' was given. Please check that the CPU Architecture of the image or disk is compatible with that of the VM size.
```

- Disambiguous Azure VM Linux x86_64 Maven 8 and 11 to avoid the JDK11 label providing a JDK8 and JDK8 agents unable to spawn