### PR TITLE
feat(trusted.ci): switch to managed identity for azure vm spawning

### DIFF
--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -87,7 +87,7 @@ profile::jenkinscontroller::jcasc:
     azure_vm_agents:
       clouds:
         azure-vms-jenkins-sponsorship:
-          azureCredentialsId: azure-jenkins-sponsorship-credentials # Managed manually
+          azureCredentialsId: azure-jenkins-sponsorship-managed-identity # Managed manually
           resourceGroup: trusted-ci-jenkins-io-ephemeral-agents
           maxInstances: 50 # Mandatory to set otherwise it's 10 by default. Worst case: 50 of 8 vCPUS = 400 which is the maximum quota
           virtualNetworkName: trusted-ci-jenkins-io-sponsorship-vnet


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4630
following https://github.com/jenkins-infra/azure/pull/1010

the credential have been created and verified manually within the trusted.ci jenkins controller UI.