### PR TITLE
feat(aws.ci.jenkins.io): add Windows Server Core 2025 agent definition templates

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -660,6 +660,24 @@ profile::jenkinscontroller::jcasc:
               - win-2022
             spot: true
             acpServerId: aws-internal
+          - description: "Spot Windows 2025 x86_64 with JDK17"
+            maxInstances: 50
+            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            os: "windows"
+            os_version: "2025"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: 'C:/tools/jdk-17'
+            # Utilizes the local NVMe mounted in Z:
+            customDataDisk: 'Z:'
+            remoteAdmin: jenkins
+            labels:
+              - win-2025-amd64-maven-17
+              # Labels indicating it is the default VM template for Windows 2025 (but not windows)
+              - docker-windows-2025
+              - win-2025
+            spot: true
+            acpServerId: aws-internal
           - description: "Windows Infra Test"
             maxInstances: 5
             instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -230,7 +230,7 @@ profile::jenkinscontroller::jcasc:
       subscription_id: dff2ec18-6a8e-405c-8e45-b7df7465acf0
     container_images:
       # All in one image (same as VM templates)
-      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.73.0@sha256:e4c66d769b29436c2396dbb40a56fa49a8b02a8012d3633a1c222aacdbe3c8f2
+      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.74.0@sha256:e3a6f511c8e80192f7846accc316f764104b68a485963f90987c1474e167bedd
       jnlp-packaging: jenkinsciinfra/packaging:latest
   tools_default_versions:
     jdk21:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -224,7 +224,7 @@ profile::jenkinscontroller::jcasc:
       ubuntu-22.04-amd64: ami-003a2a2280a8d24cc
       windows-2019-amd64: ami-0cf3080ff61f65e15
       ubuntu-22.04-arm64: ami-08f33e496cd328989
-      windows-2022-amd64: ami-03b11aebf76924172
+      windows-2022-amd64: ami-055f9a1f206c0a11e
     azure_vms_gallery_image:
       version: 2.73.0
       subscription_id: dff2ec18-6a8e-405c-8e45-b7df7465acf0

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -222,7 +222,7 @@ profile::jenkinscontroller::jcasc:
   agent_images:
     ec2_amis:
       ubuntu-22.04-amd64: ami-037fad88b2cb70c37
-      windows-2019-amd64: ami-0cf3080ff61f65e15
+      windows-2019-amd64: ami-0b34c6af57a88300d
       ubuntu-22.04-arm64: ami-08f33e496cd328989
       windows-2022-amd64: ami-055f9a1f206c0a11e
     azure_vms_gallery_image:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -226,7 +226,7 @@ profile::jenkinscontroller::jcasc:
       ubuntu-22.04-arm64: ami-08f33e496cd328989
       windows-2022-amd64: ami-055f9a1f206c0a11e
     azure_vms_gallery_image:
-      version: 2.73.0
+      version: 2.74.0
       subscription_id: dff2ec18-6a8e-405c-8e45-b7df7465acf0
     container_images:
       # All in one image (same as VM templates)

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -225,6 +225,7 @@ profile::jenkinscontroller::jcasc:
       windows-2019-amd64: ami-0b34c6af57a88300d
       ubuntu-22.04-arm64: ami-014fdb70800e3dab2
       windows-2022-amd64: ami-055f9a1f206c0a11e
+      windows-2025-amd64: ami-06fb8aedb2ea0340a
     azure_vms_gallery_image:
       version: 2.74.0
       subscription_id: dff2ec18-6a8e-405c-8e45-b7df7465acf0

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -223,7 +223,7 @@ profile::jenkinscontroller::jcasc:
     ec2_amis:
       ubuntu-22.04-amd64: ami-037fad88b2cb70c37
       windows-2019-amd64: ami-0b34c6af57a88300d
-      ubuntu-22.04-arm64: ami-08f33e496cd328989
+      ubuntu-22.04-arm64: ami-014fdb70800e3dab2
       windows-2022-amd64: ami-055f9a1f206c0a11e
     azure_vms_gallery_image:
       version: 2.74.0

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -221,7 +221,7 @@ profile::jenkinscontroller::jcasc:
       registryMirror: https://dockerhubmirror.azurecr.io
   agent_images:
     ec2_amis:
-      ubuntu-22.04-amd64: ami-003a2a2280a8d24cc
+      ubuntu-22.04-amd64: ami-037fad88b2cb70c37
       windows-2019-amd64: ami-0cf3080ff61f65e15
       ubuntu-22.04-arm64: ami-08f33e496cd328989
       windows-2022-amd64: ami-055f9a1f206c0a11e

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -195,6 +195,18 @@ profile::jenkinscontroller::jcasc:
               - docker-windows-2022
               - win-2022
             spot: false
+          - description: "Windows 2025 x86_64 with default (current) JDK"
+            maxInstances: 4
+            ami: ami-xxxxxxxxx
+            instanceType: T3aXlarge # 4 vCPUs / 16 Gb
+            os: "windows"
+            os_version: "2025"
+            ebsOptimized: true
+            architecture: "amd64"
+            labels:
+              - docker-windows-2025
+              - win-2025
+            spot: false
     kubernetes:
       first-cluster:
         enabled: true
@@ -403,6 +415,22 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - docker-windows-2022
+          maxInstances: 50
+          useAsMuchAsPossible: true
+          credentialsId: "jenkinsvmagents-userpass"
+          usePrivateIP: true
+          spot: false
+        - name: "win-2025-ssh" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2025"
+          imageDefinition: jenkins-agent-windows-2025-amd64
+          os: "windows"
+          os_version: "2025"
+          location: "East US 2"
+          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          ephemeralOSDisk: true
+          architecture: amd64
+          labels:
+            - docker-windows-2025
           maxInstances: 50
           useAsMuchAsPossible: true
           credentialsId: "jenkinsvmagents-userpass"


### PR DESCRIPTION
This PR adds Windows Server Core 2025 packer image AMI reference, and adds a Windows Server Core 2025 agent definition template for aws.ci.jenkins.io, with appropriate 2025 labels while keeping the existing 2022 template and label.

Sibling pull request:
- https://github.com/jenkins-infra/kubernetes-management/pull/7283

Follow-up of:
- https://github.com/jenkins-infra/packer-images/pull/2195

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/4791#issuecomment-3585295631

#### Testing done
`vagrant up --provision jenkins::controller`