### PR TITLE
hotfix(jenkinscontroller/ci.jenkins.io) set hostkey to CHECK_NEW_SOFT on windows agents

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -278,7 +278,7 @@ jenkins:
         description: "<%= agent['description'] %>"
         ebsEncryptRootVolume: DEFAULT
         ebsOptimized: "<%= agent['ebsOptimized'] ? "true" : "false" %>"
-        hostKeyVerificationStrategy: CHECK_NEW_HARD
+        hostKeyVerificationStrategy: "<%= if $os == 'windows' ? CHECK_NEW_SOFT : CHECK_NEW_HARD %>%"
         idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] ? agent['idleTerminationMinutes'] : -5 %>"
         # Note: Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
         initScript: |-


### PR DESCRIPTION
As there are no host key upload to EC2 API out of the box

Related to https://github.com/jenkins-infra/helpdesk/issues/4688
Fixup of #4242 