### PR TITLE
chore(updatecli) tracks `semver` version of azcopy

### DIFF
--- a/updatecli/weekly.d/azcopy.yaml
+++ b/updatecli/weekly.d/azcopy.yaml
@@ -21,6 +21,8 @@ sources:
       owner: Azure
       repository: azure-storage-azcopy
       token: "{{ requiredEnv .github.token }}"
+      versionFilter:
+        kind: semver
     transformers:
       - trimprefix: v
 


### PR DESCRIPTION
ref - https://github.com/jenkins-infra/jenkins-infra/pull/4276

This PR  tracks `semver` version of azcopy

Tested locally with success:

```

⚠ - change detected:
        * key "$.profile::azcopy::azcopy_version" should be updated from "10.30.0-preview.2" to "10.29.1", in file "hieradata/common.yaml"

```