### PR TITLE
fix(archives,vpn) ensure admins can rsync to archives.jio

### DIFF
--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -185,7 +185,7 @@ class profile::openvpn (
       $external_ips_vpn_restricted.each |String $service_name, String $external_ssh_ip| {
         $external_ssh_ip_cidr = "${external_ssh_ip}/32"
 
-        firewall { "100 allow routing from ${vpn_network['cidr']} to ${service_name} (${external_ssh_ip}) on port 22":
+        firewall { "100 allow routing from ${vpn_network['cidr']} to ${service_name} (${external_ssh_ip}) on usual ports":
           chain       => 'POSTROUTING',
           jump        => 'MASQUERADE',
           proto       => 'tcp',
@@ -195,6 +195,7 @@ class profile::openvpn (
             22,   # Allow SSH to external VMs
             80,   # Allow HTTP to external VMs
             443,  # Allow HTTPS to external VMs
+            873,  # Allow rsync to external VMs
           ],
           destination => $external_ssh_ip_cidr,
           table       => 'nat',

--- a/dist/profile/templates/archives/rsyncd.conf.erb
+++ b/dist/profile/templates/archives/rsyncd.conf.erb
@@ -1,8 +1,4 @@
-# /etc/rsyncd: configuration file for
-rsync daemon mode
-
 # See rsyncd.conf man page for more options.
-
 # configuration example:
 
 uid = nobody
@@ -34,4 +30,3 @@ hosts allow = <%= @rsync_hosts_allow.join(',') %>
 [jenkins]
 path = <%= @archives_dir %>
 comment = "Jenkins Read-Only Mirror"
- 

--- a/hieradata/clients/archives.do.jenkins.io.yaml
+++ b/hieradata/clients/archives.do.jenkins.io.yaml
@@ -1,6 +1,7 @@
 ---
+profile::archives::rsync_hosts_allow:
+  - 0.0.0.0
 ## TODO: uncomment and add values from our mirrors to allow them to download data
-# profile::archives::rsync_hosts_allow:
 #   - localhost
 #   - archives.jenkins.io
 #   - pkg.origin.jenkins.io


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4653

- archives: fix a rsync warning (`params.c:Parameter() - Ignoring badly formed line in config file: rsync daemon mode`)
- archives: explicitly set all Ipv4 in the rsync allow list
- openvpn: ensure rsync is allowed from VPN to archives