### PR TITLE
Revert "feat(aws.ci.jenkins.io): disable `ci.jenkins.io-agents-2` and `ci.jenkins.io-agents-2-bom` clouds for Kubernetes 1.33.5 upgrade"

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -120,7 +120,7 @@ profile::jenkinscontroller::jcasc:
   cloud_agents:
     kubernetes:
       ci.jenkins.io-agents-2:
-        enabled: false
+        enabled: true
         ## Note: no URL/credential/CA data as we rely on jenkins' KUBECONFIG to allow EC2 instance profile authentication
         # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
         imageNamePrefix: "326712726440.dkr.ecr.us-east-2.amazonaws.com/docker-hub/"
@@ -253,7 +253,7 @@ profile::jenkinscontroller::jcasc:
                 value: "true"
                 effect: "NoSchedule"
       ci.jenkins.io-agents-2-bom:
-        enabled: false
+        enabled: true
         ## Note: no URL/credential/CA data as we rely on jenkins' KUBECONFIG to allow EC2 instance profile authentication
         # TODO: track with updatecli
         imageNamePrefix: "326712726440.dkr.ecr.us-east-2.amazonaws.com/docker-hub/"


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#4569

ref https://github.com/jenkins-infra/helpdesk/issues/4820#issuecomment-3607329009