### PR TITLE
fix(aws.ci) add missing 'docker && nonspot' support

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -375,6 +375,21 @@ profile::jenkinscontroller::jcasc:
               - docker
             spot: true
             acpServerId: aws-internal
+          - description: "Non Spot Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
+            maxInstances: 50
+            instanceType: M5dnXlarge # 4 vCPUs / 16 Gb / nvme 150Gb
+            os: "ubuntu"
+            os_version: "22.04"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: /opt/jdk-21
+            labels:
+              - ubuntu-22-amd64-maven21-nonspot
+              # Note: we need to get rid of these labels from doc. and caller as they can be used either by spot or non spot
+              - linux-amd64
+              - docker
+            spot: false
+            acpServerId: aws-internal
           ####
           # arm64 Linux VMs
           - description: "Spot Ubuntu 22.04 LTS arm64 with JDK17 set as default java CLI"


### PR DESCRIPTION
Ref.

We need to support the case of `docker && nonspot`:
- https://github.com/jenkins-infra/acceptance-tests/blob/a0c1de530865770497768df4a0f5611c65503bdd/Jenkinsfile#L20
- https://github.com/jenkins-infra/pipeline-library/blob/cee001dd5abeb557c7442cb8b57a4a22fc223cb3/vars/buildPlugin.groovy#L50-L55