### PR TITLE
chore(updatecli): add tracking for `certbot_version` in spec

### DIFF
--- a/updatecli/weekly.d/certbot.yaml
+++ b/updatecli/weekly.d/certbot.yaml
@@ -49,6 +49,7 @@ targets:
       key: $.profile::letsencrypt::certbot_version
     scmid: default
   updateSpecFile:
+    name: "Update certbot_version in letsencrypt_spec.rb"
     kind: file
     sourceid: certbotLatestRelease
     spec:

--- a/updatecli/weekly.d/certbot.yaml
+++ b/updatecli/weekly.d/certbot.yaml
@@ -45,10 +45,16 @@ targets:
     sourceid: certbotLatestRelease
     spec:
       file: hieradata/common.yaml
+      engine: yamlpath
       key: $.profile::letsencrypt::certbot_version
-    transformers:
-      - addprefix: "'"
-      - addsuffix: "'"
+    scmid: default
+  updateSpecFile:
+    kind: file
+    sourceid: certbotLatestRelease
+    spec:
+      file: spec/classes/profile/letsencrypt_spec.rb
+      matchpattern: 'certbot_version = "(\d+\.\d+\.\d+)"'
+      replacepattern: 'certbot_version = "{{ source "certbotLatestRelease" }}"'
     scmid: default
 
 actions:

--- a/updatecli/weekly.d/certbot_dnsazure.yaml
+++ b/updatecli/weekly.d/certbot_dnsazure.yaml
@@ -43,12 +43,21 @@ targets:
     sourceid: certbotDnsAzureLatestRelease
     spec:
       file: hieradata/common.yaml
+      engine: yamlpath
       key: $.profile::letsencrypt::certbot_dnsazure_version
     # Puppet 6 uses a buggy yaml parser so we need quotes to ensure string
-    transformers:
-      - addprefix: "'"
-      - addsuffix: "'"
-    scmid: default
+    # transformers:
+    #   - addprefix: "'"
+    #   - addsuffix: "'"
+    # scmid: default
+  updateSpecFile:
+    kind: file
+    sourceid: certbotDnsAzureLatestRelease
+    spec:
+      file: spec/classes/profile/letsencrypt_spec.rb
+      matchpattern: 'certbot_dns_azure_version = "(\d+\.\d+\.\d+)"'
+      replacepattern: 'certbot_dns_azure_version = "{{ source "certbotDnsAzureLatestRelease" }}"'
+    
 
 actions:
   default:

--- a/updatecli/weekly.d/certbot_dnsazure.yaml
+++ b/updatecli/weekly.d/certbot_dnsazure.yaml
@@ -43,21 +43,12 @@ targets:
     sourceid: certbotDnsAzureLatestRelease
     spec:
       file: hieradata/common.yaml
-      engine: yamlpath
       key: $.profile::letsencrypt::certbot_dnsazure_version
     # Puppet 6 uses a buggy yaml parser so we need quotes to ensure string
-    # transformers:
-    #   - addprefix: "'"
-    #   - addsuffix: "'"
-    # scmid: default
-  updateSpecFile:
-    kind: file
-    sourceid: certbotDnsAzureLatestRelease
-    spec:
-      file: spec/classes/profile/letsencrypt_spec.rb
-      matchpattern: 'certbot_dns_azure_version = "(\d+\.\d+\.\d+)"'
-      replacepattern: 'certbot_dns_azure_version = "{{ source "certbotDnsAzureLatestRelease" }}"'
-    
+    transformers:
+      - addprefix: "'"
+      - addsuffix: "'"
+    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/4654

This PR tracks and updates `certbot_version` in spec

Tested locally with success.