### PR TITLE
fix(ci.jenkins.io/ec2) do not use arm64 for highmem

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -453,7 +453,7 @@ profile::jenkinscontroller::jcasc:
           ####
           - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK17 set as default java CLI"
             maxInstances: 50
-            instanceType: "m6gd.2xlarge" # 8 vCPUs / 32 Gb / nvme 475Gb
+            instanceType: "m5ad.2xlarge" # 8 vCPUs / 32 Gb / nvme 300Gb
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -466,8 +466,7 @@ profile::jenkinscontroller::jcasc:
           # High Memory SPOT Linux VMs (ATH mostly)
           - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK17 set as default java CLI"
             maxInstances: 50
-            instanceType: "m6gd.2xlarge" # 8 vCPUs / 32 Gb / nvme 475Gb
-            os: "ubuntu"
+            instanceType: "m5ad.2xlarge" # 8 vCPUs / 32 Gb / nvme 300Gb            os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
             architecture: "amd64"
@@ -478,7 +477,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
             maxInstances: 50
-            instanceType: "m6gd.2xlarge" # 8 vCPUs / 32 Gb / nvme 475Gb
+            instanceType: "m5ad.2xlarge" # 8 vCPUs / 32 Gb / nvme 300Gb
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -498,7 +497,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
             maxInstances: 50
-            instanceType: "m6gd.2xlarge" # 8 vCPUs / 32 Gb / nvme 475Gb
+            instanceType: "m5ad.2xlarge" # 8 vCPUs / 32 Gb / nvme 300Gb
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true
@@ -512,7 +511,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK25 set as default java CLI"
             maxInstances: 50
-            instanceType: "m6gd.2xlarge" # 8 vCPUs / 32 Gb / nvme 475Gb
+            instanceType: "m5ad.2xlarge" # 8 vCPUs / 32 Gb / nvme 300Gb
             os: "ubuntu"
             os_version: "22.04"
             ebsOptimized: true


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/jenkins-infra/pull/4485 to avoid provisioning error such as:

```
SlaveTemplate{description='Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI', labels='ubuntu linux ubuntu-22.04 amd64 aws ec2 vm nonspot ubuntu-22-amd64-highmem-maven21 highmem highram docker-highmem linux-amd64-big spot'}. Exception during provisioning
software.amazon.awssdk.services.ec2.model.Ec2Exception: The architecture 'arm64' of the specified instance type does not match the architecture 'x86_64' of the specified AMI. Specify an instance type and an AMI that have matching architectures, and try again. You can use 'describe-instance-types' or 'describe-images' to discover the architecture of the instance type or AMI. (Service: Ec2, Status Code: 400, Request ID: xxxxxx) (SDK Attempt Count: 1)
```