### PR TITLE
Install CSP plugin on cert.ci

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -272,6 +272,7 @@ profile::jenkinscontroller::plugins:
   # System configuration
   - azure-vm-agents
   - configuration-as-code
+  - csp
   - generic-tool
   - ldap
   - matrix-auth


### PR DESCRIPTION
As noted in https://github.com/jenkins-infra/helpdesk/issues/4776, it's already installed, but this aligns the as-code.