### PR TITLE
fix(ci.jenkins.io) change EC2 VM agents subnet (to use another AZ)

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -351,7 +351,7 @@ profile::jenkinscontroller::jcasc:
         # TODO: maintain with updatecli
         securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
         # TODO: maintain with updatecli
-        subnetId: "subnet-00279b22fc0bb0997"
+        subnetId: "subnet-0ec8bba512d3f0b31"
         # TODO: maintain with updatecli
         registryMirror: "k8s-hubmirro-hubmirro-477f7dfd76-9bbe4e560ee83036.elb.us-east-2.amazonaws.com:5000"
         agent_definitions:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4768#issuecomment-3206148755

The subnet has been created in https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/324

Tested manually with success using the "infra test" template: https://ci.jenkins.io/job/Infra/job/acceptance-tests/job/infra-checks/262/