### PR TITLE
fixup(ci.jenkins.io): switch to jdk21

### DIFF
--- a/hieradata/clients/controller.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.ci.jenkins.io.yaml
@@ -24,7 +24,7 @@ profile::jenkinscontroller::additional_fqdns:
   ci.jenkins-ci.org: null
 profile::jenkinscontroller::letsencrypt: true
 profile::jenkinscontroller::docker_image: 'jenkins/jenkins'
-profile::jenkinscontroller::docker_tag: 'lts-jdk17'
+profile::jenkinscontroller::docker_tag: 'lts-jdk21'
 profile::jenkinscontroller::groovy_init_enabled: true
 profile::jenkinscontroller::block_remote_access_api: true
 profile::jenkinscontroller::groovy_d_lock_down_jenkins: 'present'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -231,7 +231,7 @@ profile::jenkinscontroller::jcasc:
       jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.45.0@sha256:96391da4d4aad8314903b442e5a3e98885426e6d28c4000841b0602477aa7d28
       jnlp-webbuilder: jenkinsciinfra/builder:latest@sha256:a1536f2da0d6f8248fbb22d8245978e74609f14dddaebf67ae51ce1a60c279b8
       # default template from the official inbound-agent image here to provide a default agent (`node()` pipeline step)
-      jnlp: latest-jdk21@sha256:b26f645f109413a475e8d30b007d693505d8ec2d88b3f8b3bb39e42d53907c98
+      jnlp: jenkins/inbound-agent:latest-jdk21@sha256:b26f645f109413a475e8d30b007d693505d8ec2d88b3f8b3bb39e42d53907c98
       jnlp-packaging: jenkinsciinfra/packaging:latest
   tools_default_versions:
     jdk8: 8u452-b09


### PR DESCRIPTION
follow up of #4091 

correct specific tag for ci.jio and correct image name for jnlp