### PR TITLE
fix(controller.ci.jenkins.io) deprecate labels `maven`, `windows` and `maven-windows`

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -179,7 +179,6 @@ profile::jenkinscontroller::jcasc:
             imageName: jnlp-maven-all-in-one
             javaHome: /opt/jdk-8
             labels:
-              - maven
               - maven-8
               - jdk8
             cpus: 4
@@ -622,9 +621,6 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - win-2019-amd64-maven8
-            # Legacy tag for Windows + JDK8. TODO: update pipeline library to avoid this "default" tag.
-            - maven-windows
-            - windows
             # Used to be a Windows container (same label pattern as Kubernetes Agents)
             - maven-8-windows
             # Labels to support the "nonspot" usage used in retries (as current Azure subscription does not allow using spot)


### PR DESCRIPTION
As per https://github.com/jenkins-infra/pipeline-library/pull/926#issuecomment-2791706203

These labels should be deprecated.

It reverts the 2 following hotfixes:

- https://github.com/jenkins-infra/jenkins-infra/commit/0a2dfc8a687276dae530ec47a85950beced3f94c
- https://github.com/jenkins-infra/jenkins-infra/commit/2fc4e9305305b30545b4982fcfb049701ef6bf8f