### PR TITLE
feat(usage): add the new VM usage.do.jenkins.io

### DIFF
--- a/dist/profile/manifests/usage.pp
+++ b/dist/profile/manifests/usage.pp
@@ -6,27 +6,43 @@
 #
 # This usage information is then processed and ultimately finds its way into
 # our "census" data
+# letsencrypt = true (Default)
+#   Enable letsencrypt configuration, for this to work the sensus host has to
+#   be on the public internet
+#
 class profile::usage (
   Stdlib::Absolutepath $docroot    = '/var/www/usage.jenkins.io',
   Stdlib::Absolutepath $home_dir   = '/srv/bigger-usage',
   Stdlib::Fqdn         $usage_fqdn = 'usage.jenkins.io',
+  Stdlib::Fqdn         $usage_fqdn_legacy = 'usage.jenkins-ci.org',
   String               $user       = 'usagestats',
   String               $group      = 'usagestats',
   Hash                 $ssh_keys   = undef,
+  # Boolean              $letsencrypt = true,
 ) {
   include stdlib # Required to allow using stlib methods and custom datatypes
   include apache
-  # volume configuration is in hiera
-  include lvm
+
+  $lvm_enable = lookup('lvm::volume_groups', { default_value => {}, value_type => Hash, merge => hash })
+  if $lvm_enable {
+    # volume configuration is in hiera
+    include lvm
+  }
   include profile::accounts
   include profile::apachemisc
   include profile::firewall
-  include profile::letsencrypt
 
-  package { 'lvm2':
-    ensure => present,
+  $letsencrypt = lookup( 'letsencrypt::enable', Boolean )
+
+  if $letsencrypt {
+    include profile::letsencrypt
   }
 
+  if $lvm_enable {
+    package { 'lvm2':
+      ensure => present,
+    }
+  }
   $mounted_logs_dir = "${home_dir}/apache-logs"
   $mounted_stats_dir = "${home_dir}/usage-stats"
 
@@ -135,7 +151,7 @@ class profile::usage (
   apache::vhost { "${usage_fqdn} unsecured":
     servername                   => $usage_fqdn,
     serveraliases                => [
-      'usage.jenkins-ci.org',
+      $usage_fqdn_legacy,
     ],
     port                         => 80,
     use_servername_for_filenames => true,
@@ -153,63 +169,42 @@ class profile::usage (
     ],
   }
 
-  # Legacy (usage.jenkins-ci.org) SSL host with the legacy SSL key
-  file { '/etc/apache2/legacy_cert.key':
-    ensure  => file,
-    content => lookup('ssl_legacy_key'),
-    require => Package['httpd'],
-  }
-
-  file { '/etc/apache2/legacy_chain.crt':
-    ensure  => file,
-    content => lookup('ssl_legacy_chain'),
-    require => Package['httpd'],
-  }
-  file { '/etc/apache2/legacy_cert.crt':
-    ensure  => file,
-    content => lookup('ssl_legacy_cert'),
-    require => Package['httpd'],
-  }
-
   # Since usage stats are reported via the browser instead of the Jenkins
   # controller itself, we can just redirect from usage.jenkins-ci.org to
   # usage.jenkins.io and let usage.jenkins.io log the access
   # https://github.com/jenkinsci/jenkins/blob/5416411/core/src/main/resources/hudson/model/UsageStatistics/footer.jelly
-  apache::vhost { 'usage.jenkins-ci.org':
-    servername                   => 'usage.jenkins-ci.org',
+  apache::vhost { $usage_fqdn_legacy:
+    servername                   => $usage_fqdn_legacy,
     docroot                      => $docroot,
     port                         => 443,
     use_servername_for_filenames => true,
     use_port_for_filenames       => true,
     ssl                          => true,
-    ssl_key                      => '/etc/apache2/legacy_cert.key',
-    ssl_chain                    => '/etc/apache2/legacy_chain.crt',
-    ssl_cert                     => '/etc/apache2/legacy_cert.crt',
     override                     => ['All'],
     redirect_status              => 'permanent',
-    redirect_dest                => 'https://usage.jenkins.io/',
+    redirect_dest                => "https://${usage_fqdn}/",
     # Blackhole all these redirect logs https://issues.jenkins-ci.org/browse/INFRA-739
 
     access_log_file              => '/dev/null',
     require                      => [
-      File['/etc/apache2/legacy_cert.crt'],
-      File['/etc/apache2/legacy_cert.key'],
-      File['/etc/apache2/legacy_chain.crt'],
       Apache::Vhost[$usage_fqdn],
     ],
   }
 
-  # We can only acquire certs in production due to the way the letsencrypt
-  # challenge process works
-  if (($environment == 'production') and ($facts['vagrant'] != '1')) {
+  # Obtain Let's Encrypt certificate(s) and set them up in Apache if in production (e.g. not in vagrant local test)
+  if ($letsencrypt == true) and ($environment == 'production') {
+    $letsencrypt_plugin = lookup('profile::letsencrypt::plugin')
+
+    # Request a multi-domain certificate (uses Subject Alternate Name)
     letsencrypt::certonly { $usage_fqdn:
-      domains => [$usage_fqdn],
-      plugin  => 'apache',
+      domains       => [$usage_fqdn, $usage_fqdn_legacy],
+      custom_plugin => true,
+      manage_cron   => false,
     }
 
     Apache::Vhost <| title == $usage_fqdn |> {
-      ssl_key   => "/etc/letsencrypt/live/${usage_fqdn}/privkey.pem",
-      ssl_cert  => "/etc/letsencrypt/live/${usage_fqdn}/fullchain.pem",
+      ssl_key       => "/etc/letsencrypt/live/${usage_fqdn}/privkey.pem",
+      ssl_cert      => "/etc/letsencrypt/live/${usage_fqdn}/fullchain.pem",
     }
   }
 }

--- a/hieradata/clients/usage.do.jenkins.io.yaml
+++ b/hieradata/clients/usage.do.jenkins.io.yaml
@@ -1,0 +1,11 @@
+---
+# Per-host Datadog configuration
+datadog_agent::host: "usage.do.jenkins.io"
+profile::usage::home_dir: '/srv/usage'
+accounts:
+  abayer:
+    ssh_keys:
+      abayer_laptop:
+        key: AAAAB3NzaC1yc2EAAAABIwAAAQEA402I3RoTGntFReTPTs5UGO2HkU4UN3PDZ/slALFXRC6qKMhdySzHfIXJTVx8IE7Z/TcBuM411Hy/HwTZFZBihw/B8mD6ubut5py0GUc8sI/Qo7++1qaEjhXg6aLZGqu+USH0aE/fgqzZq1o8YF+HxuN5FhWKsbL3T1ukf387gT6rhuUje4Ch9ko/h40IsIyvpcqVCGo47SfDz+lCT2A0mXp/rtJRYOTGdqLAUcJ1zZNawf7FrxGtphuppgyGYFHT+qq4lRRlgVu6rZrAWWoDPPexGB4XuRrbcgKXZ595WQjpx+zlz6Og5TNX4bvX59MQPKr8cg3Qj842ZfOgPkBvOw==
+    groups:
+      - sudo

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -77,6 +77,7 @@ accounts:
     groups:
       - sudo
 # Lets Encrypt settings
+letsencrypt::enable: true
 letsencrypt::config::email: "tyler@monkeypox.org"
 letsencrypt::config::server: "https://acme-staging-v02.api.letsencrypt.org/directory" # Staging by default
 profile::letsencrypt::plugin: apache

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -9,6 +9,7 @@ lookup_options:
       strategy: deep
       merge_hash_arrays: true
 profile::jenkinscontroller::letsencrypt: false
+letsencrypt::enable: false # TODO use this setting on all profiles (see usage.yaml)
 # Per-host Datadog configuration
 datadog_agent::host: "vagrant.local"
 datadog_agent::non_local_traffic: true # Allow jenkins container to contact the agent for metrics
@@ -16,6 +17,14 @@ datadog_agent::apm_enabled: true
 datadog_agent::apm_non_local_traffic: true # Allow jenkins container to contact the agent for traces and logs
 datadog_agent::agent_extra_options:
   bind_host: "0.0.0.0" # All hosts interfaces to allow container access
+# Fake self signed certificate
+ssl_legacy_cert: |
+  -----BEGIN CERTIFICATE-----
+  -----END CERTIFICATE-----
+# Fake self signed certificate
+ssl_legacy_key: |
+  -----BEGIN PRIVATE KEY-----
+  -----END PRIVATE KEY-----
 usage_ssh_privkey: |
   -----BEGIN RSA PRIVATE KEY-----
   overridewith_usage_ssh_privkey

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -17,14 +17,6 @@ datadog_agent::apm_enabled: true
 datadog_agent::apm_non_local_traffic: true # Allow jenkins container to contact the agent for traces and logs
 datadog_agent::agent_extra_options:
   bind_host: "0.0.0.0" # All hosts interfaces to allow container access
-# Fake self signed certificate
-ssl_legacy_cert: |
-  -----BEGIN CERTIFICATE-----
-  -----END CERTIFICATE-----
-# Fake self signed certificate
-ssl_legacy_key: |
-  -----BEGIN PRIVATE KEY-----
-  -----END PRIVATE KEY-----
 usage_ssh_privkey: |
   -----BEGIN RSA PRIVATE KEY-----
   overridewith_usage_ssh_privkey

--- a/hieradata/vagrant/roles/usage.yaml
+++ b/hieradata/vagrant/roles/usage.yaml
@@ -1,9 +1,2 @@
 ---
-lvm::volume_groups:
-  data:
-    physical_volumes:
-      - /dev/loop0
-    logical_volumes:
-      usage:
-        size: 12M
-        mountpath: /srv/usage
+profile::usage::home_dir: '/srv/usage'

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -40,6 +40,15 @@ node 'archives.do.jenkins.io' {
   }
   include role::archives
 }
+node 'usage.do.jenkins.io' {
+  mount { '/srv':
+    ensure => 'mounted',
+    atboot => 'true',
+    device => 'UUID=5e21c9f9-d2a2-422b-90e9-433d9ba42de1',
+    fstype => 'ext4',
+  }
+  include role::usage
+}
 
 node 'census' {
   sshkeyman::hostkey { ['census.jenkins.io']: }

--- a/spec/classes/profile/usage_spec.rb
+++ b/spec/classes/profile/usage_spec.rb
@@ -71,9 +71,8 @@ describe 'profile::usage' do
         :port => 443,
         :ssl => true,
         :docroot => params[:docroot],
-        :ssl_key   => '/etc/apache2/legacy_cert.key',
-        :ssl_chain => '/etc/apache2/legacy_chain.crt',
-        :ssl_cert  => '/etc/apache2/legacy_cert.crt',
+        :ssl_key   => '/etc/ssl/private/ssl-cert-snakeoil.key',
+        :ssl_cert  => '/etc/ssl/certs/ssl-cert-snakeoil.pem',
         :redirect_dest => 'https://usage.jenkins.io/',
       })
     end


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/1626

- change the way we set the usage of letsencrypt with a global switch
- detect if lvm plugin is needed or not
- add the new VM to the puppet master

testing done
impact limited to the new machine, but as a security measure, I will disable puppet agent on the current usage VM.
