### PR TITLE
feat(ci.jenkins.io/tools/jdk25) use agent JDK installation instead of downloading an installer

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -98,33 +98,16 @@ profile::jenkinscontroller::jcasc:
             cpu_arch: "s390x"
       jdk25:
         installers:
-          linux-amd64:
-            type: "zip"
-            label: "linux-amd64 || (linux && amd64)"
-            cpu_arch: "x64"
-            # TODO: track with updatecli
-            custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B30-ea-beta/OpenJDK25U-jdk_x64_linux_hotspot_25_30-ea.tar.gz
-            subdir: jdk-25+30
           linux-arm64:
-            type: "zip"
+            type: command
             label: "linux-arm64 || (linux && arm64)"
-            cpu_arch: "aarch64"
-            # TODO: track with updatecli
-            custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B30-ea-beta/OpenJDK25U-jdk_aarch64_linux_hotspot_25_30-ea.tar.gz
-            subdir: jdk-25+30
-          s390x:
-            type: "zip"
+            command: "echo /opt/jdk-25"
+            toolHome: /opt/jdk-25
+          linux-s390x:
+            type: command
             label: "s390x"
-            cpu_arch: "s390x"
-            # TODO: track with updatecli
-            custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B30-ea-beta/OpenJDK25U-jdk_s390x_linux_hotspot_25_30-ea.tar.gz
-            subdir: jdk-25+30
-          windows-amd64:
-            type: "zip"
-            label: "windows"
-            os: "windows"
-            custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B25-ea-beta/OpenJDK-jdk_x64_windows_hotspot_25_25-ea.zip
-            subdir: "jdk-26+1"
+            command: "echo /opt/jdk-25"
+            toolHome: /opt/jdk-25
   artifact_caching_proxy:
     enabled: true
     servers:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -207,6 +207,18 @@ profile::jenkinscontroller::jcasc:
             type: "zip"
             label: "windows"
             os: "windows"
+      jdk25:
+        installers:
+          linux-amd64:
+            type: command
+            label: "linux-amd64 || (linux && amd64)"
+            command: "echo /opt/jdk-25"
+            toolHome: /opt/jdk-25
+          windows-amd64:
+            type: batchFile
+            label: "windows || windows-2019 || windows-2022 || maven-25-windows"
+            command: "echo C:/Tools/jdk-25"
+            toolHome: "C:/Tools/jdk-25"
   agents_setup:
     windows:
       agentDir: 'C:/Jenkins/agent'

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -110,30 +110,16 @@ profile::jenkinscontroller::jcasc:
             cpu_arch: "s390x"
       jdk25:
         installers:
-          linux-amd64:
-            type: "zip"
-            label: "linux && amd64"
-            cpu_arch: "x64"
-            custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B30-ea-beta/OpenJDK25U-jdk_x64_linux_hotspot_25_30-ea.tar.gz
-            subdir: jdk-25+30
           linux-arm64:
-            type: "zip"
-            label: "linux && arm64"
-            cpu_arch: "aarch64"
-            custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B30-ea-beta/OpenJDK25U-jdk_aarch64_linux_hotspot_25_30-ea.tar.gz
-            subdir: jdk-25+30
-          s390x:
-            type: "zip"
+            type: command
+            label: "linux-arm64 || (linux && arm64)"
+            command: "echo /opt/jdk-25"
+            toolHome: /opt/jdk-25
+          linux-s390x:
+            type: command
             label: "s390x"
-            cpu_arch: "s390x"
-            custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B30-ea-beta/OpenJDK25U-jdk_s390x_linux_hotspot_25_30-ea.tar.gz
-            subdir: jdk-25+30
-          windows-amd64:
-            type: "zip"
-            label: "windows"
-            os: "windows"
-            custom_url: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B25-ea-beta/OpenJDK-jdk_x64_windows_hotspot_25_25-ea.zip
-            subdir: "jdk-26+1"
+            command: "echo /opt/jdk-25"
+            toolHome: /opt/jdk-25
   permanent_agents:
     s390x-agent:
       remoteFS: /home/jenkins/agent


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4831#issuecomment-3433351085

This PR changes the JDK25 tool installers for ci.jenkins.io to use the JDK25 already installed in the agents instead of trying to download the Adoptium installer on each build.

It also means less code and less updates for the Jenkins infra team as the packer image will be the only location where to update.


Testing done:
- Hieradata (Puppet) + JCasC syntax on the local Vagrant VM
- Tried on ci.jenkins with 2 JDKs manually:

```
# ci.jenkins.io JCasC excerpt
- name: "jdk25"
  properties:
    # ...
    # Unchanged installers here to avoid mayhem
    # ...
      - command:
          command: "echo '/opt/jdk-25'"
          label: "s390x"
          toolHome: "/opt/jdk-25"
      - batchFile:
          command: "echo 'C:/Tools/jdk-25'"
          label: "windows"
          toolHome: "C:/Tools/jdk-25"
```

Then ran the following pipelines:

```
node('s390x') {
    final static String javaHome = "${tool name: 'jdk25', type: 'jdk'}"
    withEnv(["JAVA_HOME=${javaHome}","PATH+JAVA=${javaHome}/bin"]) {
        sh 'env | sort -u'
        sh 'which java'
        sh 'java -version'
        sh 'mvn -v'
    }
}
```

Result:

```text
13:49:58  + which java
13:49:58  /opt/jdk-25/bin/java
13:50:06  [Pipeline] sh
13:49:58  + java -version
13:49:58  openjdk version "25" 2025-09-16 LTS
13:49:58  OpenJDK Runtime Environment Temurin-25+36 (build 25+36-LTS)
13:49:58  OpenJDK 64-Bit Server VM Temurin-25+36 (build 25+36-LTS, mixed mode, sharing)
13:50:06  [Pipeline] sh&&&@
13:49:59  + mvn -v
13:49:59  Apache Maven 3.9.11 (3e54c93a704957b63ee3494413a2b544fd3d825b)
13:49:59  Maven home: /home/jenkins/tools/apache-maven-3.9.11
13:49:59  Java version: 25, vendor: Eclipse Adoptium, runtime: /opt/jdk-25
13:49:59  Default locale: en_US, platform encoding: UTF-8
13:49:59  OS name: "linux", version: "5.15.0-157-generic", arch: "s390x", family: "unix"
```

and Windows:

```
node('windows') {
    final static String javaHome = "${tool name: 'jdk25', type: 'jdk'}"
    withEnv(["JAVA_HOME=${javaHome}","PATH+JAVA=${javaHome}/bin"]) {
        pwsh 'gci env:'
        pwsh 'java -version'
        pwsh 'mvn -v'
    }
}
```

```text
14:03:26  [Pipeline] pwsh
14:03:24  openjdk version "25" 2025-09-16 LTS
14:03:24  OpenJDK Runtime Environment Temurin-25+36 (build 25+36-LTS)
14:03:24  OpenJDK 64-Bit Server VM Temurin-25+36 (build 25+36-LTS, mixed mode, sharing)
14:03:31  [Pipeline] pwsh
14:03:36  Apache Maven 3.9.11 (3e54c93a704957b63ee3494413a2b544fd3d825b)
14:03:36  Maven home: C:\tools\apache-maven-3.9.11
14:03:36  Java version: 25, vendor: Eclipse Adoptium, runtime: C:\Tools\jdk-25
14:03:36  Default locale: en_US, platform encoding: UTF-8
14:03:36  OS name: "windows server 2019", version: "10.0", arch: "amd64", family: "windows"
```