### PR TITLE
fix(jenkinscontroller/jcasc/amazon-ec2) use new JCasC syntax for IP strategy

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -30,11 +30,11 @@ jenkins:
           unixData:
       <%- end -%>
             sshPort: "22"
-        associatePublicIp: "<%= agent['associatePublicIp'] ? agent['associatePublicIp'] : (ec2_cloud_setup['associatePublicIp'] ? ec2_cloud_setup['associatePublicIp'] : "false" ) %>"
+        associateIPStrategy: "PRIVATE_IP"
         avoidUsingOrphanedNodes: true # Set maxTotalUses to 1 when this is true (ephemeral VMs)
         maxTotalUses: 1 # Throw away the VMs after a build
         connectBySSHProcess: false
-        connectionStrategy: "<%= agent['associatePublicIp'] || ec2_cloud_setup['associatePublicIp'] ? "PUBLIC_DNS" : "PRIVATE_IP" %>"
+        connectionStrategy: "PRIVATE_IP"
         deleteRootOnTermination: true
         description: "<%= agent['description'] %>"
         ebsEncryptRootVolume: DEFAULT

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -351,7 +351,6 @@ profile::jenkinscontroller::jcasc:
         region: us-east-2
         useInstanceProfileForCredentials: true
         sshKeysCredentialsId: "ec2-agent-ssh"
-        associatePublicIp: false
         # TODO: maintain with updatecli
         securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
         # TODO: maintain with updatecli

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -157,7 +157,6 @@ profile::jenkinscontroller::jcasc:
         region: us-east-2
         useInstanceProfileForCredentials: true
         sshKeysCredentialsId: "ec2-agent-ssh"
-        associatePublicIp: false
         securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
         subnetId: "subnet-0138ee90cd53d58f7"
         registryMirror: "urltodockerproxy:5000"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4832

This PR adapts our JCasC setup, when using the `ec2` plugin, to ensure that plugin version https://github.com/jenkinsci/ec2-plugin/releases/tag/2036.vb_105a_db_e4a_ea_ and above can be used.

Since we do NOT use public IPs at all for EC2 agebnts, we remove all the associated code and set up private IP raw.