### PR TITLE
chore(updatecli): add a manifest to track the tools url for jdk25 on ci.jio

### DIFF
--- a/updatecli/scripts/jdk-subdir.sh
+++ b/updatecli/scripts/jdk-subdir.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+if [ $# -eq 0 ]; then
+    echo "this script need a jdk download url"
+    exit 1
+fi
+
+command -v curl >/dev/null 2>&1 || { echo "ERROR: curl command not found. Exiting."; exit 1; }
+command -v tar >/dev/null 2>&1 || { echo "ERROR: tar command not found. Exiting."; exit 1; }
+
+DOWNLOAD_URL="$1"
+
+MAIN_FOLDER=$(curl --location --silent "$DOWNLOAD_URL" | tar --list --gzip | head -1 | cut -d'/' -f1)
+echo "${MAIN_FOLDER}"

--- a/updatecli/weekly.d/jenkinscontroller-tools-jdk25-ci.jio.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-jdk25-ci.jio.yaml
@@ -1,0 +1,101 @@
+---
+name: Bump jdk25 version (Jenkins tools) ci.jenkins.io linux-amd
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastRelease-Version-linux-amd64:
+    kind: temurin
+    spec:
+      featureversion: 25
+      releasetype: ea
+      architecture: x64
+      operatingsystem: linux
+
+  lastRelease-URL-linux-amd64:
+    kind: temurin
+    spec:
+      featureversion: 25
+      releasetype: ea
+      architecture: x64
+      operatingsystem: linux
+      result: installer_url
+  lastRelease-URL-linux-arm64:
+    kind: temurin
+    spec:
+      featureversion: 25
+      releasetype: ea
+      architecture: aarch64
+      operatingsystem: linux
+      result: installer_url
+  lastRelease-URL-linux-s390x:
+    kind: temurin
+    spec:
+      featureversion: 25
+      releasetype: ea
+      architecture: s390x
+      operatingsystem: linux
+      result: installer_url
+
+conditions:
+  bumpAllorNone:
+    sourceid: lastRelease-Version-linux-amd64
+    kind: temurin
+    spec:
+      releasetype: ea
+      ## add all platform to make sure to update everyone or none
+      platforms:
+        - linux/x64
+        - linux/aarch64
+        - linux/s390x
+
+targets:
+  setjdk25Version-linux-amd64:
+    name: "Bump jdk25 version on tools for linux-amd64"
+    sourceid: lastRelease-URL-linux-amd64
+    kind: yaml
+    spec:
+      files:
+        - hieradata/vagrant/common.yaml
+        - hieradata/clients/controller.ci.jenkins.io.yaml
+      key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.linux-amd64.custom_url
+    scmid: default
+  setjdk25Version-linux-arm64:
+    name: "Bump jdk25 version on tools for linux-arm64"
+    sourceid: lastRelease-URL-linux-arm64
+    kind: yaml
+    spec:
+      files:
+        - hieradata/vagrant/common.yaml
+        - hieradata/clients/controller.ci.jenkins.io.yaml
+      key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.linux-arm64.custom_url
+    scmid: default
+  setjdk25Version-linux-s390x:
+    name: "Bump jdk25 version on tools for linux-s390x"
+    sourceid: lastRelease-URL-linux-s390x
+    kind: yaml
+    spec:
+      files:
+        - hieradata/vagrant/common.yaml
+        - hieradata/clients/controller.ci.jenkins.io.yaml
+      key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.s390x.custom_url
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump jdk25 version (Jenkins tools) on ci.jenkins.io {{ source "lastRelease-Version-linux-amd64" }}
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/weekly.d/jenkinscontroller-tools-jdk25-ci.jio.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-jdk25-ci.jio.yaml
@@ -67,7 +67,7 @@ targets:
     spec:
       files:
         - hieradata/vagrant/common.yaml
-        - hieradata/clients/controller.ci.jenkins.io.yaml
+        - hieradata/clients/aws.ci.jenkins.io.yaml
       key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.linux-amd64.custom_url
     scmid: default
   setjdk25Version-linux-arm64:
@@ -77,7 +77,7 @@ targets:
     spec:
       files:
         - hieradata/vagrant/common.yaml
-        - hieradata/clients/controller.ci.jenkins.io.yaml
+        - hieradata/clients/aws.ci.jenkins.io.yaml
       key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.linux-arm64.custom_url
     scmid: default
   setjdk25Version-linux-s390x:
@@ -87,7 +87,7 @@ targets:
     spec:
       files:
         - hieradata/vagrant/common.yaml
-        - hieradata/clients/controller.ci.jenkins.io.yaml
+        - hieradata/clients/aws.ci.jenkins.io.yaml
       key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.s390x.custom_url
     scmid: default
 

--- a/updatecli/weekly.d/jenkinscontroller-tools-jdk25-ci.jio.yaml
+++ b/updatecli/weekly.d/jenkinscontroller-tools-jdk25-ci.jio.yaml
@@ -46,6 +46,10 @@ sources:
       architecture: s390x
       operatingsystem: linux
       result: installer_url
+  getSubDir:
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/jdk-subdir.sh {{ source "lastRelease-URL-linux-amd64" }}
 
 conditions:
   bumpAllorNone:
@@ -70,6 +74,16 @@ targets:
         - hieradata/clients/aws.ci.jenkins.io.yaml
       key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.linux-amd64.custom_url
     scmid: default
+  setjdk25Subdir-linux-amd64:
+    name: "Bump jdk25 subdir on tools for linux-amd64"
+    sourceid: getSubDir
+    kind: yaml
+    spec:
+      files:
+        - hieradata/vagrant/common.yaml
+        - hieradata/clients/aws.ci.jenkins.io.yaml
+      key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.linux-amd64.subdir
+    scmid: default
   setjdk25Version-linux-arm64:
     name: "Bump jdk25 version on tools for linux-arm64"
     sourceid: lastRelease-URL-linux-arm64
@@ -80,6 +94,16 @@ targets:
         - hieradata/clients/aws.ci.jenkins.io.yaml
       key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.linux-arm64.custom_url
     scmid: default
+  setjdk25Subdir-linux-arm64:
+    name: "Bump jdk25 subdir on tools for linux-arm64"
+    sourceid: getSubDir
+    kind: yaml
+    spec:
+      files:
+        - hieradata/vagrant/common.yaml
+        - hieradata/clients/aws.ci.jenkins.io.yaml
+      key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.linux-arm64.subdir
+    scmid: default
   setjdk25Version-linux-s390x:
     name: "Bump jdk25 version on tools for linux-s390x"
     sourceid: lastRelease-URL-linux-s390x
@@ -89,6 +113,16 @@ targets:
         - hieradata/vagrant/common.yaml
         - hieradata/clients/aws.ci.jenkins.io.yaml
       key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.s390x.custom_url
+    scmid: default
+  setjdk25Subdir-linux-s390x:
+    name: "Bump jdk25 subdir on tools for linux-s390x"
+    sourceid: getSubDir
+    kind: yaml
+    spec:
+      files:
+        - hieradata/vagrant/common.yaml
+        - hieradata/clients/aws.ci.jenkins.io.yaml
+      key: $.profile::jenkinscontroller::jcasc.tools.jdk.jdk25.installers.s390x.subdir
     scmid: default
 
 actions:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4641
depends on https://github.com/jenkins-infra/jenkins-infra/pull/4238

track jdk25 on tools for ci.jio