### PR TITLE
feat(mirror-script) export rsync filter list for sync.sh to allow mirror sponsors to only keep 1 year of artifacts

### DIFF
--- a/dist/profile/templates/mirror-scripts/sync.sh.erb
+++ b/dist/profile/templates/mirror-scripts/sync.sh.erb
@@ -1,20 +1,22 @@
 #!/bin/bash -xe
-HOST=<%= @osuosl_mirroring['username'] %>@<%= @osuosl_mirroring['host'] %>
-BASE_DIR="<%= @release_root %>"
-RSYNC_ARGS="-rlpDvz"
-SCRIPT_DIR="${PWD}"
-FLAG="${1}"
+osuosl_host=<%= @osuosl_mirroring['username'] %>@<%= @osuosl_mirroring['host'] %>
+base_dir="<%= @release_root %>"
+script_dir="${PWD}"
+script_flag="${1}"
+rsync_filter_file="${base_dir}/rsync-jenkins-mirrors.filter"
 
 # This script can be run from a crontab where the PATH is stripped compared to an interactive/login session
 export PATH="${HOME}"/.bin:/usr/local/bin:"${PATH}"
 
-pushd "${BASE_DIR}"
-  time rsync "${RSYNC_ARGS}" --chown=jenkins --times --delete-during --delete-excluded --prune-empty-dirs --include-from=<(
+pushd "${base_dir}"
+  {
+    # Provider pattern file to mirror maintainers - https://github.com/jenkins-infra/helpdesk/issues/4681
+    echo "+ ${rsync_filter_file}"
     # keep all the plugins
     echo '+ plugins/**'
     echo '+ art/**'
     echo '+ podcast/**'
-    # I think this is a file we create on OSUOSL so dont let that be deleted
+    # Used by mirrorbits when scanning mirrors
     echo '+ TIME'
     # copy all the symlinks
     #shellcheck disable=SC2312
@@ -24,8 +26,17 @@ pushd "${BASE_DIR}"
     find . -type f -mtime +365 | sed -e 's#\./#- /#g'
     # the rest of the rules come from rsync.filter
     #shellcheck disable=SC2312
-    cat "${SCRIPT_DIR}/rsync.filter"
-  ) . "${HOST}:jenkins/"
+    cat "${script_dir}/rsync.filter"
+  } > "${rsync_filter_file}"
+  time rsync \
+    -rlpDvz \
+    --chown=jenkins \
+    --times \
+    --delete-during \
+    --delete-excluded \
+    --prune-empty-dirs \
+    --include-from="${rsync_filter_file}" \
+    . "${osuosl_host}:jenkins/"
 popd
 
 echo ">> Delivering bits to archives.jenkins.io (fallback of get.jenkins.io)"
@@ -41,7 +52,7 @@ echo ">> Updating the latest symlink for LTS RC"
 /srv/releases/update-latest-symlink.sh "-stable-rc"
 
 echo ">> Triggering remote mirroring script"
-ssh "${HOST}" "sh trigger-jenkins"
+ssh "${osuosl_host}" "sh trigger-jenkins"
 
 echo ">> move index from staging to production"
 # Excluding some files which the packaging repo which are now managed by Puppet
@@ -50,7 +61,7 @@ echo ">> move index from staging to production"
     --exclude=.htaccess --exclude=jenkins.repo \
     "<%= @pkg_staging_basedir %>"/ "<%= @pkg_basedir %>"/)
 
-if [[ "${FLAG}" = '--full-sync' ]]; then
+if [[ "${script_flag}" = '--full-sync' ]]; then
   echo ">> Updating artifacts on get.jenkins.io..."
 
   # Don't print any trace
@@ -76,7 +87,7 @@ if [[ "${FLAG}" = '--full-sync' ]]; then
     --recursive `# Source directory contains at least one subdirectory` \
     --overwrite=ifSourceNewer `# Only overwrite if source is more recent (time comparison)` \
     --log-level=ERROR `# Do not write too much logs (I/O...)` \
-    "${BASE_DIR}/*" "${fileShareSignedUrl}"
+    "${base_dir}/*" "${fileShareSignedUrl}"
   echo ">>> finished azcopy-ing files to get.jenkins.io filesystem"
 
   # Back to debug mode


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4681

A bit of (chore/nitpick) shell cleanup (using lower case and meaningful name for non environmental variables, fixing comments, etc.)