### PR TITLE
chore(updatecli): add tracking for `certbot_dns_azure_version` in spec

### DIFF
--- a/updatecli/weekly.d/certbot_dnsazure.yaml
+++ b/updatecli/weekly.d/certbot_dnsazure.yaml
@@ -42,12 +42,9 @@ targets:
     kind: yaml
     sourceid: certbotDnsAzureLatestRelease
     spec:
+      engine: yamlpath
       file: hieradata/common.yaml
       key: $.profile::letsencrypt::certbot_dnsazure_version
-    # Puppet 6 uses a buggy yaml parser so we need quotes to ensure string
-    transformers:
-      - addprefix: "'"
-      - addsuffix: "'"
     scmid: default
   updateSpecFile:
     name: "Update certbot_dnsazure_version in letsencrypt_spec.rb"

--- a/updatecli/weekly.d/certbot_dnsazure.yaml
+++ b/updatecli/weekly.d/certbot_dnsazure.yaml
@@ -49,6 +49,15 @@ targets:
       - addprefix: "'"
       - addsuffix: "'"
     scmid: default
+  updateSpecFile:
+    name: "Update certbot_dnsazure_version in letsencrypt_spec.rb"
+    kind: file
+    sourceid: certbotDnsAzureLatestRelease
+    spec:
+      file: spec/classes/profile/letsencrypt_spec.rb
+      matchpattern: 'certbot_dns_azure_version = "(\d+\.\d+\.\d+)"'
+      replacepattern: 'certbot_dns_azure_version = "{{ source "certbotDnsAzureLatestRelease" }}"'
+    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/4654

This PR tracks and updates `certbot_dns_azure_version` in spec

Tested locally with success.