### PR TITLE
fix(jenkinscontroller/ec2-clouds) remove SSH delay on Windows machines for faster agent availability

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -24,7 +24,6 @@ jenkins:
         amiType:
       <%- if $os == 'windows' -%>
           windowsSSHData:
-            bootDelay: "60"
       <%- else -%>
           unixData:
       <%- end -%>
@@ -130,9 +129,6 @@ jenkins:
                 # Don't set this before Set-ExecutionPolicy as it throws an error
                 $ErrorActionPreference = "stop"
 
-                # Ensure Jenkins controller does not start the agent in process in its workspace until we are ready
-                Stop-Service sshd
-
                 ## Setup NVMe
                 $nb = Get-Disk | Where-Object PartitionStyle -eq 'RAW' | tee -Variable Disks | measure
                 Write-Output "$nb.Count disk found."
@@ -178,9 +174,6 @@ jenkins:
 
                 # Restart docker engine
                 Restart-Service docker
-
-                # Ensure Jenkins controller does not start the agent in process in its workspace until we are ready
-                Start-Service sshd
 
                 ## Mark cloud init as finished using a marker file
                 New-Item -Path "<%= $cloudInitDoneParentDir %>" -ItemType "Directory"


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/4730, following #4329 and #4330, it appears that we can safely remove the SSH delay of 60s on Windows EC2 agents:

- VM AMI is now effectively running proper sysprep with no restart during the boot (taken care by Fast Launch)
- The Windows SSH native launcher allows us to block the agent initialization until a custom marker file is created
=> No need to stop and start SSH which was causing the requirement for a 60s delay (SSH connection was done BEFORE cloudinit effectively started its userdata powershell script: stoping SSH closed abruptely the connection, resulting in killing the VM agent).

Tested on vagrant (syntax).

Also manually on ci.jenkins.io: result is a Windows agent ready in ~2 min (instead of 3-4 min before):

```
15:39:51  [Pipeline] node
15:40:06  Still waiting to schedule task
15:40:06  ‘[EC2 (aws-us-east-2) - Windows Infra Test (i-0ca5461e8d83d19a6)](https://ci.jenkins.io/computer/EC2%20%28aws%2Dus%2Deast%2D2%29%20%2D%20Windows%20Infra%20Test%20%28i%2D0ca5461e8d83d19a6%29/)’ is offline
15:41:56  Running on [EC2 (aws-us-east-2) - Windows Infra Test (i-0ca5461e8d83d19a6)](https://ci.jenkins.io/computer/EC2%20%28aws%2Dus%2Deast%2D2%29%20%2D%20Windows%20Infra%20Test%20%28i%2D0ca5461e8d83d19a6%29/) in Z:/jenkins/workspace/ra_acceptance-tests_infra-checks
15:41:56  [Pipeline] {
```