### PR TITLE
fix(pkg) ensure all repositories redirects to absolute URLs, either get.io or pkg.jio (fastly)

### DIFF
--- a/dist/profile/templates/pkgrepo/debian_htaccess.erb
+++ b/dist/profile/templates/pkgrepo/debian_htaccess.erb
@@ -6,11 +6,6 @@ RewriteCond %{HTTP_USER_AGENT}  APT.*\(0\.7\.20     [OR]
 RewriteCond %{HTTP_USER_AGENT}  APT.*\(0\.7\.1[0-9]
 RewriteRule ^binary/(.*)\.deb$  /<%= @name %>/direct/$1.deb [L]
 
-
-# If we are serving over https://pkg.jenkins.io then redirect to Azure blob
-# storage when possible
-# 
-# See also: https://issues.jenkins-ci.org/browse/INFRA-964
 RewriteCond %{HTTPS} on
 
-RewriteRule ^binary/(.*)\.deb$ https://mirrors.jenkins.io/<%= @name %>/$1.deb [R=302,L]
+RewriteRule ^binary/(.*)\.deb$ https://get.jenkins.io/<%= @name %>/$1.deb [R=302,L]

--- a/dist/profile/templates/pkgrepo/jenkins.repo.erb
+++ b/dist/profile/templates/pkgrepo/jenkins.repo.erb
@@ -1,4 +1,0 @@
-[jenkins]
-name=Jenkins<%= @name.gsub(/redhat/, '') %>
-baseurl=http://pkg.jenkins.io/<%= @name %>
-gpgcheck=1

--- a/dist/profile/templates/pkgrepo/redhat_htaccess.erb
+++ b/dist/profile/templates/pkgrepo/redhat_htaccess.erb
@@ -5,4 +5,4 @@ Options -Indexes
 RewriteCond %{HTTPS} on
 RewriteCond %{REQUEST_URI} ^/<%= @name %>/*
 
-RedirectMatch /<%= @name %>/(.*)$ /rpm<%= @name.gsub(/redhat/, '').gsub(/opensuse/, '') %>/$1
+RedirectMatch /<%= @name %>/(.*)$ https://pkg.jenkins.io/rpm<%= @name.gsub(/redhat/, '').gsub(/opensuse/, '') %>/$1


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4774

Follows up #4541