### PR TITLE
feat(aws.ci.jenkins.io): add `customDataDiskNotUsedForDocker` ec2 agent template parameter

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -171,8 +171,6 @@ jenkins:
                 # Restart docker engine
                 Restart-Service docker
                 <%- end -%>
-                <%- else -%>
-                ## No NVMe(s) as custom disk(s)
                 <%- end -%>
 
                 <%- if $remoteAdmin != 'Administrator' -%>

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -22,6 +22,7 @@ jenkins:
       <%- $cloudInitDoneParentDir = "#{$tempDir}" -%>
       <%- $cloudInitDoneFile = "#{$cloudInitDoneParentDir}/.cloud-init.done" -%>
       <%- $javaHome = agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] -%>
+      <%- $noCustomDataDiskForDocker = agent['noCustomDataDiskForDocker'] == nil ? false : agent['noCustomDataDiskForDocker'] -%>
       - ami: "<%= agent['ami'] ? agent['ami'] : @jcasc['agent_images']['ec2_amis'][$os + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"
         amiType:
       <%- if $os == 'windows' -%>
@@ -156,6 +157,9 @@ jenkins:
                   }
                 }
 
+                <%- if $noCustomDataDiskForDocker -%>
+                ## Not using custom disk for docker
+                <%- else -%>
                 ## Setup Docker Engine to store its data in the <%= agent['customDataDisk'] %> drive
                 # Note: file path MUST use Unix-style separator (/)
                 @'
@@ -166,6 +170,9 @@ jenkins:
 
                 # Restart docker engine
                 Restart-Service docker
+                <%- end -%>
+                <%- else -%>
+                ## No NVMe(s) as custom disk(s)
                 <%- end -%>
 
                 <%- if $remoteAdmin != 'Administrator' -%>

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -22,7 +22,7 @@ jenkins:
       <%- $cloudInitDoneParentDir = "#{$tempDir}" -%>
       <%- $cloudInitDoneFile = "#{$cloudInitDoneParentDir}/.cloud-init.done" -%>
       <%- $javaHome = agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] -%>
-      <%- $noCustomDataDiskForDocker = agent['noCustomDataDiskForDocker'] == nil ? false : agent['noCustomDataDiskForDocker'] -%>
+      <%- $customDataDiskNotUsedForDocker = agent['customDataDiskNotUsedForDocker'] == nil ? false : agent['customDataDiskNotUsedForDocker'] -%>
       - ami: "<%= agent['ami'] ? agent['ami'] : @jcasc['agent_images']['ec2_amis'][$os + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"
         amiType:
       <%- if $os == 'windows' -%>
@@ -157,7 +157,7 @@ jenkins:
                   }
                 }
 
-                <%- if $noCustomDataDiskForDocker -%>
+                <%- if $customDataDiskNotUsedForDocker -%>
                 ## Not using custom disk for docker
                 <%- else -%>
                 ## Setup Docker Engine to store its data in the <%= agent['customDataDisk'] %> drive

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -22,7 +22,6 @@ jenkins:
       <%- $cloudInitDoneParentDir = "#{$tempDir}" -%>
       <%- $cloudInitDoneFile = "#{$cloudInitDoneParentDir}/.cloud-init.done" -%>
       <%- $javaHome = agent['javaHome'] ? agent['javaHome'] : @jcasc['agents_setup'][$os]['javaHome'] -%>
-      <%- $customDataDiskNotUsedForDocker = agent['customDataDiskNotUsedForDocker'] == nil ? false : agent['customDataDiskNotUsedForDocker'] -%>
       - ami: "<%= agent['ami'] ? agent['ami'] : @jcasc['agent_images']['ec2_amis'][$os + "-" + agent['os_version'].to_s + "-" + agent['architecture'].to_s] %>"
         amiType:
       <%- if $os == 'windows' -%>
@@ -157,7 +156,7 @@ jenkins:
                   }
                 }
 
-                <%- if $customDataDiskNotUsedForDocker -%>
+                <%- if agent['customDataDiskNotUsedForDocker'] -%>
                 ## Not using custom disk for docker
                 <%- else -%>
                 ## Setup Docker Engine to store its data in the <%= agent['customDataDisk'] %> drive

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -689,7 +689,7 @@ profile::jenkinscontroller::jcasc:
             # Utilizes the local NVMe mounted in Z:
             customDataDisk: 'Z:'
             # Don't use local NVMe as data-root for docker
-            noCustomDataDiskForDocker: true
+            customDataDiskNotUsedForDocker: true
             remoteAdmin: jenkins
             labels:
               - infratest-windows

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -686,8 +686,10 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
-            # # Utilizes the local NVMe mounted in Z:
-            # customDataDisk: 'Z:'
+            # Utilizes the local NVMe mounted in Z:
+            customDataDisk: 'Z:'
+            # Don't use local NVMe as data-root for docker
+            noCustomDataDiskForDocker: true
             remoteAdmin: jenkins
             labels:
               - infratest-windows

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -205,7 +205,7 @@ profile::jenkinscontroller::jcasc:
             os_version: "2025"
             ebsOptimized: true
             customDataDisk: 'Z:'
-            noCustomDataDiskForDocker: true
+            customDataDiskNotUsedForDocker: true
             architecture: "amd64"
             labels:
               - docker-windows-2025

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -169,7 +169,7 @@ profile::jenkinscontroller::jcasc:
               - win-2019-amd64-maven-21
               - maven-21-windows-nonspot
             spot: false
-          - description: "Spot Windows 2019 x86_64 with JDK21"
+          - description: "Spot Windows 2019 x86_64 with JDK21 with custom disk"
             maxInstances: 5
             ami: ami-xxxxxxxxx
             instanceType: T3aXlarge # 4 vCPUs / 16 Gb
@@ -182,8 +182,9 @@ profile::jenkinscontroller::jcasc:
             remoteAdmin: jenkins
             labels:
               - maven-21-windows
+              - custom-disk
             spot: true
-          - description: "Windows 2022 x86_64 with default (current) JDK"
+          - description: "Windows 2022 x86_64 with default (current) JDK without custom disk"
             maxInstances: 4
             ami: ami-xxxxxxxxx
             instanceType: T3aXlarge # 4 vCPUs / 16 Gb
@@ -194,18 +195,23 @@ profile::jenkinscontroller::jcasc:
             labels:
               - docker-windows-2022
               - win-2022
+              - no-custom-disk
             spot: false
-          - description: "Windows 2025 x86_64 with default (current) JDK"
+          - description: "Windows 2025 x86_64 with default (current) JDK with custom disk but not using it for docker"
             maxInstances: 4
             ami: ami-xxxxxxxxx
             instanceType: T3aXlarge # 4 vCPUs / 16 Gb
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
+            customDataDisk: 'Z:'
+            noCustomDataDiskForDocker: true
             architecture: "amd64"
             labels:
               - docker-windows-2025
               - win-2025
+              - custom-disk
+              - no-custom-disk-for-docker
             spot: false
     kubernetes:
       first-cluster:


### PR DESCRIPTION
This PR adds a `customDataDiskNotUsedForDocker` ec2 agent template parameter allowing to not create any docker daemon config file using local NVMe as data-root if a custom disk is defined in a ci.jenkins.io ec2 template, to avoid hitting https://github.com/moby/moby/issues/48093 when building Windows images of different versions from a same host version.

If this parameter is undefined, a docker daemon config using custom disk is still created by default in the cloud-init script of ec2 VM, to avoid breaking existing agent templates.

### Testing done
`vagrant up jenkins::controller --provision`

Then in http://localhost:8080/manage/cloud/aws-us-east-2/configure checked the different cloud-init content (in "Advanced" details) for the following ec2 templates:
- "Spot Windows 2019 x86_64 with JDK21 with custom disk"
  - `customDataDisk: 'Z:'` set in its vagrant definition
  - Has a local NVMe as custom disk and a docker daemon config using this custom disk
  - <details>

    <img width="1361" height="1375" alt="image" src="https://github.com/user-attachments/assets/3081d686-ffe3-4860-8696-e3f583f86a67" />
    </details>
- "Windows 2022 x86_64 with default (current) JDK without custom disk"
  - No `customDataDisk: 'Z:'` set in its vagrant definition
  - Does not have a local NVMe as custom disk nor a docker daemon config using this custom disk
  - <details>

    <img width="1361" height="1375" alt="image" src="https://github.com/user-attachments/assets/3081d686-ffe3-4860-8696-e3f583f86a67" />
    </details>
- "Windows 2025 x86_64 with default (current) JDK with custom disk but not using it for docker"
  - `customDataDisk: 'Z:'` set in its vagrant definition
  - `customDataDiskNotUsedForDocker: true` set in its vagrant definition
  - Has a local NVMe as custom disk but no docker daemon config using this custom disk
  - <details>

    <img width="1361" height="1375" alt="image" src="https://github.com/user-attachments/assets/3081d686-ffe3-4860-8696-e3f583f86a67" />
    </details>

Refs:
- https://github.com/jenkins-infra/jenkins-infra/pull/4560#pullrequestreview-3531102268
- https://github.com/jenkins-infra/helpdesk/issues/4791