### PR TITLE
feat(ci.jenkins.io): remove docker json conf for (Azure) windows agents

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -22,14 +22,6 @@ jenkins:
           (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: <%= @jcasc['datadog_api_key'] %>' | Set-Content C:\ProgramData\Datadog\datadog.yaml
           & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart-service
 
-          # Setup Docker Engine
-          @'
-          {
-            "registry-mirrors": ["<%= agent['registryMirror'] ? agent['registryMirror'] : @jcasc['agents_setup'][$os]['registryMirror'] %>"]
-          }
-          '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
-          Restart-Service docker
-
           <%- if agent['launcher'] && agent['launcher'] == "inbound" -%>
           # Setup inbound agent
           $jenkinsServerUrl = $args[0] # Always ends with a '/'
@@ -456,7 +448,7 @@ jenkins:
                 '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
 
                 # Restart docker engine
-                Restart-Service docker
+                
 
                 # Ensure Jenkins controller does not start the agent in process in its workspace until we are ready
                 Start-Service sshd


### PR DESCRIPTION
Cherry picking the change from https://github.com/jenkins-infra/jenkins-infra/pull/3998 where it was only done for EC2 agents.

Ref. https://matrix.to/#/!CXfiHlEKGLXlkMPLEN:gitter.im/$JYn3wdWAoAhTiWb4QiuXHLp0IJOP53lSmhQzob2PPTU?via=gitter.im&via=matrix.org&via=nani.wtf

It aims at fixing this kind of errors during Windows container builds:

```
20:31:04  Successfully built ea30f4deaf7b
20:31:04  Successfully tagged jenkins4eval/agent:jdk17-nanoserver-ltsc2022
20:31:04   Service agent_nanoserver-ltsc2022_jdk17  Built
20:31:58  unexpected EOF
20:31:58  = BUILD: Finished building all images.
script returned exit code 1
```

(from https://github.com/jenkinsci/docker-agent/pull/962 logs)