### PR TITLE
feat(aws.ci.jenkins.io): custom `infratest-windows` agent template with Windows Server Core 2025 and no local NVMe mount

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -682,12 +682,12 @@ profile::jenkinscontroller::jcasc:
             maxInstances: 5
             instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
-            os_version: "2019"
+            os_version: "2025"
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
+            # # Utilizes the local NVMe mounted in Z:
+            # customDataDisk: 'Z:'
             remoteAdmin: jenkins
             labels:
               - infratest-windows


### PR DESCRIPTION
In https://github.com/jenkinsci/docker-ssh-agent/pull/581 I successfully built a Windows Server Core 2022 image from a 2025 host by removing docker daemon config setting `data-root` to `Z:\docker` in order to avoid hitting the issue described in https://github.com/moby/moby/issues/48093.

This PR udpates `infratest-windows` ec2 agent template on ci.jenkins.io to use a 2025 image and to disable local NVMe.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4791
- https://github.com/jenkins-infra/jenkins-infra/blob/71eff0ea69c667180f748e16c1bd3f42c099edae/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb#L20-L130