### PR TITLE
fix(aws.ci.jio) correct agent labels and setups

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -140,7 +140,7 @@ profile::jenkinscontroller::jcasc:
         ## Note: no URL/credential/CA data as we rely on jenkins' KUBECONFIG to allow EC2 instance profile authentication
         # TODO: track with updatecli
         # TODO: uncomment once validated with the BOM agents
-        # imageNamePrefix: "326712726440.dkr.ecr.us-east-2.amazonaws.com/docker-hub/"
+        imageNamePrefix: "326712726440.dkr.ecr.us-east-2.amazonaws.com/docker-hub/"
         acpServerId: aws-eks-internal
         # TODO: track with updatecli
         defaultNamespace: jenkins-agents
@@ -335,8 +335,6 @@ profile::jenkinscontroller::jcasc:
               - ubuntu-22-amd64-maven11
             spot: true
             acpServerId: aws-internal
-          ####
-          # Linux VMs jdk17 (default non-spot version for buildPlugin() / docker-*)
           - description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
             maxInstances: 50
             instanceType: M5dnXlarge # 4 vCPUs / 16 Gb / nvme 150Gb
@@ -349,8 +347,6 @@ profile::jenkinscontroller::jcasc:
               - ubuntu-22-amd64-maven17-nonspot
             spot: false
             acpServerId: aws-internal
-          ####
-          # Linux VMs jdk17 (default spot version for buildPlugin() / docker-*)
           - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
             maxInstances: 50
             instanceType: M5dnXlarge # 4 vCPUs / 16 Gb / nvme 150Gb
@@ -373,8 +369,10 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-21
             labels:
               - ubuntu-22-amd64-maven21
-              # Labels indicating it is the default VM template for amd64
+              # Labels indicating it is the default VM template
               - linux-amd64
+              - java
+              - docker
             spot: true
             acpServerId: aws-internal
           ####
@@ -389,8 +387,6 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-17
             labels:
               - ubuntu-22-arm64-maven17
-
-
             spot: true
             acpServerId: aws-internal
           - description: "Spot Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
@@ -403,11 +399,9 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-21
             labels:
               - ubuntu-22-arm64-maven21
-              # Labels indicating it is the default VM template for arm64
+              # Labels indicating it is the default VM template (for arm64)
               - arm64docker
               - arm64linux
-              - java
-              - docker
               - linux-arm64
             spot: true
             acpServerId: aws-internal
@@ -423,7 +417,6 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: /opt/jdk-17
             labels:
-              - docker-highmem-nonspot
               - ubuntu-22-amd64-highmem-maven17-nonspot
             spot: false
             acpServerId: aws-internal
@@ -457,6 +450,20 @@ profile::jenkinscontroller::jcasc:
               - docker-highmem
               - linux-amd64-big
             spot: true
+            acpServerId: aws-internal
+          - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
+            maxInstances: 50
+            instanceType: M5dn2xlarge # 8 vCPUs / 32 Gb / nvme 300Go
+            os: "ubuntu"
+            os_version: "22.04"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: /opt/jdk-21
+            labels:
+              - ubuntu-22-amd64-highmem-maven21-nonspot
+              # Labels indicating it is the default VM template (for arm64)
+              - docker-highmem-nonspot
+            spot: false
             acpServerId: aws-internal
           ####
           # Windows VMs


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4688

- Enable the containers prefix for "normal linux container agents" to use the ECR cache (tested with success with bom agents) to decrease outbound bandwidth to DockerHub and improve container pulling performances
- Fix EC2 labels to ensure x86_64 JDK21 Spot agent is used for default with `docker` and `java` labels (yes these lables should go but..
- Add missing EC2 agent template `docker-highmem-nonspot`