### PR TITLE
fix(jenkinscontroller/jcasc) correct obsolete syntax to fix warning messsage

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/global-libraries.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/global-libraries.yaml.erb
@@ -15,7 +15,7 @@ unclassified:
         retriever:
           modernSCM:
             scm:
-              git:
+              gitSource:
                 id: "<%= name %>"
                 remote: "<%= setup['remote'] %>"
                 traits:


### PR DESCRIPTION
This PR fixes the following warning message in the administrative monitor which appears a few days ago (LTS 2.528.1 ?):

```
'git' is obsolete, please use 'gitSource'
```

<img width="757" height="262" alt="Capture d’écran 2025-10-20 à 08 27 11" src="https://github.com/user-attachments/assets/3ca53b99-6dee-42ba-8adf-2b89dd8f7387" />


Tested with vagrant: the warning disappear with this change
