### PR TITLE
feat(jenkinscontroller) allow setting up pages where pipeline-graph-view is shown

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -199,6 +199,8 @@ class profile::jenkinscontroller (
       'jenkinscontroller/casc/datadog.yaml.erb',
       # Opt-in with `profile::jenkinscontroller::jcasc.artifacts_manager
       'jenkinscontroller/casc/artifacts-manager.yaml.erb',
+      # Opt-in with `profile::jenkinscontroller::jcasc.appearance
+      'jenkinscontroller/casc/appearance.yaml.erb',
     ],
     config_dir => 'casc.d', # Relative to the jenkins_home
   }

--- a/dist/profile/templates/jenkinscontroller/casc/appearance.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/appearance.yaml.erb
@@ -1,0 +1,8 @@
+<%- if @jcasc['appearance'] && !@jcasc['appearance']['disabled'] == "true" -%>
+appearance:
+  <%- if @jcasc['appearance']['pipeline_graph_view'] -%>
+  pipelineGraphView:
+    showGraphOnBuildPage: <%= @jcasc['appearance']['pipeline_graph_view']['on_build_page'] %>
+    showGraphOnJobPage: <%= @jcasc['appearance']['pipeline_graph_view']['on_job_page'] %>
+  <%- end -%>
+<%- end -%>

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -45,6 +45,10 @@ profile::jenkinscontroller::jcasc:
         # but hieradata is behaving weirdly (bug in YAML parser?)
         defaultDisplayUrlProvider:
           providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
+  appearance:
+    pipeline_graph_view:
+      on_build_page: true
+      on_job_page: false
   tools:
     groovy:
       groovy: # Default version is named "groovy"
@@ -603,7 +607,6 @@ profile::jenkinscontroller::plugins:
   - matrix-auth # Required for specifying authorization schemes for RBAC
   - parallel-test-executor # Provides the pipleine keyword "splitTest" used byt the Jenkins "ATH" - https://github.com/jenkinsci/acceptance-test-harness/blob/54adf0da5605e2caa4afc3f0b00fbc6191991e9a/Jenkinsfile#L32
   - pipeline-github # This plugin adds the following pipeline triggers: issueCommentTrigger, pullRequestReview
-  - pipeline-graph-view # Candidate for replacing Blue Ocean use cases
   - pipeline-stage-view # Old but classic pipeline view
   - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs
   - ssh-slaves # SSH Build Agent to implement "outbound agents"

--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -49,6 +49,10 @@ profile::jenkinscontroller::jcasc:
         # but hierdata is behaving weirdly (bug in YAML parser?)
         defaultDisplayUrlProvider:
           providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
+  appearance:
+    pipeline_graph_view:
+      on_build_page: true
+      on_job_page: false
   tools:
     groovy:
       groovy: # Default version is named "groovy"
@@ -729,7 +733,6 @@ profile::jenkinscontroller::plugins:
   - matrix-auth # Required for specifying authorization schemes for RBAC
   - parallel-test-executor # Provides the pipleine keyword "splitTest" used byt the Jenkins "ATH" - https://github.com/jenkinsci/acceptance-test-harness/blob/54adf0da5605e2caa4afc3f0b00fbc6191991e9a/Jenkinsfile#L32
   - pipeline-github # This plugin adds the following pipeline triggers: issueCommentTrigger, pullRequestReview
-  - pipeline-graph-view # Candidate for replacing Blue Ocean use cases
   - pipeline-stage-view # Old but classic pipeline view
   - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs
   - ssh-slaves # SSH Build Agent to implement "outbound agents"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -45,6 +45,10 @@ profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAlreoLMhSaHCcZZaL1r7BQgmqUVbqWs+e2kaj0cn+r8o4N/qKZGXkkYBN9xhK+b5MRe2cTlfQ9J3gFFLFa6i1n1GrM/WwNMUm/cVYA2eGFNcV3ruUfigyriIrIaQVm7KIQZqv+RIQoZHJ1cWy+CdKg2hXi4KUBSawl1V3VXjSD4ZJEWv96KSceJZRTzVjZW66iD8i8Uq50WvHhvivMfHkaghowz626w/ejz0AettIKCVL9/j0B1iVv+ghOyd4A5kyIYJKR0BwQLpfKFoXY/0uhB7toZWSe7TUS7hzTAfYNhyTbS0aaczsa7pshiFZzxHAdvMeU7om4N1Dj+5LDUgAsDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBByyf8QkfPXbWYxJbMykP8SgCAQ5ncRq7jZddH/cFcb+xHJzKluSoRQU3fnSKJ8fnbEQA==]
   datadog_api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEADyo2YPgZgSJTKYK+zqkBcrmKKDuMOkZ1PqeCbCjHaJEJpM41lUGTe0s9wZfKV0poQZxF+REOhrV4wisuvt9tTMZpPUgG+Z5tetLO9GDJ8Ml0t7P/OHooFt4gebBwZQAPnUN35R87FQcS69XDKVCrp/RepteuicPSqUozjPls652mHiaR+OqBzqVr0+jlRfprt7UG8UthT+rih89OfVzmnTj9PSmbt1q5R3kMFg8/7yQTTf8yvS9XPthNLXTC/3/3ygdA+Md6Le9kzknIrJGFcide8S2JO3CLuf5LFo9/8RViCAhDmZulXOmm8GbCe7M+/Ok7NRJrcFZz0mN7yK4lxjBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBByYY131KQj7XGZAvJLNH+ngDBqKvrxjSNhJ2gzQPlVrur+mYzqf3avlfwUqKFuGTK/9kQ/7vwqI1DfvqiRTy3EJpM=]
+  appearance:
+    pipeline_graph_view:
+      on_build_page: true
+      on_job_page: false
   tools:
     groovy:
       groovy: # Default version is named "groovy"
@@ -300,7 +304,6 @@ profile::jenkinscontroller::plugins:
   - lockable-resources
   - mailer
   - parallel-test-executor
-  - pipeline-graph-view
   - pipeline-stage-view
   - pipeline-utility-steps
   - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -182,7 +182,6 @@ profile::jenkinscontroller::plugins:
   - kubernetes
   - ldap
   - matrix-auth
-  - pipeline-graph-view
   - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs
   - ssh-slaves # SSH Build Agent to implement "outbound agents"
   - toolenv

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -54,6 +54,10 @@ profile::jenkinscontroller::jcasc:
         # but hierdata is behaving weirdly (bug in YAML parser?)
         defaultDisplayUrlProvider:
           providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
+  appearance:
+    pipeline_graph_view:
+      on_build_page: true
+      on_job_page: false
   tools:
     groovy:
       groovy: # Default version is named "groovy"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4620

We expect this PR not to change anything on existing controllers (keep default graph view setting for aws.ci and trusted.ci, keep cert.ci without the graph view) but to add graph view on build pages to azure.ci