### PR TITLE
fix(aws.ci.jenkins.io): 2 errors in labels, wrong jdk

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -472,7 +472,6 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: /opt/jdk-17
             labels:
-              - docker-highmem
               - ubuntu-22-amd64-highmem-maven17
             spot: true
             acpServerId: aws-internal
@@ -607,7 +606,7 @@ profile::jenkinscontroller::jcasc:
             agentDir: 'Z:/jenkins'
             tempDir: 'Z:/Temp'
             labels:
-              - win-2022-amd64-maven-11
+              - win-2022-amd64-maven-17
               # Labels indicating it is the default VM template for Windows 2022 (but not windows)
               - docker-windows-2022
               - win-2022


### PR DESCRIPTION
while working on jdk25 I found out 2 errors in the labels:

- one is pointing docker-highmem on a jdk17 agent (we have jdk21 by default for those).
- the other is referring to jdk11 when is use jdk17