### PR TITLE
fix(profile::buildagent) use valid adoptium binary URLs when running on amd64

### DIFF
--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -94,7 +94,11 @@ class profile::buildagent (
         name => $jdk_name,
         major_version => regsubst($jdk_name, 'jdk', '').regsubst($jdk_name, 'jdk-', ''),
         version => $jdk_version,
-        cpu_arch => $facts['os']['architecture'],
+        cpu_arch => $facts['os']['architecture'] ? {
+          'amd64'  => 'x64',
+          'arm64'  => 'aarch64',
+          default  => $facts['os']['architecture'],
+        },
       }
       $java_dir = "/opt/jdk-${$jdk['major_version']}"
       $java_bin = "${java_dir}/bin/java"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/jenkins-infra/pull/4146#issuecomment-2903785830

Related to https://github.com/jenkins-infra/helpdesk/issues/4121#issuecomment-2890355054 task