### PR TITLE
fix(ci.jenkins.io/ec2-vm-agents) patch to disable spot instances without removing the existing labels

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -99,11 +99,6 @@ jenkins:
         remoteAdmin: "<%= $remoteAdmin %>"
         remoteFS: "<%= agent['customDataDisk'] ? agent['customDataDisk'] + '/agent' : (agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir']) %>"
         securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
-      <%- if agent['spot'] -%>
-        spotConfig:
-          fallbackToOndemand: true
-          useBidPrice: false
-      <%- end -%>
         stopOnTerminate: false
         subnetId: "<%= agent['subnetId'] ? agent['subnetId'] : (ec2_cloud_setup['subnetId'] ? ec2_cloud_setup['subnetId'] : "") %>"
         t2Unlimited: false


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4768#issuecomment-3450028988

Note: this an UGLY PATCH which can be reverted easily. It keeps the same labels to avoid breaking pipelines usages. But will need to be revised in the upcoming weeks