### PR TITLE
feat(jenkinscontroller) auto detect plugins to install from JCasC hieradata config

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -404,7 +404,38 @@ class profile::jenkinscontroller (
   }
 ##############################################################################
 
-  profile::jenkinsplugin { $plugins:
+  # Add specific plugins if the JCasC configuration need them, even if not specified
+  $known_plugins_configs = {
+    'artifact-manager-s3' => 'artifacts_manager',
+    'azure-vm-agents' => 'cloud_agents.azure_vm_agents',
+    'configuration-as-code' => 'enabled',
+    'config-file-provider' => 'artifact_caching_proxy',
+    'datadog' => 'datadog',
+    'ec2' => 'cloud_agents.ec2',
+    'kubernetes' => 'cloud_agents.kubernetes',
+    'pipeline-graph-view' => 'appearance.pipeline_graph_view',
+    'toolenv' => 'tools.generic',
+    'workflow-aggregator' => 'global_libraries',
+  }
+  $all_plugins = ($plugins + $known_plugins_configs.keys).unique.map |$plugin| {
+    # If the specified plugin is in our "known" list and has a config then we want it
+    if $known_plugins_configs.get($plugin, false) {
+      if $jcasc.get($known_plugins_configs[$plugin],false) or
+      # If the user specified the plugin: return it early because they want it
+      ($plugin in $plugins) {
+        $plugin
+      } else {
+        break()
+      }
+    } else {
+      # Return the plugin if not in our "known list"
+      $plugin
+    }
+  }.sort
+
+  notice($all_plugins)
+
+  profile::jenkinsplugin { $all_plugins:
     # Only install plugins after we've secured Jenkins, that seems reasonable
     require => [
       File[$groovy_d],

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -475,23 +475,15 @@ profile::jenkinscontroller::jcasc:
 # These are plugins we need in our ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor
-  - artifact-manager-s3
-  - azure-container-agents
-  - azure-vm-agents
-  - blueocean
   - build-timeout
   - buildtriggerbadge
   - build-discarder # Remove older builds if no policy defined - https://github.com/jenkins-infra/helpdesk/issues/3495
   - cloudbees-folder
   - coverage
-  - config-file-provider
   - configuration-as-code
   - coverage-badges-extension
   - credentials
   - credentials-binding
-  - datadog
-  - docker-workflow
-  - ec2
   - embeddable-build-status
   - git-client
   - git
@@ -499,8 +491,6 @@ profile::jenkinscontroller::plugins:
   - github-checks
   - github-branch-source
   - groovy
-  - kubernetes
-  - jobConfigHistory
   - junit-attachments
   - junit-realtime-test-reporter
   - ldap
@@ -509,7 +499,6 @@ profile::jenkinscontroller::plugins:
   - matrix-auth
   - parallel-test-executor
   - pipeline-githubnotify-step
-  - pipeline-graph-view
   - pipeline-stage-view
   - pipeline-utility-steps
   - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs
@@ -518,7 +507,6 @@ profile::jenkinscontroller::plugins:
   - timestamper
   - toolenv
   - warnings-ng
-  - workflow-aggregator
   - workflow-multibranch
 profile::buildagent::tools_versions:
   awscli: 2.25.11


### PR DESCRIPTION
Requires plugins to be registered in the map linked to config Hash dotted path.

This change allows to avoid dumb mistakes when we move controllers around