### PR TITLE
feat(aws.ci.jenkins.io): don't use custom data disk for docker in Windows 2025 ec2 template

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -670,6 +670,8 @@ profile::jenkinscontroller::jcasc:
             javaHome: 'C:/tools/jdk-17'
             # Utilizes the local NVMe mounted in Z:
             customDataDisk: 'Z:'
+            # Don't use local NVMe as data-root for docker
+            customDataDiskNotUsedForDocker: true
             remoteAdmin: jenkins
             labels:
               - win-2025-amd64-maven-17


### PR DESCRIPTION
This PR disable the use of custom data disk for docker in "Spot Windows 2025 x86_64 with JDK17" ec2 agent template on ci.jenkins.io.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4791#issuecomment-3606439533