### PR TITLE
feat: introduces aznfs profile and set up aznfs mount for agent.trusted.ci

### DIFF
--- a/dist/profile/manifests/aptmicrosoftprod.pp
+++ b/dist/profile/manifests/aptmicrosoftprod.pp
@@ -1,0 +1,23 @@
+# Profile to ensure `azcopy` and `az-cli` are installed, up-to-date and set up (SAS token generation, etc.)
+class profile::aptmicrosoftprod (
+
+) {
+  # Dependencies used to install azcopy
+  ensure_packages([
+      'curl',
+      'tar',
+  ])
+
+  $msprodpackagepath = '/tmp/packages-microsoft-prod.deb'
+  file { $msprodpackagepath:
+    ensure => 'file',
+    source => "https://packages.microsoft.com/config/${facts['os']['name'].downcase()}/${facts['os']['release']['full']}/packages-microsoft-prod.deb",
+  }
+
+  package { 'packages-microsoft-prod':
+    ensure   => present,
+    source   => $msprodpackagepath,
+    provider => dpkg,
+    require  => File[$msprodpackagepath],
+  }
+}

--- a/dist/profile/manifests/azcopy.pp
+++ b/dist/profile/manifests/azcopy.pp
@@ -5,39 +5,12 @@ class profile::azcopy (
   String $install_dir   = '/usr/local/bin',
 ) {
   include apt
-
-  # Dependencies used to install azcopy
-  ensure_packages([
-      'curl',
-      'tar',
-  ])
+  include profile::aptmicrosoftprod
 
   if $azcopy_version {
-    # Hack for Vagrant
-    if ( $facts['os']['architecture'] == 'aarch64' and $facts['os']['distro']['codename'] == 'bionic') {
-      exec { 'get-azcopy-bin':
-        require => [Package['curl'], Package['tar']],
-        command => '/usr/bin/curl --silent --show-error --location https://aka.ms/downloadazcopy-v10-linux-arm64 --output /tmp/azcopy.tgz && tar xzf /tmp/azcopy.tgz -C /tmp && find /tmp -type f -name azcopy -exec mv {} /usr/bin/ \; && rm -rf /tmp/azcopy*',
-        creates => '/usr/bin/azcopy',
-      }
-    } else {
-      $msprodpackagepath = '/tmp/microsoft-prod.deb'
-      file { $msprodpackagepath:
-        ensure => 'file',
-        source => "https://packages.microsoft.com/config/${facts['os']['name'].downcase()}/${facts['os']['release']['full']}/packages-microsoft-prod.deb",
-      }
-
-      package { 'microsoftprod':
-        ensure   => present,
-        source   => $msprodpackagepath,
-        provider => dpkg,
-        require  => File[$msprodpackagepath],
-      }
-
-      package { 'azcopy':
-        ensure  => $azcopy_version,
-        require => [Class['apt::update'], Package['microsoftprod']],
-      }
+    package { 'azcopy':
+      ensure  => $azcopy_version,
+      require => Class['apt::update'],
     }
   }
 

--- a/dist/profile/manifests/aznfs.pp
+++ b/dist/profile/manifests/aznfs.pp
@@ -1,0 +1,26 @@
+# Profile to ensure `azcopy` and `az-cli` are installed, up-to-date and set up (SAS token generation, etc.)
+class profile::aznfs (
+  Array $mounts                       = [],
+) {
+  include profile::aptmicrosoftprod
+
+  package { 'nfs-common':
+    ensure  => 'latest',
+    require => Class['apt::update'],
+  }
+
+  package { 'aznfs':
+    ensure  => 'latest',
+    require => Class['apt::update'],
+  }
+
+  $mounts.each | $aznfs_mount | {
+    mount { $aznfs_mount['mountpoint']:
+      ensure  => 'mounted',
+      atboot  => 'true',
+      device  => $aznfs_mount['url'],
+      fstype  => 'aznfs',
+      options => 'vers=4,minorversion=1,_netdev,nofail,sec=sys,nconnect=4',
+    }
+  }
+}

--- a/hieradata/clients/agent.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/agent.trusted.ci.jenkins.io.yaml
@@ -92,6 +92,8 @@ profile::updatecenter::rsync_privkey: >
   yhELTnLcIarOCyO2KKYf5WRC8XGvvlz70=]
 profile::buildagent::tools_versions:
   awscli: 2.28.3
+profile::aznfs::mounts:
+  "/updates-jenkins-io-data": "updatesjenkinsio.file.core.windows.net:/updatesjenkinsio/updates-jenkins-io-data"
 accounts:
   kevingrdj:
     ssh_keys:

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -86,6 +86,7 @@ node 'agent.trusted.ci.jenkins.io' {
     fstype => 'ext4',
   }
   include role::updatecenter
+  include profile::aznfs
 }
 node 'controller.trusted.ci.jenkins.io' {
   mount { '/var/lib/jenkins':


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4758#issuecomment-3159980783

This PR introduces:

- A new `aznfs` profile to install the brand new Azure `AZNFS` client as described in https://learn.microsoft.com/en-us/azure/storage/files/storage-files-how-to-mount-nfs-shares?tabs=Ubuntu#step-2-mount-an-nfs-azure-file-share and mount custom NFS
- Factorize the `packages-microsoft-prod` metapackage (so that `azcopy`, `aznfs` and `az` use the same and only once)
- Set up agent.trusted.ci.jenkins.io to have the updates.jenkins.io's file share mounted in NFSv4.1