### PR TITLE
fix(trusted.ci) use the standard HTTPS port

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -9,7 +9,6 @@ lookup_options:
       strategy: deep
       merge_hash_arrays: true
 profile::jenkinscontroller::ci_fqdn: 'cert.ci.jenkins.io'
-profile::jenkinscontroller::proxy_port: 443
 docker::log_opt::max-size: "100m"
 docker::log_opt::max-file: 2
 # Per-host Datadog configuration

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -24,7 +24,6 @@ docker::log_opt::max-file: 2
 # Per-host Datadog configuration
 datadog_agent::host: "controller.trusted.ci.jenkins.io"
 profile::jenkinscontroller::ci_fqdn: "trusted.ci.jenkins.io"
-profile::jenkinscontroller::proxy_port: 1443
 profile::jenkinscontroller::anonymous_access: false
 profile::jenkinscontroller::admin_ldap_groups:
   - admins

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -112,8 +112,6 @@ profile::jenkinsadmin::jira_password: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYC
 # access to freenode (for authenticating as 'jenkinsadmin')
 # TODO: nickname is hard-coded to the bot right now
 profile::jenkinsadmin::nick_password: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEApcoIRvdK5ucSrPibeyrhAQactyxQGTJLdVaopQdEu8MUVQIPcsi052ib60se8E51JUSiQhus3dV9b7KTnLqPGV2eYz08jAgUJTnYcxOlSp7nRY8HXRXIAJ8uhjrYxXpw8B0pisxb4joEEMhYdlBMrFthXUxD8g3LoybOLsRVjQViFJeRfvg9cVUQ2fgqHnXKyyTCadqQCYyNXlSB9yc8J4W1/xfjpIfE3EcQ6GcHYe225tPy0aPMetUnt7v5qRzuuO5xPYO86ByBDd4rSxn6El1cokOxIIg1IAr4q55h6QwFLHoXX4GtvV05CHB9pgfxuxc0JHV7Mv9L/+cDpwyq8jA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCvd92Vb6hSA9rBlA48KfaogBDLJlf7Q+XwAU4fMZbOO7go]
-# Tag is the docker container image tag from our build process, this job:
-# <https://trusted.ci.jenkins.io:1443/job/Containers/job/ircbot>
 profile::jenkinsadmin::image_tag: "64-build32db94"
 # Key that Jenkins uses to push bits into OSUOSL
 osuosl_mirroring::host: ftp-osl.osuosl.org

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -4,7 +4,6 @@ lookup_options:
       strategy: deep
       merge_hash_arrays: true
 profile::jenkinscontroller::ci_fqdn: 'jenkinscontroller.profile.rspec.test.local'
-profile::jenkinscontroller::proxy_port: 443
 profile::jenkinscontroller::letsencrypt: false
 profile::jenkinscontroller::groovy_init_enabled: false
 profile::jenkinscontroller::memory_limit: '14g'

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -35,7 +35,6 @@ profile::jenkinscontroller::additional_fqdns:
   foo.localhost:
     isalias: true
   legacy.localhost: null
-profile::jenkinscontroller::proxy_port: 443
 profile::jenkinscontroller::groovy_init_enabled: false
 profile::jenkinscontroller::memory_limit: '14g'
 profile::jenkinscontroller::jcasc:


### PR DESCRIPTION
Instead of `1443`, to remove the `It appears that your reverse proxy set up is broken.` message in "Manage Jenkins" on  trusted.ci.jenkins.io