### PR TITLE
chore(updatecli) cert.ci maven tool versions

### DIFF
--- a/updatecli/updatecli.d/jenkinscontroller-cert-ci-maven.yaml
+++ b/updatecli/updatecli.d/jenkinscontroller-cert-ci-maven.yaml
@@ -61,25 +61,25 @@ sources:
 
 conditions:
   checkIfReleaseIsAvailable3-5:
-    kind: file
+    kind: shell
     disablesourceinput: true
     spec:
-      file: https://archive.apache.org/dist/maven/maven-3/{{ source `mavenVersion3-5` }}/binaries/apache-maven-{{ source `mavenVersion3-5` }}-bin.tar.gz
+      command: curl --connect-timeout 5 --location --head --fail --silent --show-error https://archive.apache.org/dist/maven/maven-3/{{ source `mavenVersion3-5` }}/binaries/apache-maven-{{ source `mavenVersion3-5` }}-bin.tar.gz
   checkIfReleaseIsAvailable3-6:
-    kind: file
+    kind: shell
     disablesourceinput: true
     spec:
-      file: https://archive.apache.org/dist/maven/maven-3/{{ source `mavenVersion3-6` }}/binaries/apache-maven-{{ source `mavenVersion3-6` }}-bin.tar.gz
+      command: curl --connect-timeout 5 --location --head --fail --silent --show-error https://archive.apache.org/dist/maven/maven-3/{{ source `mavenVersion3-6` }}/binaries/apache-maven-{{ source `mavenVersion3-6` }}-bin.tar.gz
   checkIfReleaseIsAvailable3-8:
-    kind: file
+    kind: shell
     disablesourceinput: true
     spec:
-      file: https://archive.apache.org/dist/maven/maven-3/{{ source `mavenVersion3-8` }}/binaries/apache-maven-{{ source `mavenVersion3-8` }}-bin.tar.gz
+      command: curl --connect-timeout 5 --location --head --fail --silent --show-error https://archive.apache.org/dist/maven/maven-3/{{ source `mavenVersion3-8` }}/binaries/apache-maven-{{ source `mavenVersion3-8` }}-bin.tar.gz
   checkIfReleaseIsAvailable3-9:
-    kind: file
+    kind: shell
     disablesourceinput: true
     spec:
-      file: https://archive.apache.org/dist/maven/maven-3/{{ source `mavenVersion3-9` }}/binaries/apache-maven-{{ source `mavenVersion3-9` }}-bin.tar.gz
+      command: curl --connect-timeout 5 --location --head --fail --silent --show-error https://archive.apache.org/dist/maven/maven-3/{{ source `mavenVersion3-9` }}/binaries/apache-maven-{{ source `mavenVersion3-9` }}-bin.tar.gz
 
 targets:
   updateMaven3-5Version:


### PR DESCRIPTION
The updatecli execution is quite long and one of the culprit is the condition of type `file` which downloads the whole Maven archive while what we only want to test the existence.

This download accounts for a lot of Mb and quite some time spent on it:

```
08:11:09  condition: condition#checkIfReleaseIsAvailable3-5
08:11:09  --------------------------------------
08:13:09  ✔ condition on file ["https://archive.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz"] passed
08:13:09  
08:13:09  condition: condition#checkIfReleaseIsAvailable3-9
08:13:09  --------------------------------------
08:14:35  ✔ condition on file ["https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz"] passed
08:14:35  
08:14:35  condition: condition#checkIfReleaseIsAvailable3-6
08:14:35  --------------------------------------
08:15:27  ubuntu-22-4512c1 seems to be removed or offline (java.lang.InterruptedException); will wait for 5 min 0 sec for it to come back online
08:15:48  ubuntu-22-4512c1 is back online
08:15:59  ✔ condition on file ["https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz"] passed
08:15:59  
08:15:59  condition: condition#checkIfReleaseIsAvailable3-8
08:15:59  --------------------------------------
08:17:01  ✔ condition on file ["https://archive.apache.org/dist/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz"] passed
```

----

(edit) result is good:

- Before: `Took 9 min 58 sec`
- After: `Took 4 min 56 sec`