### PR TITLE
feat(pkg) stop tracking redhat/opensuse RPM repos and redirect `/redhat/` and `/opensuse/` to `/rpm/`

### DIFF
--- a/dist/profile/manifests/pkgrepo.pp
+++ b/dist/profile/manifests/pkgrepo.pp
@@ -254,7 +254,7 @@ Host ${$archives_jenkins_io_mirroring['host']}
     group     => $www_common_group,
   }
 
-  profile::redhat_repo { ['redhat', 'redhat-stable', 'redhat-rc', 'redhat-stable-rc']:
+  profile::redhat_repo { ['redhat']:
     ensure    => present,
     docroot   => $pkg_docroot,
     repo_fqdn => $repo_fqdn,
@@ -269,7 +269,7 @@ Host ${$archives_jenkins_io_mirroring['host']}
     require     => File[$repos],
   }
 
-  profile::opensuse_repo { ['opensuse', 'opensuse-stable', 'opensuse-rc', 'opensuse-stable-rc']:
+  profile::opensuse_repo { ['opensuse']:
     ensure      => present,
     docroot     => $pkg_docroot,
     mirror_fqdn => $mirror_fqdn,

--- a/dist/profile/manifests/redhat_repo.pp
+++ b/dist/profile/manifests/redhat_repo.pp
@@ -6,19 +6,9 @@ define profile::redhat_repo (
   Stdlib::Absolutepath $docroot,
   Stdlib::Fqdn $repo_fqdn,
 ) {
-  file { "${docroot}/${name}/jenkins.repo":
-    ensure  => $ensure,
-    content => template("${module_name}/pkgrepo/jenkins.repo.erb"),
-  }
-
-  # Manage some redirects off-host
-  # See also: https://issues.jenkins-ci.org/browse/INFRA-967
+  # Ensure users are redirected to /rpm
   file { "${docroot}/${name}/.htaccess":
     ensure  => $ensure,
     content => template("${module_name}/pkgrepo/redhat_htaccess.erb"),
-  }
-
-  file { "${docroot}/${name}/repodata":
-    ensure  => directory,
   }
 }

--- a/dist/profile/templates/pkgrepo/redhat_htaccess.erb
+++ b/dist/profile/templates/pkgrepo/redhat_htaccess.erb
@@ -2,12 +2,7 @@
 RewriteEngine On
 Options -Indexes
 
-# If we are serving over https://pkg.jenkins.io then redirect to Azure blob
-# storage when possible
-# 
-# See also: https://issues.jenkins-ci.org/browse/INFRA-967
 RewriteCond %{HTTPS} on
-RewriteCond %{REQUEST_URI} ^/<%= @name %>/RPMS/noarch/*
+RewriteCond %{REQUEST_URI} ^/<%= @name %>/*
 
-RedirectMatch /<%= @name %>/RPMS/noarch/(.*)\.rpm$ https://mirrors.jenkins.io/<%= @name %>/$1.rpm
-RedirectMatch /<%= @name %>/(.*)\.rpm$ https://mirrors.jenkins.io/<%= @name %>/$1.rpm
+RedirectMatch /<%= @name %>/(.*)$ /rpm<%= @name.gsub(/redhat/, '').gsub(/opensuse/, '') %>/$1

--- a/spec/classes/profile/pkgrepo_spec.rb
+++ b/spec/classes/profile/pkgrepo_spec.rb
@@ -72,8 +72,8 @@ describe "profile::pkgrepo" do
   end
 
   context "repository directories" do
-    platforms = ["debian", "opensuse", "redhat"]
-    variants = [nil, "stable", "rc", "stable-rc"]
+    platforms = ["debian", "rpm"]
+    variants = [nil, "stable"]
 
     platforms.each do |platform|
       variants.each do |variant|
@@ -96,39 +96,12 @@ describe "profile::pkgrepo" do
       end
     end
 
-    context "opensuse repos" do
+    context "RPM repos" do
       variants.each do |variant|
-        platform = "opensuse"
+        platform = "rpm"
         variant = "-#{variant}" unless variant.nil?
         variant = "#{platform}#{variant}"
         let(:variant_dir) { "#{$pkg_docroot}/#{variant}" }
-
-        it "should define an .htaccess file for #{variant} redirects" do
-          expect(subject).to contain_file("#{variant_dir}/.htaccess").with({
-            :ensure => :present,
-          })
-        end
-
-        it "should define a repodata/ for #{variant}" do
-          expect(subject).to contain_file("#{variant_dir}/repodata").with({
-            :ensure => :directory,
-          })
-        end
-      end
-    end
-
-    context "redhat repos" do
-      variants.each do |variant|
-        platform = "redhat"
-        variant = "-#{variant}" unless variant.nil?
-        variant = "#{platform}#{variant}"
-        let(:variant_dir) { "#{$pkg_docroot}/#{variant}" }
-
-        it "should define a jenkins.repo for #{variant}" do
-          expect(subject).to contain_file("#{variant_dir}/jenkins.repo").with({
-            :ensure => :present,
-          })
-        end
 
         it "should define an .htaccess file for #{variant} redirects" do
           expect(subject).to contain_file("#{variant_dir}/.htaccess").with({


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4774#issuecomment-3543551929

Tested scenarios on local vagrant with the command `curl -v -o /dev/null -H 'Host: pkg.origin.jenkins.io` <URL>`:


- HTTP/200: http://localhost/opensuse-stable/jenkins.io.key
- HTTP/302: http://localhost/opensuse/jenkins.io.key -> http://pkg.origin.jenkins.io/rpm/jenkins.io.key
- HTTP/200: http://localhost/redhat-stable/jenkins.io.key
- HTTP/302: http://localhost/redhat/jenkins.io.key -> http://pkg.origin.jenkins.io/rpm/jenkins.io.key
- HTTP/200: http://localhost/rpm-stable/jenkins.io.key
- HTTP/200: http://localhost/rpm/jenkins.io.key