### PR TITLE
feat: add `authenticated_access` propertie to `jenkinscontroller` for read access of authenticated users

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -15,6 +15,7 @@
 #
 class profile::jenkinscontroller (
   Boolean $anonymous_access                    = false,
+  Boolean $authenticated_access                = false,
   Array $admin_ldap_groups                     = ['admins'],
   Stdlib::Fqdn $ci_fqdn                        = '',
   Hash $additional_fqdns                       = {},

--- a/dist/profile/templates/jenkinscontroller/lockbox.groovy.erb
+++ b/dist/profile/templates/jenkinscontroller/lockbox.groovy.erb
@@ -53,6 +53,15 @@ AuthorizationStrategy strategy = new GlobalMatrixAuthorizationStrategy()
 }
 <%end%>
 
+<%if @authenticated_access %>
+[
+    Jenkins.READ,
+    Item.READ,
+].each { permission ->
+    strategy.add(permission, PermissionEntry.user('authenticated'))
+}
+<%end%>
+
 <% @admin_ldap_groups.each do |group|%>
 strategy.add(Jenkins.ADMINISTER, PermissionEntry.group('<%= group %>'))
 <%end%>

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -11,6 +11,7 @@ datadog_agent::apm_non_local_traffic: true # Allow jenkins container to contact 
 datadog_agent::agent_extra_options:
   bind_host: "0.0.0.0" # All hosts interfaces to allow container access
 profile::jenkinscontroller::anonymous_access: true
+profile::jenkinscontroller::authenticated_access: true
 profile::jenkinscontroller::admin_ldap_groups:
   - admins
   - jenkins-admins

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -38,6 +38,7 @@ profile::jenkinscontroller::additional_fqdns:
 profile::jenkinscontroller::proxy_port: 443
 profile::jenkinscontroller::groovy_init_enabled: false
 profile::jenkinscontroller::memory_limit: '14g'
+profile::jenkinscontroller::authenticated_access: true
 profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: SuperSecretThatShouldBeEncryptedInProduction
@@ -55,6 +56,14 @@ profile::jenkinscontroller::jcasc:
         # but hierdata is behaving weirdly (bug in YAML parser?)
         defaultDisplayUrlProvider:
           providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
+      # Allow to check authenticated_access in http://localhost:8080/manage/configureSecurity/
+      jenkins:
+        securityRealm:
+          local:
+            allowsSignup: false
+            users:
+              - id: "admin"
+                password: "butler"
   csp-plugin:
     reportOnly: true
     rule: |-


### PR DESCRIPTION
This PR allows a controller to give read permission to authenticated users, ex on ci.jenkins.io

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4780#issuecomment-3324423281

### Testing done
Ran `vagrant up --provision jenkins::controller` then checked authenticated users access on http://localhost:8080/manage/configureSecurity/:

> <img width="1617" height="833" alt="image" src="https://github.com/user-attachments/assets/a155d23f-42ab-4b4b-9c18-867b3e71f9b3" />
