### PR TITLE
fix(openvpn) correct an edge case where the route to private-vnet is not created due to an invalid 'unless' check

### DIFF
--- a/dist/profile/manifests/openvpn.pp
+++ b/dist/profile/manifests/openvpn.pp
@@ -144,7 +144,7 @@ class profile::openvpn (
         $gateway = "${network_prefix}.1"
         exec { "addroute ${peered_network_prefix}.0 through ${gateway} (NIC ${network_nic})":
           command => "ip route add ${peered_net_cidr} via ${gateway} dev ${network_nic}",
-          unless  => "route | grep ${peered_network_prefix}.0",
+          unless  => "ip route | grep ${network_nic} | grep ${peered_network_prefix}.0",
           require => [
             # The CLI command 'route' is needed
             Package['net-tools'],


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/4690, I was not able to reach the new `privatek8s` cluster even from the VPN VM.

After checking, it appears that there was a missing route: there should be a `private-vnet` route through `eth1` (while `eth0` is only the `private-vnet-dmz` subnet and default, preventing the access to the cluster API (and other private resources such as infra.ci agents).

This route is missing because the `unless` check of the `exec` resource is not accounting for this case: `eth0` route to the DMZ subnet (`10.248.0.0/28`) was selected by `grep`.

The PR corrects the check which successfully create the route!