### PR TITLE
hotfix(jenkinscontroller/ci.jenkins.io) set hostkey to CHECK_NEW_HARD by default

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -278,8 +278,7 @@ jenkins:
         description: "<%= agent['description'] %>"
         ebsEncryptRootVolume: DEFAULT
         ebsOptimized: "<%= agent['ebsOptimized'] ? "true" : "false" %>"
-        # TODO: allow customization
-        hostKeyVerificationStrategy: ACCEPT_NEW
+        hostKeyVerificationStrategy: CHECK_NEW_HARD
         idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] ? agent['idleTerminationMinutes'] : -5 %>"
         # Note: Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
         initScript: |-


### PR DESCRIPTION
Fix the warning message on ci.jenkins.io below:

<img width="1522" alt="Capture d’écran 2025-07-07 à 10 25 46" src="https://github.com/user-attachments/assets/d6262e3d-d566-4638-b788-9879d0a7e20e" />


I don't know why this did not pop when we ran the tests in https://github.com/jenkins-infra/helpdesk/issues/4688 🤔 