### PR TITLE
feat(trusted.ci, cert.ci, agent.trusted.ci) add JDK25 EA 25+36

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -141,6 +141,27 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
           usePrivateIP: true
+        - name: "ubuntu-22-amd64-maven-25"
+          description: "Ubuntu 22.04 LTS x86_64 with JDK25 set as default java CLI"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: false
+          architecture: amd64
+          labels:
+            - ubuntu-amd64-maven-25
+            - ubuntu-22-amd64-maven-25
+            - maven-25
+            - jdk25
+          javaHome: '/opt/jdk-25'
+          maxInstances: 10
+          useAsMuchAsPossible: true
+          credentialsId: "azure-login"
+          usePrivateIP: true
         - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019 Maven-11"
           imageDefinition: jenkins-agent-windows-2019-amd64
@@ -199,6 +220,25 @@ profile::jenkinscontroller::jcasc:
             - win-2019-amd64-maven-21
             - maven-21-windows
           javaHome: 'C:/tools/jdk-21'
+          maxInstances: 10 # Quota of 80 vCPUs
+          useAsMuchAsPossible: true
+          credentialsId: "azure-login"
+          usePrivateIP: true
+        - name: "win-2019-amd64-maven-25" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2019 Maven-25"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: false
+          architecture: amd64
+          labels:
+            - win-2019-amd64-maven-25
+            - maven-25-windows
+          javaHome: 'C:/tools/jdk-25'
           maxInstances: 10 # Quota of 80 vCPUs
           useAsMuchAsPossible: true
           credentialsId: "azure-login"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -173,6 +173,27 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
+        - name: "ubuntu-22-amd64-maven-25"
+          description: "Ubuntu 22.04 LTS x86_64 with JDK25 set as default java CLI"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - ubuntu-amd64-maven-25
+            - ubuntu-22-amd64-maven-25
+            - maven-25
+            - jdk25
+          javaHome: '/opt/jdk-25'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
         - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019 Maven-11"
           imageDefinition: jenkins-agent-windows-2019-amd64
@@ -234,6 +255,25 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
+        - name: "win-2019-amd64-maven-25"
+          description: "Windows 2019 Maven-25"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2019-amd64-maven-25
+            - maven-25-windows
+          javaHome: 'C:/tools/jdk-25'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
         - name: "win-2022-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2022 Maven-11"
           imageDefinition: jenkins-agent-windows-2022-amd64
@@ -287,6 +327,24 @@ profile::jenkinscontroller::jcasc:
           labels:
             - win-2022-amd64-maven-21
           javaHome: 'C:/tools/jdk-21'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2022-amd64-maven-25"
+          description: "Windows 2022 Maven-25"
+          imageDefinition: jenkins-agent-windows-2022-amd64
+          os: "windows"
+          os_version: "2022"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2022-amd64-maven-25
+          javaHome: 'C:/tools/jdk-25'
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -239,6 +239,11 @@ profile::jenkinscontroller::jcasc:
       linux:
         amd64: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_x64_linux_hotspot_21.0.8_9.tar.gz
         arm64: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.8_9.tar.gz
+    jdk25:
+      version: 25+36
+      linux:
+        amd64: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jdk_x64_linux_hotspot_25_36.tar.gz
+        arm64: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B36/OpenJDK25U-jdk_aarch64_linux_hotspot_25_36.tar.gz
     maven: 3.9.11
 # These variables should be filled in, in production.yaml, with the legacy
 # jenkins-ci.org cert details

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -9,3 +9,4 @@ github:
 
 jdks:
   - major: 21
+  - major: 25


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4848

Following https://github.com/jenkins-infra/helpdesk/issues/4831, this PR adds JDK25 to trusted.ci.jenkins.io and cert.ci.jenkins.io:

- On cert.ci, it adds a Linux Agent template and a Windows Agent template
- On trusted.ci, there are 3 new agents templates: a Linux one, a Windows 2019 and a Windows 2022.
  - Note: JDK25 is also added to the agent.trusted.ci.jenkins.io permanent agent