### PR TITLE
fix(ci.jenkins.io/profile::jenkinscontroller) stabilization: ensure EC2 clouds removes orphans nodes and fallback to ondemand instance when spot is out of capacity

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -4,6 +4,7 @@ jenkins:
   <%- @jcasc['cloud_agents']['ec2'].each do |ec2_cloud_name, ec2_cloud_setup| -%>
   - amazonEC2:
       name: <%= ec2_cloud_name %>
+      cleanUpOrphanedNodes: true
       credentialsId: "<%= ec2_cloud_setup['credentialsId'] %>"
     <%- $maxEC2Vms = 0; ec2_cloud_setup['agent_definitions'].each do |agent| -%>
       <%- $maxEC2Vms = agent['maxInstances'] + $maxEC2Vms -%>
@@ -100,7 +101,7 @@ jenkins:
         securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
       <%- if agent['spot'] -%>
         spotConfig:
-          fallbackToOndemand: false
+          fallbackToOndemand: true
           useBidPrice: false
       <%- end -%>
         stopOnTerminate: false


### PR DESCRIPTION
This PR works around stabilizing the behavior of ci.jenkins.io regarding the EC2 cloud VM agents which are having many issues:

- Enable cleanup of "orphans" instances. As per https://github.com/jenkins-infra/jenkins-infra/pull/4353#discussion_r2282530140 (related to https://github.com/jenkins-infra/helpdesk/issues/4768), EC2 plugin can "garbage" collect instances not connected since 3 hours.
  - Cc @MarkEWaite : I guess it will avoid Pagerduty errors about disk almost full on EC2 instances which are not visible on ci.jenkins.io anymore (but still in EC2).
  - Should alleviate Spot capacity not available, which queues many jobs (for instance ATH jobs in https://github.com/jenkins-infra/helpdesk/issues/4771) because these "orphaned" EC2 instances are eating slots

- Also set up the "fallback to ondemand" option for spot instances, so we always get an instance. It should help in solving https://github.com/jenkins-infra/helpdesk/issues/4771 but we'll have to carefully check cloud credits.
  - Note: we should work on the BOM builds to decrease the amount of (underlying) VM being used.