### PR TITLE
feat(jenkinscontroller/cert.ci.jio/ci.jio/trusted) Ensure that JDK tools always use the agent local JDKs instead of installing on each build

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
@@ -37,38 +37,22 @@ tool:
   jdk:
     installations:
     <%- @jcasc['tools']['jdk'].each do |name, setup| -%>
-      <%- unless setup['disabled'] -%>
     - name: "<%= name %>"
       properties:
       - installSource:
           installers:
-        <%- setup['installers'].each do |installer_name, installer_setup| -%>
-          - <%= installer_setup['type'] %>:
-          <%- if installer_setup['label'] -%>
-              label: "<%= installer_setup['label'] %>"
-          <%- end -%>
-          <%- if installer_setup['type'] == 'zip' -%>
-            <%- $jdk_major_version = name.gsub('jdk-','').gsub('jdk_','').gsub('jdk','') # Remove eventual prefix
-            $jdk = {
-              'name' => name,
-              'major_version' => $jdk_major_version,
-              'version' => installer_setup['version'] ? installer_setup['version'] : @jcasc['tools_default_versions']["jdk" + $jdk_major_version],
-              'cpu_arch' => installer_setup['cpu_arch'] ? installer_setup['cpu_arch'] : 'x64',
-              'os' => installer_setup['os'] ? installer_setup['os'] : 'linux',
-            }
-            -%>
-              # subdir is the top-level directory in the archive: depends on the how the JDK is packaged. Defaults to adoptium convention unless a customized version is specified
-              # Example of subdirs for adoptium 8: jdk8u345-b01, adoptium 11: jdk-11.0.16+8, adoptium 17: jdk-17.0.4+8, adoptium 21: jdk-21+35 ...
-              subdir: "<%= installer_setup['subdir'] ? installer_setup['subdir'] : ("jdk" + ($jdk_major_version.to_i == 8 ? '' : '-') + ($jdk_major_version.to_i == 21 ? $jdk['version'].gsub('-ea-beta', '') : $jdk['version'])) %>"
-              url: "<%= installer_setup['custom_url'] ? installer_setup['custom_url'] : (scope.call_function('template', ["profile/jdk-adoptium-url.erb"]).chop()) %>"
-          <%- elsif installer_setup['type'] == 'command' -%>
-              command: "<%= installer_setup['command'] %>"
-              toolHome: "<%= installer_setup['toolHome'] %>"
-          <%- elsif installer_setup['type'] == 'batchFile' -%>
-              command: "<%= installer_setup['command'] %>"
-              toolHome: "<%= installer_setup['toolHome'] %>"
-          <%- end -%>
+      <%- setup['installers'].each do |installer_name, installer_label| -%>
+        <%- if installer_name =~ /windows/ -%>
+          <%- $jdkHome = 'C:/Tools/jdk-' + setup['major_version'].to_s -%>
+          <%- $installerType = 'batchFile' %>
+        <%- else -%>
+          <%- $jdkHome = '/opt/jdk-' + setup['major_version'].to_s -%>
+          <%- $installerType = 'command' %>
         <%- end -%>
+          - <%= $installerType %>:
+              label: "<%= installer_label %>"
+              toolHome: "<%= $jdkHome %>"
+              command: "echo <%= $jdkHome %>"
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -62,52 +62,23 @@ profile::jenkinscontroller::jcasc:
     jdk:
       jdk8:
         installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux-arm64 || (linux && arm64)"
-            cpu_arch: "aarch64"
+          linux-arm64: "(linux && arm64) || linux-arm64"
       jdk11:
         installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux-arm64 || (linux && arm64)"
-            cpu_arch: "aarch64"
-          s390x:
-            type: "zip"
-            label: "s390x"
-            cpu_arch: "s390x"
+          linux-arm64: "(linux && arm64) || linux-arm64"
+          s390x: "s390x || s390xdocker"
       jdk17:
         installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux-arm64 || (linux && arm64)"
-            cpu_arch: "aarch64"
-          s390x:
-            type: "zip"
-            label: "s390x"
-            cpu_arch: "s390x"
+          linux-arm64: "(linux && arm64) || linux-arm64"
+          s390x: "s390x || s390xdocker"
       jdk21:
         installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux-arm64 || (linux && arm64)"
-            cpu_arch: "aarch64"
-          s390x:
-            type: "zip"
-            label: "s390x"
-            cpu_arch: "s390x"
+          linux-arm64: "(linux && arm64) || linux-arm64"
+          s390x: "s390x || s390xdocker"
       jdk25:
         installers:
-          linux-arm64:
-            type: command
-            label: "linux-arm64 || (linux && arm64)"
-            command: "echo /opt/jdk-25"
-            toolHome: /opt/jdk-25
-          linux-s390x:
-            type: command
-            label: "s390x"
-            command: "echo /opt/jdk-25"
-            toolHome: /opt/jdk-25
+          linux-arm64: "(linux && arm64) || linux-arm64"
+          s390x: "s390x || s390xdocker"
   artifact_caching_proxy:
     enabled: true
     servers:

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -51,72 +51,26 @@ profile::jenkinscontroller::jcasc:
       maven:
         home: "/usr/share/apache-maven-3.8.8"
     jdk:
-      jdk-8: &tool_jdk8
+      jdk-8:
+        major_version: 8
         installers:
-          linux-amd64:
-            type: "command"
-            label: "linux"
-            command: "echo JDK8"
-            toolHome: "/opt/jdk-8"
-          windows-amd64:
-            type: "batchFile"
-            label: "windows"
-            command: "echo JDK8"
-            toolHome: "C:/Tools/jdk-8"
-          default:
-            type: "zip"
-            version: "8u382-b05"
-      jdk-11: &tool_jdk11
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-8-windows"
+      jdk-11:
+        major_version: 11
         installers:
-          linux-amd64:
-            type: "command"
-            label: "linux"
-            command: "echo JDK11"
-            toolHome: "/opt/jdk-11"
-          windows-amd64:
-            type: "batchFile"
-            label: "windows"
-            command: "echo JDK11"
-            toolHome: "C:/Tools/jdk-11"
-          default:
-            type: "zip"
-            version: "11.0.20+8"
-      jdk-17: &tool_jdk17
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk11 || jdk-11 || maven-11"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-11-windows"
+      jdk-17:
+        major_version: 17
         installers:
-          linux-amd64:
-            type: "command"
-            label: "linux"
-            command: "echo JDK17"
-            toolHome: "/opt/jdk-17"
-          windows-amd64:
-            type: "batchFile"
-            label: "windows"
-            command: "echo JDK17"
-            toolHome: "C:/Tools/jdk-17"
-          default:
-            type: "zip"
-            version: "17.0.11+9"
-      jdk-21: &tool_jdk21
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk17 || jdk-17 || maven-17"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-17-windows"
+      jdk-21:
+        major_version: 21
         installers:
-          linux-amd64:
-            type: "command"
-            label: "linux"
-            command: "echo JDK21"
-            toolHome: "/opt/jdk-21"
-          windows-amd64:
-            type: "batchFile"
-            label: "windows"
-            command: "echo JDK21"
-            toolHome: "C:/Tools/jdk-21"
-          default:
-            type: "zip"
-            version: "21.0.3+9"
-      # Use Yaml anchor to avoid repeating configuration
-      jdk8: *tool_jdk8
-      # Use Yaml anchor to avoid repeating configuration
-      jdk11: *tool_jdk11
-      jdk17: *tool_jdk17
-      jdk21: *tool_jdk21
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk21 || jdk-21 || maven-21"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-21-windows"
     generic:
       groovy-3.0.6:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.6.zip"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -61,19 +61,16 @@ profile::jenkinscontroller::jcasc:
     jdk:
       jdk8:
         installers:
-          linux-amd64:
-            type: "zip"
-            label: "(linux && amd64) || updatecenter || census"
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
       jdk17:
         installers:
-          linux-amd64:
-            type: "zip"
-            label: "(linux && amd64) || updatecenter || census"
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
       jdk21:
         installers:
-          linux-amd64:
-            type: "zip"
-            label: "(linux && amd64) || updatecenter || census"
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
+      jdk25:
+        installers:
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
   permanent_agents:
     agent-1:
       remoteFS: /home/jenkins/agent-workspace

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -172,53 +172,30 @@ profile::jenkinscontroller::jcasc:
         default_version: true
     jdk:
       jdk8:
+        major_version: 8
         installers:
-          linux-amd64:
-            type: "zip"
-            label: "linux && amd64"
-          windows-amd64:
-            type: "zip"
-            label: "windows"
-            os: "windows"
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-8-windows"
       jdk11:
+        major_version: 11
         installers:
-          linux-amd64:
-            type: "zip"
-            label: "linux && amd64"
-          windows-amd64:
-            type: "zip"
-            label: "windows"
-            os: "windows"
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk11 || jdk-11 || maven-11"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-11-windows"
       jdk17:
+        major_version: 17
         installers:
-          linux-amd64:
-            type: "zip"
-            label: "linux && amd64"
-          windows-amd64:
-            type: "zip"
-            label: "windows"
-            os: "windows"
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk17 || jdk-17 || maven-17"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-17-windows"
       jdk21:
+        major_version: 21
         installers:
-          linux-amd64:
-            type: "zip"
-            label: "linux && amd64"
-          windows-amd64:
-            type: "zip"
-            label: "windows"
-            os: "windows"
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk21 || jdk-21 || maven-21"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-21-windows"
       jdk25:
+        major_version: 25
         installers:
-          linux-amd64:
-            type: command
-            label: "linux-amd64 || (linux && amd64)"
-            command: "echo /opt/jdk-25"
-            toolHome: /opt/jdk-25
-          windows-amd64:
-            type: batchFile
-            label: "windows || windows-2019 || windows-2022 || maven-25-windows"
-            command: "echo C:/Tools/jdk-25"
-            toolHome: "C:/Tools/jdk-25"
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk25 || jdk-25 || maven-25"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-25-windows"
   agents_setup:
     windows:
       agentDir: 'C:/Jenkins/agent'

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -70,56 +70,23 @@ profile::jenkinscontroller::jcasc:
     jdk:
       jdk8:
         installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux && arm64"
-            cpu_arch: "aarch64"
+          linux-arm64: "(linux && arm64) || linux-arm64"
       jdk11:
         installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux && arm64"
-            cpu_arch: "aarch64"
-          s390x:
-            type: "zip"
-            label: "s390x"
-            cpu_arch: "s390x"
+          linux-arm64: "(linux && arm64) || linux-arm64"
+          s390x: "s390x || s390xdocker"
       jdk17:
         installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux && arm64"
-            cpu_arch: "aarch64"
-          s390x:
-            type: "zip"
-            label: "s390x"
-            cpu_arch: "s390x"
+          linux-arm64: "(linux && arm64) || linux-arm64"
+          s390x: "s390x || s390xdocker"
       jdk21:
         installers:
-          linux-arm64:
-            type: "zip"
-            label: "linux && arm64"
-            cpu_arch: "aarch64"
-            # Test an EA version with 3 digits - https://github.com/adoptium/temurin/issues/6
-            version: 21.0.1+12-ea-beta
-          s390x:
-            # Test an EA version with 1 digit - https://github.com/adoptium/temurin/issues/6
-            version: 21+35-ea-beta
-            type: "zip"
-            label: "s390x"
-            cpu_arch: "s390x"
+          linux-arm64: "(linux && arm64) || linux-arm64"
+          s390x: "s390x || s390xdocker"
       jdk25:
         installers:
-          linux-arm64:
-            type: command
-            label: "linux-arm64 || (linux && arm64)"
-            command: "echo /opt/jdk-25"
-            toolHome: /opt/jdk-25
-          linux-s390x:
-            type: command
-            label: "s390x"
-            command: "echo /opt/jdk-25"
-            toolHome: /opt/jdk-25
+          linux-arm64: "(linux && arm64) || linux-arm64"
+          s390x: "s390x || s390xdocker"
   permanent_agents:
     s390x-agent:
       remoteFS: /home/jenkins/agent


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4848 and following the initial work from https://github.com/jenkins-infra/helpdesk/issues/4831

This PR changes ALL the Jenkins JDK tools to use the locally installed JDK (`/opt/jdk-XX` on Linux and `C:/Tools/jdk-XX` on Windows) instead of downloading Adoptium JDK installer on each build.

The "exceptions" are covered like this:

- trusted.ci.jenkins.io: All JDKs from 8 up to 21 are already installed. JDK25 added in <insert PR here>.
- cert.ci.jenkins.io: duplicating the tool configuration with `jdk-XX` configuration so both namings are present. JenSec team pinged to see if they can and want updating their (private in `jenkinsci-cert`) pipelines without breaking their usages.
- ci.jenkins.io: `s390x`: JDK25 added as part github.com/jenkins-infra/helpdesk/issues/4831

----

Tests:

- Verified the updated template is working using local Vagrant:
  - Default hieradata for vagrant is the **same** as ci.jenkins.io to validate JDK tool setups are cumulative. Works as expected ✅ 
  - Manually tried to change the vagrant hieradata with trusted.ci updated config: we see the updatecenter/census labels added (e.g. overriding default config works)
  - Manually tried to change the vagrant hieradata with cert.ci updated config: we see the `jdk-XX` tool installer presents

----

Deployment:

- Once all is green, puppet agent will be disabled on each of the 3 controllers
- Then, for each controller, we'll deploy and verify it works as expected in the current order:
  - cert.ci.jenkins.io => deploy (e.g. puppet noop + visual check + apply if OK or correcting PR otherwise) => run the [`Infra-Team-Validate-Agents`](https://cert.ci.jenkins.io/view/Top-Level%20Items/job/Infra-Team-Validate-Agents/) job and verify that all tools used in this "validation" job are working as expected without downloading installers
  - trusted.ci.jenkins.io => deploy (e.g. puppet noop + visual check + apply if OK or correcting PR otherwise) => run the [`Infra-Team-Validate-Agents`](https://trusted.ci.jenkins.io/job/Infra-Team-Validate-Agents/) job and verify that all tools used in this "validation" job are working as expected without downloading installers => also run the updatecenter freestyle job and check it keeps working as expected
  - ci.jenkins.io => deploy (e.g. puppet noop + visual check + apply if OK or correcting PR otherwise) => run acceptance tests

----

Notes:

- cert.ci.jenkins.io will not have a "default fallback" JDK tool installer anymore. Either we have the JDK tool with a local install or we don't
- This PR is one step (of two) in the direction of removing the tedious template https://github.com/jenkins-infra/jenkins-infra/blob/production/dist/profile/templates/jdk-adoptium-url.erb (it was a useful but is a hard one to maintain). Need another PR on the "build-agent" profile to be able to remove it.
  - For the same reason, `updatecli` JDK elements are not removed yet.