### PR TITLE
feat(jenkinscontroller/ec2-clouds/windows) create 'jenkins' user during boot phase when specifying a custom drive and custom user

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -160,9 +160,10 @@ jenkins:
                 }
 
                 ## Setup Docker Engine to store its data in the <%= agent['customDataDisk'] %> drive
+                # Note: file path MUST use Unix-style separator (/)
                 @'
                 {
-                  "data-root": "<%= agent['customDataDisk'] %>\docker"
+                  "data-root": "<%= agent['customDataDisk'] %>/docker"
                 }
                 '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
 

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -16,7 +16,8 @@ jenkins:
       templates:
     <%- ec2_cloud_setup['agent_definitions'].each do |agent| -%>
       <%- $os = agent['os'] ? agent['os'] : 'ubuntu' -%>
-      <%- $tempDir = agent['tempDir'] ? agent['tempDir'] : @jcasc['agents_setup'][$os]['tempDir'] -%>
+      <%- $tempDir =  agent['customDataDisk'] ? agent['customDataDisk'] + '/Temp' : (agent['tempDir'] ? agent['tempDir'] : @jcasc['agents_setup'][$os]['tempDir']) -%>
+      <%- $remoteAdmin = agent['remoteAdmin'] ? agent['remoteAdmin'] : @jcasc['agents_setup'][$os]['remoteAdmin'] -%>
       <%- $cloudInitDoneParentDir = "#{$tempDir}" -%>
       <%- $cloudInitDoneFile = "#{$cloudInitDoneParentDir}/.cloud-init.done" -%>
       <%- $javaHome = agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] -%>
@@ -93,8 +94,8 @@ jenkins:
               value: "<%= $tempDir %>"
       <%- end -%>
         numExecutors: 1
-        remoteAdmin: "<%= @jcasc['agents_setup'][$os]['remoteAdmin'] %>"
-        remoteFS: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>"
+        remoteAdmin: "<%= $remoteAdmin %>"
+        remoteFS: "<%= agent['customDataDisk'] ? agent['customDataDisk'] + '/agent' : (agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir']) %>"
         securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
       <%- if agent['spot'] -%>
         spotConfig:
@@ -129,7 +130,8 @@ jenkins:
                 # Don't set this before Set-ExecutionPolicy as it throws an error
                 $ErrorActionPreference = "stop"
 
-                ## Setup NVMe
+                <%- if agent['customDataDisk'] -%>
+                ## Setup NVMe(s) and map it to the <%= agent['customDataDisk'] %> drive
                 $nb = Get-Disk | Where-Object PartitionStyle -eq 'RAW' | tee -Variable Disks | measure
                 Write-Output "$nb.Count disk found."
                 Switch ($nb.Count)
@@ -141,7 +143,7 @@ jenkins:
                       $Disks | New-Partition -UseMaximumSize -MbrType IFS
                       $Partition = Get-Partition -DiskNumber $Disks.Number
                       $Partition | Format-Volume -FileSystem NTFS -Confirm:$false
-                      $Partition | Add-PartitionAccessPath -AccessPath "Z:"
+                      $Partition | Add-PartitionAccessPath -AccessPath "<%= agent['customDataDisk'] %>"
                       Get-WmiObject Win32_Volume | Format-Table Name, Label, FreeSpace, Capacity
                   }
                   default {
@@ -151,11 +153,39 @@ jenkins:
                               New-Partition -UseMaximumSize -MbrType IFS
                               $Partition = Get-Partition -DiskNumber $_.Number
                               $Partition | Format-Volume -FileSystem NTFS -Confirm:$false
-                              $Partition | Add-PartitionAccessPath -AccessPath "Z:"
+                              $Partition | Add-PartitionAccessPath -AccessPath "<%= agent['customDataDisk'] %>"
                           } -End {Get-Date}
                       Get-WmiObject Win32_Volume | Format-Table Name, Label, FreeSpace, Capacity
                   }
                 }
+
+                ## Setup Docker Engine to store its data in the <%= agent['customDataDisk'] %> drive
+                @'
+                {
+                  "data-root": "<%= agent['customDataDisk'] %>\docker"
+                }
+                '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
+
+                # Restart docker engine
+                Restart-Service docker
+                <%- end -%>
+
+                <%- if $remoteAdmin != 'Administrator' -%>
+                # Create the '<%= $remoteAdmin %>' agent's user account
+                $loginName="<%= $remoteAdmin %>"
+                $localHost=[ADSI]"WinNT://localhost"
+                $newUser=$localHost.Create("user",$loginName);
+                $newUser.setPassword("J3nkinsSuperSecret1234!");
+                $newUser.put("description", "User account for Jenkins Agent");
+                $newUser.setInfo();
+                Add-LocalGroupMember -Group "Administrators" -Member "$loginName"
+                  <%- if agent['customDataDisk'] -%>
+                # Custom user profiles dir. in the <%= agent['customDataDisk'] %> drive
+                $regpath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\ProfileList"
+                $regname = "ProfilesDirectory"
+                Set-ItemProperty -path $regpath -name $regname -value "<%= agent['customDataDisk'] %>"
+                  <%- end -%>
+                <%- end -%>
 
                 ## Setup datadog
                 (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: <%= @jcasc['datadog_api_key'] %>' | Set-Content C:\ProgramData\Datadog\datadog.yaml
@@ -164,16 +194,6 @@ jenkins:
                 ## Disable WinRM
                 Remove-Item -Path WSMan:\Localhost\listener\listener* -Recurse
                 cmd.exe /c net stop winrm
-
-                ## Setup Docker Engine
-                @'
-                {
-                  "data-root": "Z:/docker"
-                }
-                '@ | Set-Content C:\ProgramData\Docker\config\daemon.json
-
-                # Restart docker engine
-                Restart-Service docker
 
                 ## Mark cloud init as finished using a marker file
                 New-Item -Path "<%= $cloudInitDoneParentDir %>" -ItemType "Directory"
@@ -274,7 +294,7 @@ jenkins:
           EOF
               systemd-analyze verify "^${mount_unit_name}"
               systemctl enable "^${mount_unit_name}" --now
-              chown -R jenkins:jenkins "^${array_mount_point}"
+              chown -R <%= $remoteAdmin %>:<%= $remoteAdmin %> "^${array_mount_point}"
           fi
 
           ## Setup Docker Engine

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -575,8 +575,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-8'
             # Utilizes the local NVMe mounted in Z:
-            agentDir: 'Z:/jenkins'
-            tempDir: 'Z:/Temp'
+            customDataDisk: 'Z:'
             labels:
               - win-2019-amd64-maven-8
               - maven-8-windows
@@ -592,8 +591,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-11'
             # Utilizes the local NVMe mounted in Z:
-            agentDir: 'Z:/jenkins'
-            tempDir: 'Z:/Temp'
+            customDataDisk: 'Z:'
             labels:
               - win-2019-amd64-maven-11
               - maven-11-windows
@@ -608,8 +606,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-17'
             # Utilizes the local NVMe mounted in Z:
-            agentDir: 'Z:/jenkins'
-            tempDir: 'Z:/Temp'
+            customDataDisk: 'Z:'
             labels:
               - win-2019-amd64-maven-17
               - maven-17-windows
@@ -624,8 +621,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-17'
             # Utilizes the local NVMe mounted in Z:
-            agentDir: 'Z:/jenkins'
-            tempDir: 'Z:/Temp'
+            customDataDisk: 'Z:'
             labels:
               - win-2019-amd64-maven-17-nonspot
             spot: false
@@ -639,8 +635,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
             # Utilizes the local NVMe mounted in Z:
-            agentDir: 'Z:/jenkins'
-            tempDir: 'Z:/Temp'
+            customDataDisk: 'Z:'
             labels:
               - win-2019-amd64-maven-21
               - maven-21-windows
@@ -659,8 +654,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-25'
             # Utilizes the local NVMe mounted in Z:
-            agentDir: 'Z:/jenkins'
-            tempDir: 'Z:/Temp'
+            customDataDisk: 'Z:'
             labels:
               - win-2019-amd64-maven-25
               - maven-25-windows
@@ -675,8 +669,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-17'
             # Utilizes the local NVMe mounted in Z:
-            agentDir: 'Z:/jenkins'
-            tempDir: 'Z:/Temp'
+            customDataDisk: 'Z:'
             labels:
               - win-2022-amd64-maven-17
               # Labels indicating it is the default VM template for Windows 2022 (but not windows)
@@ -693,8 +686,7 @@ profile::jenkinscontroller::jcasc:
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
             # Utilizes the local NVMe mounted in Z:
-            agentDir: 'Z:/jenkins'
-            tempDir: 'Z:/Temp'
+            customDataDisk: 'Z:'
             labels:
               - infratest-windows
             spot: true

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -192,10 +192,23 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
-            agentDir: 'Z:/jenkins'
+            customDataDisk: 'Z:'
             labels:
               - docker-windows
               - docker-windows-2019
+            spot: false
+          - description: "Windows 2019 x86_64 with JDK21"
+            maxInstances: 5
+            ami: ami-xxxxxxxxx
+            instanceType: T3aXlarge # 4 vCPUs / 16 Gb
+            os: "windows"
+            os_version: "2019"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: 'C:/tools/jdk-21'
+            customDataDisk: 'Z:'
+            remoteAdmin: jenkins
+            labels:
               - win-2019
               - win-2019-amd64-maven-21
             spot: false
@@ -207,8 +220,6 @@ profile::jenkinscontroller::jcasc:
             os_version: "2022"
             ebsOptimized: true
             architecture: "amd64"
-            agentDir: 'Z:/jenkins'
-            tempDir: 'Z:/Temp'
             labels:
               - docker-windows-2022
               - win-2022


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4730#issuecomment-3174027719

This PR introduces a new parameter in hieradata: `customDataDisk` which, when specified, ensures that not only Docker data dir, tempdir, Jenkins agents dir, but also the user directory are stored in this disk.

=> It ensures that any call to local files (.m2 repository, etc.) uses the mounted NVMe instead of slow rootfs in AWS.


Tests run:
- Syntax check in vagrant (see the scenario provided)
- ci.jenkins.io manual test with the `infratest-windows` machine: https://ci.jenkins.io/job/Infra/job/acceptance-tests/job/infra-checks/224/replay/