### PR TITLE
fix(letsencrypt) ensure package 'python3-augeas' required for certbot apache plugin is installed

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -44,7 +44,7 @@ class profile::letsencrypt (
   }
   $python_weight       = regsubst($python_certbot_version, '\.','')
 
-  ['python3', 'python3-pip', "python${python_certbot_version}", 'libaugeas0', 'python3-cffi-backend', 'python3-cffi'].each | $package_name | {
+  ['python3', 'python3-pip', "python${python_certbot_version}", 'python3-augeas', 'libaugeas0', 'python3-cffi-backend', 'python3-cffi'].each | $package_name | {
     package { $package_name:
       ensure => 'installed',
     }


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/4688 we met issues when bootstrapping the `certbot` installation.

The package `python3-augeas` is required and was missing in AWS base ubuntu (while present on the Azure base Ubuntu and Docker ubuntu image we used for vagrant testing).