### PR TITLE
fix(jenkinscontroller/ec2-clouds) specify tempdir to agent process and do not override init script tempdir

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds.yaml.erb
@@ -296,7 +296,7 @@ jenkins:
         <%- end -%>
         instanceCapStr: "<%= agent['maxInstances'] %>"
         javaPath: "<%= agent['agentJavaBin'] ? agent['agentJavaBin'] : @jcasc['agents_setup'][$os]['agentJavaBin'] %>"
-        jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] %>"
+        jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] %> -Djava.io.tmpdir=<%= $tempDir %>"
         labelString: "<%= $os == 'ubuntu' ? 'ubuntu linux' : 'windows' %> <%= $os + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['spot'] ? 'spot' : 'nonspot' %> <%= agent['labels'].join(' ') %>"
         launchTimeoutStr: "1000"
         maxTotalUses: 1 # Throw away the VMs after a build: ephemeral machines
@@ -348,13 +348,6 @@ jenkins:
         - name: "os"
           value: "<%= $os %>"
         tenancy: Default
-        <%- if $os == 'windows' -%>
-        # Double Backslash is required for EC2 plugin as we hackishly use the unix launched for Windows to use OpenSSH
-        # And JCasc needs 2 backslashes for a literal backslash.
-        tmpDir: "<%= $tempDir.gsub('/', '\\\\\\\\\\\\\\\\') %>" <%# Inside ERB instructions, a literal backslash is expressed using 4 backslashes %>
-        <%- else -%>
-        tmpDir: "<%= $tempDir %>"
-        <%- end -%>
         type: <%= agent['instanceType'] %>
         useEphemeralDevices: true
         # Note: Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -202,6 +202,7 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             agentDir: 'Z:/jenkins'
+            tempDir: 'Z:/Temp'
             labels:
               - docker-windows-2022
               - win-2022


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4730

This PR introduces 2 fixes related to the `ec2` agent clouds in the `jenkins::controller` profile:

- Stop specifying the `tmpDir` JCasC attributes which overrides the default init script temp. dir. It avoids concurrency issues between the "cloud init" steps (user data field, run as root/admin during Vm boot phase) and the init script itself. For instance: specifying `Z:/Temp` here may happen before the Z:  drive is mounted.
- Specify the resolved temp dir. for the agent process using Java flags. We already did use this resolved value for the environment variables (and it should be used by pipeline shell steps on all OSes) but the agent may also benefit from a custom tmp when specified