### PR TITLE
chore(updatecli) tracks `certbot-dns-azure` plugin version

### DIFF
--- a/updatecli/weekly.d/certbot_dnsazure.yaml
+++ b/updatecli/weekly.d/certbot_dnsazure.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump `certbot_dnsazure` plugin version
+name: Bump certbot plugin `dns-azure` version
 
 scms:
   default:

--- a/updatecli/weekly.d/certbot_dnsazure.yaml
+++ b/updatecli/weekly.d/certbot_dnsazure.yaml
@@ -53,9 +53,9 @@ targets:
 actions:
   default:
     kind: github/pullrequest
-    title: Bump `certbot_dnsazure` version to {{ source "certbotDnsAzureLatestRelease" }}
+    title: Bump certbot plugin `dns-azure` version to {{ source "certbotDnsAzureLatestRelease" }}
     scmid: default
     spec:
       labels:
         - enhancement
-        - certbot_dnsazure
+        - certbot-dns-azure

--- a/updatecli/weekly.d/certbot_dnsazure.yaml
+++ b/updatecli/weekly.d/certbot_dnsazure.yaml
@@ -40,7 +40,6 @@ targets:
   updateCertbotVersion:
     name: "Update certbot_dnsazure_version in hieradata/common.yaml"
     kind: yaml
-    # Assuming certbotLatestRelease is the source ID that now correctly gives a SINGLE version string
     sourceid: certbotDnsAzureLatestRelease
     spec:
       file: hieradata/common.yaml

--- a/updatecli/weekly.d/certbot_dnsazure.yaml
+++ b/updatecli/weekly.d/certbot_dnsazure.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump `certbot_dnsazure` version from GitHub Release
+name: Bump `certbot_dnsazure` plugin version
 
 scms:
   default:
@@ -7,19 +7,19 @@ scms:
     spec:
       user: "{{ .github.user }}"
       email: "{{ .github.email }}"
-      owner: "{{ .github.owner }}" # e.g., jenkins-infra
-      repository: "{{ .github.repository }}" # e.g., jenkins-infra
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-      branch: "{{ .github.branch }}" # The branch where letsencrypt.pp is located
+      branch: "{{ .github.branch }}"
 
 sources:
   certbotDnsAzureLatestRelease:
     kind: githubrelease
     name: "Get the latest certbot-dns-azure release version"
     spec:
-      owner: "terricain"
-      repository: "certbot-dns-azure"
+      owner: terricain
+      repository: certbot-dns-azure
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:

--- a/updatecli/weekly.d/certbot_dnsazure.yaml
+++ b/updatecli/weekly.d/certbot_dnsazure.yaml
@@ -1,0 +1,62 @@
+---
+name: Bump `certbot_dnsazure`` version from GitHub Release
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}" # e.g., jenkins-infra
+      repository: "{{ .github.repository }}" # e.g., jenkins-infra
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}" # The branch where letsencrypt.pp is located
+
+sources:
+  certbotDnsAzureLatestRelease:
+    kind: githubrelease
+    name: "Get the latest certbot-dns-azure release version"
+    spec:
+      owner: "terricain"
+      repository: "certbot-dns-azure"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: semver
+        strict: false
+
+conditions:
+  checkCertbotOnPypi:
+    name: "Check if certbot_dnsazure version exists on PyPI"
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: >-
+        curl --connect-timeout 10 --silent --show-error --location --fail --head --output /dev/null
+        "https://pypi.org/project/certbot-dns-azure/{{ source "certbotDnsAzureLatestRelease" }}/"
+
+targets:
+  updateCertbotVersion:
+    name: "Update certbot_dnsazure_version in hieradata/common.yaml"
+    kind: yaml
+    # Assuming certbotLatestRelease is the source ID that now correctly gives a SINGLE version string
+    sourceid: certbotDnsAzureLatestRelease
+    spec:
+      file: hieradata/common.yaml
+      key: $.profile::letsencrypt::certbot_dnsazure_version
+    # Puppet 6 uses a buggy yaml parser so we need quotes to ensure string
+    transformers:
+      - addprefix: "'"
+      - addsuffix: "'"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump `certbot_dnsazure` version to {{ source "certbotDnsAzureLatestRelease" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - certbot_dnsazure

--- a/updatecli/weekly.d/certbot_dnsazure.yaml
+++ b/updatecli/weekly.d/certbot_dnsazure.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump `certbot_dnsazure`` version from GitHub Release
+name: Bump `certbot_dnsazure` version from GitHub Release
 
 scms:
   default:


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/4654

This PR tracks and updates `certbot_dnsazure` version

Tested locally with success.