### PR TITLE
feat(ci.jenkins.io) change EC2 cloud default setup regarding `idleTerminationTime` and `avoidUsingOrphanedNodes`

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -30,6 +30,8 @@ jenkins:
       <%- end -%>
             sshPort: "22"
         associatePublicIp: "<%= agent['associatePublicIp'] ? agent['associatePublicIp'] : (ec2_cloud_setup['associatePublicIp'] ? ec2_cloud_setup['associatePublicIp'] : "false" ) %>"
+        avoidUsingOrphanedNodes: true # Set maxTotalUses to 1 when this is true (ephemeral VMs)
+        maxTotalUses: 1 # Throw away the VMs after a build
         connectBySSHProcess: false
         connectionStrategy: "<%= agent['associatePublicIp'] || ec2_cloud_setup['associatePublicIp'] ? "PUBLIC_DNS" : "PRIVATE_IP" %>"
         deleteRootOnTermination: true
@@ -37,7 +39,7 @@ jenkins:
         ebsEncryptRootVolume: DEFAULT
         ebsOptimized: "<%= agent['ebsOptimized'] ? "true" : "false" %>"
         hostKeyVerificationStrategy: "<%= $os == 'windows' ? "CHECK_NEW_SOFT" : "CHECK_NEW_HARD" %>"
-        idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] ? agent['idleTerminationMinutes'] : -5 %>"
+        idleTerminationMinutes: "<%= agent['idleTerminationMinutes'] ? agent['idleTerminationMinutes'] : '1' %>"
         # Note: Escape '$' in JCasc with '^' - ref. https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc#passing-secrets-through-variables
         initScript: |-
       <%- if $os == 'windows' -%>
@@ -64,7 +66,6 @@ jenkins:
         jvmopts: "<%= agent['agentJavaOpts'] ? agent['agentJavaOpts'] : @jcasc['agents_setup'][$os]['agentJavaOpts'] %> -Djava.io.tmpdir=<%= $tempDir %>"
         labelString: "<%= $os == 'ubuntu' ? 'ubuntu linux' : 'windows' %> <%= $os + "-" + agent['os_version'] %> <%= agent['architecture'] %> aws ec2 vm <%= agent['spot'] ? 'spot' : 'nonspot' %> <%= agent['labels'].join(' ') %>"
         launchTimeoutStr: "1000"
-        maxTotalUses: 1 # Throw away the VMs after a build: ephemeral machines
         metadataEndpointEnabled: true
         metadataHopsLimit: 1
         metadataSupported: true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4768#issuecomment-3196841090

This PR introduces 2 changes on the EC2 cloud agent templates (ci.jenkins.io only):

- Idle Termination time is now set to 1 minutes. The goal is to run the "EC2 GC" as often as possible

<img width="1371" height="336" alt="Capture d’écran 2025-08-18 à 15 49 36" src="https://github.com/user-attachments/assets/6016a50f-f3bb-4c4e-b4b1-6e2a385ef1a7" />

- Enable the "Avoid Using Orphaned Nodes": we only use Ephemeral machines, let's use this (relatively) new feature as per @jglick advise:

<img width="1285" height="242" alt="Capture d’écran 2025-08-18 à 15 49 29" src="https://github.com/user-attachments/assets/8a16492b-212e-439d-8771-86cb44084e51" />
