### PR TITLE
fix(pkg,archives) correct a few elements from #4344

### DIFF
--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -148,8 +148,22 @@ Host ${$osuosl_mirroring['host']}
     ensure => present,
   }
 
-  # Create apache dirs
-  [$archives_dir, $apache_log_dir_fqdn,$apache_log_dir_legacy_fqdn].each |String $dir| {
+  # Create dirs owned by mirrorsync user but required by httpd service
+  # Note: apache user is expected to be a member of the mirrorbits group
+  [$archives_dir].each |String $dir| {
+    file { $dir:
+      ensure  => directory,
+      owner   => $mirrorsync_user,
+      group   => $mirrorsync_group,
+      mode    => '0755',
+      require => [
+        User[$mirrorsync_user],
+        Group[$mirrorsync_group],
+      ],
+    }
+  }
+  # Create dirs owned by apache and required by httpd service
+  [$apache_log_dir_fqdn,$apache_log_dir_legacy_fqdn].each |String $dir| {
     file { $dir:
       ensure  => directory,
       owner   => $apache_owner,

--- a/dist/profile/templates/archives/mirrorsync.erb
+++ b/dist/profile/templates/archives/mirrorsync.erb
@@ -63,9 +63,9 @@ sync_osuosl(){
   echo "$TIME - OSUOSL successfully synchronized" >> /var/log/mirrorsync/mirrorsync.log
 }
 
-# Ensure we run this script as user <%= @owner %>
-if [ "$(/usr/bin/whoami)" != "<%= @apache_owner %>" ]; then
-  exec /usr/bin/sudo --user="<%= @apache_owner %>" /usr/bin/mirrorsync
+# Ensure we run this script as user <%= @mirrorsync_user %>
+if [ "$(/usr/bin/whoami)" != "<%= @mirrorsync_user %>" ]; then
+  exec /usr/bin/sudo --user="<%= @mirrorsync_user %>" /usr/bin/mirrorsync
 else
   time sync_osuosl
 fi

--- a/dist/profile/templates/mirror-scripts/sync.sh.erb
+++ b/dist/profile/templates/mirror-scripts/sync.sh.erb
@@ -1,6 +1,5 @@
 #!/bin/bash -xe
 base_dir="<%= @release_root %>"
-jenkins_data_dir="${base_dir}/jenkins"
 archives_jio_host="<%= @archives_jenkins_io_mirroring["username"] %>@<%= @archives_jenkins_io_mirroring["host"] %>"
 archives_remote_dir="/srv/releases"
 script_flag="${1}"
@@ -18,7 +17,7 @@ echo ">> Updating the latest symlink for LTS RC"
 /srv/releases/update-latest-symlink.sh "-stable-rc"
 
 echo ">> Delivering bits to archives.jenkins.io (fallback of get.jenkins.io)"
-pushd "${jenkins_data_dir}"
+pushd "${base_dir}"
 time rsync --recursive \
   --links `# Copy symlinks as symlinks: destination is a Linux filesystem` \
   --perms `# Preserve permissions: destination is a Linux filesystem` \

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -120,6 +120,8 @@ osuosl_mirroring::username: jenkins
 osuosl_mirroring::privkey: ''
 osuosl_mirroring::known_hosts:
 - '|1|FT0ktWYsQXSvsnAM5+QPVeT0ZMA=|MpUvUUaEFw0LH6MwlHzails4s2U= ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGBiBCeg+35U7h9ckQzDbNHX0O1aYC5yT8mGj/aWmBRlOThU+Qgd199XWgr1Eb6Lnnpol/ZLYKQE7UKK6U0m7iM='
+- '|1|yDsn0WtrT6LnEYwcPrgzhYtozi8=|66DNkrAGDMBCy73CuvzEnZ6Rn/4= ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCgSzcofSNcr0LWSmVRb/14QNaEAPRn8aY2VpCKY9L+4d+/3x537gWNUs2h8YTF+tmwwV4Qk8wzZSr5vfrWDcGRgQrA28I4tinsGUm0g/9uXN71Dso9Ci8p9pR4uxr2E9lc5vwltaPt5WhphY0XLrzneweGwDrINVFoQd4R6/7PfRHPpkL95SX3fS0VwkvNBAtTC9ghpr68g5jOZjThrxooom+Wkn8D38XcOY76EWAdSz68ZRvjHGDt1almqUWekeeOwzOf4ESGgWfpk2xIVu4t+7DLGuJfv11HcOZgjqXWJG4RH9VRc2Hy4dZSoAU6OuplFh30MsggikYUZmciq2eL'
+- '|1|uu8x0w9RGi/Ynhj7b2LMnt/UVL0=|VPmpjfNZ0lOdN+mRhkJ/fmjJb/s= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFLNMBOqPAhksTi+573SvJ5m1PS/OUvHALnaevJ4eINS'
 archives_jenkins_io_mirroring::host: archives.jenkins.io
 archives_jenkins_io_mirroring::username: mirrorsync
 archives_jenkins_io_mirroring::privkey: ''


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4653

This PR fixes up #4344 (see comment in https://github.com/jenkins-infra/jenkins-infra/pull/4344#issuecomment-3188261769 for details):

- archives: Ensure the user `mirrorsync` owns the data dir `/srv/release`
- archives: Ensure the user `mirrorsync` is used by the `/usr/bin/mirrorsync` sync script
- archives: Ensure ososul SSH host fingerprints are all there (there was only 1 while we need 3)
- pkg: Ensure the correct 'basedir' is used in the 'sync.sh' script