### PR TITLE
fix(usage.jenkins-ci.org) fix certificate to use usage.jenkins.io one

### DIFF
--- a/dist/profile/manifests/usage.pp
+++ b/dist/profile/manifests/usage.pp
@@ -206,5 +206,10 @@ class profile::usage (
       ssl_key       => "/etc/letsencrypt/live/${usage_fqdn}/privkey.pem",
       ssl_cert      => "/etc/letsencrypt/live/${usage_fqdn}/fullchain.pem",
     }
+
+    Apache::Vhost <| title == $usage_fqdn_legacy |> {
+      ssl_key       => "/etc/letsencrypt/live/${usage_fqdn}/privkey.pem",
+      ssl_cert      => "/etc/letsencrypt/live/${usage_fqdn}/fullchain.pem",
+    }
   }
 }


### PR DESCRIPTION
following #4414 need to provide the certificate for legacy domain usage.jenkins-ci.org