### PR TITLE
chore(updatecli/certbot-dns-multi): use `engine: yamlpath` to avoid updatecli parsing error

### DIFF
--- a/spec/classes/profile/letsencrypt_spec.rb
+++ b/spec/classes/profile/letsencrypt_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
-# TODO: track with updatecli
 certbot_version = "3.3.0"
-# TODO: track with updatecli
 certbot_dns_azure_version = "2.6.1"
 
 describe "profile::letsencrypt" do

--- a/updatecli/weekly.d/certbot_dnsmulti.yaml
+++ b/updatecli/weekly.d/certbot_dnsmulti.yaml
@@ -42,12 +42,9 @@ targets:
     kind: yaml
     sourceid: certbotDnsMultiLatestRelease
     spec:
+      engine: yamlpath
       file: hieradata/common.yaml
       key: $.profile::letsencrypt::certbot_dnsmulti_version
-    # Puppet 6 uses a buggy yaml parser so we need quotes to ensure string
-    transformers:
-      - addprefix: "'"
-      - addsuffix: "'"
     scmid: default
 
 actions:


### PR DESCRIPTION
Related to - https://github.com/jenkins-infra/helpdesk/issues/4654#issuecomment-2883033609

We use yaml engine to avoid the parsing error introduced by updatecli in updating the targets.