### PR TITLE
fix(aws.ci.jenkins.io) use the Z: drive (local NVMe) for tempdir (Windows path, agent execution and build execution)

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -512,7 +512,9 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-8'
+            # Utilizes the local NVMe mounted in Z:
             agentDir: 'Z:/jenkins'
+            tempDir: 'Z:/Temp'
             labels:
               - win-2019-amd64-maven-8
               - maven-8-windows
@@ -527,7 +529,9 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-11'
+            # Utilizes the local NVMe mounted in Z:
             agentDir: 'Z:/jenkins'
+            tempDir: 'Z:/Temp'
             labels:
               - win-2019-amd64-maven-11
               - maven-11-windows
@@ -543,7 +547,9 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-17'
+            # Utilizes the local NVMe mounted in Z:
             agentDir: 'Z:/jenkins'
+            tempDir: 'Z:/Temp'
             labels:
               - win-2019-amd64-maven-17
               - maven-17-windows
@@ -557,7 +563,9 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-17'
+            # Utilizes the local NVMe mounted in Z:
             agentDir: 'Z:/jenkins'
+            tempDir: 'Z:/Temp'
             labels:
               - win-2019-amd64-maven-17-nonspot
             spot: false
@@ -570,7 +578,9 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
+            # Utilizes the local NVMe mounted in Z:
             agentDir: 'Z:/jenkins'
+            tempDir: 'Z:/Temp'
             labels:
               - win-2019-amd64-maven-21
               - maven-21-windows
@@ -588,7 +598,9 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-17'
+            # Utilizes the local NVMe mounted in Z:
             agentDir: 'Z:/jenkins'
+            tempDir: 'Z:/Temp'
             labels:
               - win-2022-amd64-maven-11
               # Labels indicating it is the default VM template for Windows 2022 (but not windows)


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4730

Stolen from @MarkEWaite PR on the pipeline library in https://github.com/jenkins-infra/pipeline-library/pull/947 but generalized to all cases (Windows only though).

This PR changes the EC2 agent configuration for Windows agents to use the local NVMe (mounted in `Z:`) for temporary directory operations.
It includes:

- Agent temp dir setup (e.g. the temp dir Java process eventually passed to its children processes)
- Environment variables set to shell/powershell processes triggered by the agent

Until now was using the default `C:\Windows/Temp` which is in a mounted EBS drive.

----

Once merged, we'll have to check it is correctly applied by verifying:

- [ ] The reported environment values in "System Info" page of an allocated Windows agents
- [x] The powershell reported environment in a replayed pipeline (`pwsh 'dir env:'`)
- [x] The Java reported `java.io.tmpdir` property using `java -XshowSettings`
=> I'm not sure for Maven, I assume it honors `java.io.tmpdir` property from JVM?