### PR TITLE
feat(agent.trusted) mount the new datastorage NFS

### DIFF
--- a/hieradata/clients/agent.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/agent.trusted.ci.jenkins.io.yaml
@@ -95,6 +95,8 @@ profile::buildagent::tools_versions:
 profile::aznfs::mounts:
   - mountpoint: "/updates-jenkins-io-data"
     url: "updatesjenkinsio.file.core.windows.net:/updatesjenkinsio/updates-jenkins-io-data"
+  - mountpoint: "/data-storage-jenkins-io"
+    url: "datastoragejenkinsio.file.core.windows.net:/datastoragejenkinsio/data-storage-jenkins-io"
 accounts:
   kevingrdj:
     ssh_keys:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4767#issuecomment-3180139293

Verification done prior to this PR:

- Mount point created
- Manually mounted the NFS share once and started to populate it with future dir tree for updates.jenkins.io and get.jenkins.io:

```
$ mount -t aznfs datastoragejenkinsio.file.core.windows.net:/datastoragejenkinsio/data-storage-jenkins-io /data-storage-jenkins-io -o vers=4,minorversion=1,sec=sys,nconnect=4
$ df -h /data-storage-jenkins-io/
Filesystem                                               Size  Used Avail Use% Mounted on
127.0.0.1:/datastoragejenkinsio/data-storage-jenkins-io  750G     0  750G   0% /data-storage-jenkins-io
$ mkdir -p /data-storage-jenkins-io/updates.jenkins.io/redirections /data-storage-jenkins-io/updates.jenkins.io/geoipdata /data-storage-jenkins-io/updates.jenkins.io/content /data-storage-jenkins-io/get.jenkins.io/mirrorbits /data-storage-jenkins-io/get.jenkins.io/geoipdata
$ umount /data-storage-jenkins-io
```