### PR TITLE
cleanup(agent.trusted) remove the (now) unused updates.jenkins.io NFS mount in favor of the new data-storage one as default

### DIFF
--- a/hieradata/clients/agent.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/agent.trusted.ci.jenkins.io.yaml
@@ -93,8 +93,6 @@ profile::updatecenter::rsync_privkey: >
 profile::buildagent::tools_versions:
   awscli: 2.28.8
 profile::aznfs::mounts:
-  - mountpoint: "/updates-jenkins-io-data"
-    url: "updatesjenkinsio.file.core.windows.net:/updatesjenkinsio/updates-jenkins-io-data"
   - mountpoint: "/data-storage-jenkins-io"
     url: "datastoragejenkinsio.file.core.windows.net:/datastoragejenkinsio/data-storage-jenkins-io"
 accounts:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4767#issuecomment-3180139293