### PR TITLE
cleanup(hieradata/common) remove unused dummy LDAP values

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -250,10 +250,6 @@ profile::jenkinscontroller::jcasc:
     jdk17: 17.0.16+8
     jdk21: 21.0.8+9
     maven: 3.9.11
-ldap_url: "ldap://localhost:389"
-ldap_dn: "dc=example,dc=com"
-ldap_admin_dn: "cn=admin,dc=example,dc=com"
-ldap_admin_password: "hunter2"
 # These variables should be filled in, in production.yaml, with the legacy
 # jenkins-ci.org cert details
 ssl_legacy_cert: ""

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -170,3 +170,7 @@ profile::jenkinscontroller::plugins:
   - toolenv
   - workflow-aggregator
   - workflow-multibranch
+ldap_url: "ldap://localhost:389"
+ldap_dn: "dc=example,dc=com"
+ldap_admin_dn: "cn=admin,dc=example,dc=com"
+ldap_admin_password: "DummyPasswordForRspecUnitTests"

--- a/hieradata/rspec/role_jenkins.yaml
+++ b/hieradata/rspec/role_jenkins.yaml
@@ -6,3 +6,7 @@ lookup_options:
       merge_hash_arrays: true
 
 profile::jenkinscontroller::ci_fqdn: 'jenkins.role.rspec.test.local'
+ldap_url: "ldap://localhost:389"
+ldap_dn: "dc=example,dc=com"
+ldap_admin_dn: "cn=admin,dc=example,dc=com"
+ldap_admin_password: "DummyPasswordForRspecUnitTests"


### PR DESCRIPTION
Note: these dummy values are still required by rspec unit tests. Changed the "dummy" password value accordingly so that reporters should not think we have plain text passwords