### PR TITLE
feat(jenkinscontroller/cert.ci/trusted.ci) specify User Assigned Identity for trusted.ci and cert.ci Azure VM agents

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -179,7 +179,6 @@ jenkins:
         encryptionAtHost: true
         doNotUseMachineIfInitFails: true
         enableMSI: false
-        enableUAMI: false
         ephemeralOSDisk: "<%= agent['ephemeralOSDisk'] ? agent['ephemeralOSDisk'] : false %>"
         existingStorageAccountName: "<%= cloudsetup['storageAccount'] %>"
         storageAccountNameReferenceType: "existing"
@@ -214,6 +213,15 @@ jenkins:
         templateDesc: "Dynamically provisioned <%= agent['description'] %> machine"
         templateDisabled: false
         templateName: "<%= agent['name'] %>"
+      <%- if agent['userInstanceIdentity'] -%>
+        enableUAMI: true
+        uamiID: "<%= agent['userInstanceIdentity'] %>"
+      <%- elsif cloudsetup['userInstanceIdentity'] -%>
+        enableUAMI: true
+        uamiID: "<%= cloudsetup['userInstanceIdentity'] %>"
+      <%- else -%>
+        enableUAMI: false
+      <%- end -%>
         usageMode: "<%= agent['useAsMuchAsPossible'] == true ? 'NORMAL' : 'EXCLUSIVE' %>"
         virtualMachineSize: "<%= agent['instanceType'] %>"
         <%- if agent['maxInstances'] -%>

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -130,6 +130,7 @@ profile::jenkinscontroller::jcasc:
           subnetName: cert-ci-jenkins-io-sponsorship-vnet-ephemeral-agents
           disableSpot: true # Not enough quota available
           storageAccount: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAHnSCgxZHR7PGhJROKv6Y5r2HJupg+Mi9UBCfMm0wL60+8jfvI35sKcc8qQVJTJLtTiSudf9YyG43we03L3JrNpw6HOIi4tnjQlNtPzoIfN47cY9UmAHuhiLIaQM3x8f2wm/Gf4+2VPZP+YoF2ye8Aa5Y9NKbu6sTd2sYEa/LkBslYIafQbLkud1zCW0iWolnSZad6CxPIGP/s0a9vOhQfeEbxbvfiQq2NelhOP499AjQpmbQd1mnzruUB5xp3yll3eEmPl5zzWSzcfrU9od3ZsBCHK5ag3hm8wMDLns4RnFM35UZGBXRsVaS2HNtaHeZNzJL9YhCdhwWgWQc/bN6gzA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBnRt4ORJZ+RrwhVTTG2OlQgBA3r788oLc+SZ7UK0e5AAFH]
+          userInstanceIdentity: '/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/cert-ci-jenkins-io-controller/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cert-ci-jenkins-io-agents-sponsorship'
       agent_definitions:
         - name: "ubuntu-22-amd64-maven-11"
           description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -96,6 +96,7 @@ profile::jenkinscontroller::jcasc:
           subnetName: trusted-ci-jenkins-io-sponsorship-vnet-ephemeral-agents
           disableSpot: true # Not enough quota available
           storageAccount: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEABg+VT2jJfm39KjS0i/PhizdtKpy7AC4wLmKN4DWOsdfea3XUbUU0FQfuPLNY/9CA7iuEIAtO9y7pht9vwX16b2sC2xqL9CJlxj2B6bgLkJsqo9Qeib7Sy7nYe0LyIgE+HUrQ8Y1rCU1itPxHCdXFjy+GiG/q7xs1bMUuulQf/aL48uTC8BvO3DGNaNdNadpI+6NpVwtzk5wtLZS6mbL053f8t+DFmpyUR0HYYnYGxVl2eDFRlR5qV93kErpPMGfuWj3sk7P3o4h8RXt5BIgR/0Hd9/ypd60mKjGJpUn3y4LMBthDEIB0iEwiIBw5oE5EJHnBTPVEYkKMPZ+5Ct837zBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDuNBYp213f+ubJVbpnKwIbgCChAER2/Kp5oAKS60k5HWAcu0cgHJMIK2d6SgAHv5FhuA==]
+          userInstanceIdentity: '/subscriptions/1311c09f-aee0-4d6c-99a4-392c2b543204/resourceGroups/jenkinsinfra-trusted-ci-controller/providers/Microsoft.ManagedIdentity/userAssignedIdentities/trusted-ci-jenkins-io-agents-sponsorship'
       agent_definitions:
         - name: "ubuntu-22-amd64-maven-11"
           description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -291,6 +291,7 @@ profile::jenkinscontroller::jcasc:
           disableSpot: true # Not enough quota available
           storageAccount: SuperSecretEncryptedInProductionSecondary
           acpServerId: external
+          userInstanceIdentity: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}'
       agent_definitions:
         - name: "ubuntu-22-inbound"
           description: "Ubuntu 22.04 LTS"
@@ -366,6 +367,7 @@ profile::jenkinscontroller::jcasc:
           usePrivateIP: true
           javaHome: /opt/jdk-11 # Test override of the default JDK for builds
           agentJavaBin: /opt/jdk-17 # Test override of the default JDK for builds
+          userInstanceIdentity: '/specific/value/which/overrides/cloud/default'
         - name: "win-2019-inbound" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019"
           imageDefinition: jenkins-agent-windows-2019-amd64


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4696

This PR allows specifying a custom User Assigned Identity for the Azure VM agent clouds.
It may be specified cloud-wide or per agent template. If both are specified, the agent template specified UAID takes precedence.

Tested with Vagrant, which hieradata covers the 4 possible use cases:

- No UAID (ci.jenkins.io)
- Agent-level UAID (no case but better covering it)
- UAID at cloud level (cert.ci and trusted.ci)
- UAID and agent-level (no case yet but better covering it)