### PR TITLE
fix(ci.jenkins.io.yaml) correct tool label matching to cover the non default `arm64` introduced with the AWS migration

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -60,13 +60,13 @@ profile::jenkinscontroller::jcasc:
         installers:
           linux-arm64:
             type: "zip"
-            label: "linux-arm64 && arm64"
+            label: "(linux-arm64 && arm64) || (linux && arm64)"
             cpu_arch: "aarch64"
       jdk11:
         installers:
           linux-arm64:
             type: "zip"
-            label: "linux-arm64 && arm64"
+            label: "(linux-arm64 && arm64) || (linux && arm64)"
             cpu_arch: "aarch64"
           s390x:
             type: "zip"
@@ -76,7 +76,7 @@ profile::jenkinscontroller::jcasc:
         installers:
           linux-arm64:
             type: "zip"
-            label: "linux-arm64 && arm64"
+            label: "(linux-arm64 && arm64) || (linux && arm64)"
             cpu_arch: "aarch64"
           s390x:
             type: "zip"
@@ -86,7 +86,7 @@ profile::jenkinscontroller::jcasc:
         installers:
           linux-arm64:
             type: "zip"
-            label: "linux-arm64 && arm64"
+            label: "(linux-arm64 && arm64) || (linux && arm64)"
             cpu_arch: "aarch64"
           s390x:
             type: "zip"
@@ -103,7 +103,7 @@ profile::jenkinscontroller::jcasc:
             subdir: jdk-25+30
           linux-arm64:
             type: "zip"
-            label: "linux-arm64 && arm64"
+            label: "(linux-arm64 && arm64) || (linux && arm64)"
             cpu_arch: "aarch64"
             # TODO: track with updatecli
             custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B30-ea-beta/OpenJDK25U-jdk_aarch64_linux_hotspot_25_30-ea.tar.gz

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -60,13 +60,13 @@ profile::jenkinscontroller::jcasc:
         installers:
           linux-arm64:
             type: "zip"
-            label: "(linux-arm64 && arm64) || (linux && arm64)"
+            label: "linux-arm64 || (linux && arm64)"
             cpu_arch: "aarch64"
       jdk11:
         installers:
           linux-arm64:
             type: "zip"
-            label: "(linux-arm64 && arm64) || (linux && arm64)"
+            label: "linux-arm64 || (linux && arm64)"
             cpu_arch: "aarch64"
           s390x:
             type: "zip"
@@ -76,7 +76,7 @@ profile::jenkinscontroller::jcasc:
         installers:
           linux-arm64:
             type: "zip"
-            label: "(linux-arm64 && arm64) || (linux && arm64)"
+            label: "linux-arm64 || (linux && arm64)"
             cpu_arch: "aarch64"
           s390x:
             type: "zip"
@@ -86,7 +86,7 @@ profile::jenkinscontroller::jcasc:
         installers:
           linux-arm64:
             type: "zip"
-            label: "(linux-arm64 && arm64) || (linux && arm64)"
+            label: "linux-arm64 || (linux && arm64)"
             cpu_arch: "aarch64"
           s390x:
             type: "zip"
@@ -96,14 +96,14 @@ profile::jenkinscontroller::jcasc:
         installers:
           linux-amd64:
             type: "zip"
-            label: "linux-amd64 && amd64"
+            label: "linux-amd64 || (linux && amd64)"
             cpu_arch: "x64"
             # TODO: track with updatecli
             custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B30-ea-beta/OpenJDK25U-jdk_x64_linux_hotspot_25_30-ea.tar.gz
             subdir: jdk-25+30
           linux-arm64:
             type: "zip"
-            label: "(linux-arm64 && arm64) || (linux && arm64)"
+            label: "linux-arm64 || (linux && arm64)"
             cpu_arch: "aarch64"
             # TODO: track with updatecli
             custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B30-ea-beta/OpenJDK25U-jdk_aarch64_linux_hotspot_25_30-ea.tar.gz


### PR DESCRIPTION
When me moved ci.jenkins.io from Azure to AWS, we had to introduce spot/non spot instances, along with JDK21 additionally.
It led to unplanned cases met by @daniel-beck where there were missing labels.

As explained in  https://github.com/jenkins-infra/helpdesk/issues/4762#issuecomment-3163158212, I'm not sure if the tool specified labels are matched against the "pipeline/user requested labels" or against the "effective labels of the agent taken for the job/stage" => as such i would like multiple review of this proposed change to be sure it works as expected

cc @MarkEWaite @daniel-beck @timja 