### PR TITLE
fix(jenkinscontroller) ensure the Jenkins URL location is set to the ci_fqdn

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/jenkins.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/jenkins.yaml.erb
@@ -1,8 +1,10 @@
-<%- if @jcasc['jenkins_global'] && !@jcasc['jenkins_global']['disabled'] == "true" -%>
+<%- unless (@jcasc['jenkins_global'] && @jcasc['jenkins_global']['disabled'] == "true") -%>
 jenkins:
   # No builds on controller
   numExecutors: 0
 unclassified:
+  location:
+    url: "https://<%= @ci_fqdn %>"
   shell:
     shell: "/bin/bash"
 <%- end -%>


### PR DESCRIPTION
To avoid warning messages on an empty controller