### PR TITLE
cleanup(agent.trusted.ci.jenkins.io) remove unused JDKs 8, 11 and 17

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -233,21 +233,6 @@ profile::jenkinscontroller::jcasc:
       jnlp-webbuilder: jenkinsciinfra/builder:latest@sha256:405912641faec2b42dd8afcced8a1953fd0b111a79202a49a39bf0c8c93625f0
       jnlp-packaging: jenkinsciinfra/packaging:latest
   tools_default_versions:
-    jdk8:
-      version: 8u462-b08
-      linux:
-        amd64: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u462b08.tar.gz
-        arm64: https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u462b08.tar.gz
-    jdk11:
-      version: 11.0.28+6
-      linux:
-        amd64: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jdk_x64_linux_hotspot_11.0.28_6.tar.gz
-        arm64: https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.28_6.tar.gz
-    jdk17:
-      version: 17.0.16+8
-      linux:
-        amd64: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.16_8.tar.gz
-        arm64: https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.16_8.tar.gz
     jdk21:
       version: 21.0.8+9
       linux:


### PR DESCRIPTION
As the trusted.ci.jenkins.io controller runs with JDK21, and the Update Center generation job is set up to use JDK21 as well, we don't need these old JDKs on the permanent agent anymore.

Note: this PR does NOT remove these old JDK from the "Jenkins JDK tools" setup. It's only the JDKs installed on the permanent agent. We don't expect a pipeline job using the `jdk8`, `jdk11` or `jdk17` Jenkins tool to succeed if they run on the permanent agents.