### PR TITLE
fix(ci.jio) temporarily adding manually the spot label on non-spot agents

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -538,6 +538,8 @@ profile::jenkinscontroller::jcasc:
               - highram
               - docker-highmem
               - linux-amd64-big
+              # temporarily adding manually the false label spot to avoid job failure since https://github.com/jenkins-infra/helpdesk/issues/4795
+              - spot
             # we switch temporarily to non spot as per https://github.com/jenkins-infra/helpdesk/issues/4795
             spot: false
             acpServerId: aws-internal


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4795
and following #4397 we add `spot` to those non-spot agent to ensure that no job would fail waiting for that kind of agent.