### PR TITLE
cleanup(jenkinscontroller/ec2-clouds) remove support for winrm

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -21,17 +21,10 @@ jenkins:
       <%- $javaHome = agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] -%>
       - ami: "<%= agent['ami'] ? agent['ami'] : @jcasc['agent_images']['ec2_amis'][$os + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"
         amiType:
-      <%- if agent['launcher'] && agent['launcher'] == "winrm" -%>
-          windowsData:
-            allowSelfSignedCertificate: true
-            specifyPassword: false
-            useHTTPS: true
-      <%- else -%>
           unixData:
             sshPort: "22"
-        <%- if $os == 'windows' -%>
+      <%- if $os == 'windows' -%>
             bootDelay: "60"
-        <%- end -%>
       <%- end -%>
         associatePublicIp: "<%= agent['associatePublicIp'] ? agent['associatePublicIp'] : (ec2_cloud_setup['associatePublicIp'] ? ec2_cloud_setup['associatePublicIp'] : "false" ) %>"
         connectBySSHProcess: false
@@ -169,42 +162,9 @@ jenkins:
                 (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: <%= @jcasc['datadog_api_key'] %>' | Set-Content C:\ProgramData\Datadog\datadog.yaml
                 & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart-service
 
-        <%- if agent['launcher'] && agent['launcher'] == "winrm" -%>
-                ## Setup WinRM
-                # Remove existing listeners
-                Remove-Item -Path WSMan:\Localhost\listener\listener* -Recurse
-
-                # Generate a new Cert using the current hostname (instead of the AMI inherited one)
-                $Cert = New-SelfSignedCertificate -CertstoreLocation Cert:\LocalMachine\My -DnsName $env:computername
-                New-Item -Path WSMan:\LocalHost\Listener -Transport HTTPS -Address * -CertificateThumbPrint $Cert.Thumbprint -Force
-
-                # Setup WinRM from scratch and restart it
-                cmd.exe /c winrm quickconfig -q
-                cmd.exe /c winrm set "winrm/config" '@{MaxTimeoutms="1800000"}'
-                cmd.exe /c winrm set "winrm/config/winrs" '@{MaxMemoryPerShellMB="1024"}'
-                cmd.exe /c winrm set "winrm/config/service" '@{AllowUnencrypted="true"}'
-                cmd.exe /c winrm set "winrm/config/client" '@{AllowUnencrypted="true"}'
-                cmd.exe /c winrm set "winrm/config/service/auth" '@{Basic="true"}'
-                cmd.exe /c winrm set "winrm/config/client/auth" '@{Basic="true"}'
-                cmd.exe /c winrm set "winrm/config/service/auth" '@{CredSSP="true"}'
-                cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTPS" "@{Port=`"5986`";Hostname=`"$($env:computername)`";CertificateThumbprint=`"$($Cert.Thumbprint)`"}"
-                # Yes, Firewall
-                cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes
-                # CIFS over TCP
-                cmd.exe /c netsh firewall add portopening TCP 445 "Port 445"
-                # WinRM HTTP
-                cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985"
-                # WinRM HTTPS
-                cmd.exe /c netsh firewall add portopening TCP 5986 "Port 5986"
-                cmd.exe /c net stop winrm
-                cmd.exe /c net start winrm
-                # Sanity check
-                winrm enumerate winrm/config/listener
-        <%- else -%>
                 ## Disable WinRM
                 Remove-Item -Path WSMan:\Localhost\listener\listener* -Recurse
                 cmd.exe /c net stop winrm
-        <%- end -%>
 
                 ## Setup Docker Engine
                 @'

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -213,7 +213,6 @@ profile::jenkinscontroller::jcasc:
               - docker-windows-2022
               - win-2022
             spot: false
-            launcher: winrm
     kubernetes:
       first-cluster:
         enabled: true


### PR DESCRIPTION
As it makes pipeline unstable while Windows support OpenSSH natively. Less code to maintain!