### PR TITLE
feat(archives) disable rsync host restriction temporarily

### DIFF
--- a/hieradata/clients/archives.do.jenkins.io.yaml
+++ b/hieradata/clients/archives.do.jenkins.io.yaml
@@ -1,10 +1,11 @@
 ---
-profile::archives::rsync_hosts_allow:
-  - localhost
-  - archives.jenkins.io
-  - pkg.origin.jenkins.io
-  - get.jenkins.io
-  - 46.101.121.132 # archives.do.jenkins.io
+## TODO: uncomment and add values from our mirrors to allow them to download data
+# profile::archives::rsync_hosts_allow:
+#   - localhost
+#   - archives.jenkins.io
+#   - pkg.origin.jenkins.io
+#   - get.jenkins.io
+#   - 46.101.121.132 # archives.do.jenkins.io
 # Per-host Datadog configuration
 datadog_agent::host: "archives.do.jenkins.io"
 apache::mime_types_additional:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4653

We already have a rsync server enabled on archives(.do).jenkins.io (and set up on read-only to the `/srv/releases` directory) which restricts allowed hosts.

This PR temporarily lifts this restriction until our get.jenkins.io mirrors all have provided their outbound IP (for the restriction list).