### PR TITLE
Remove better-pipeline-flowgraph-table from cert.ci

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -264,6 +264,5 @@ profile::jenkinscontroller::plugins:
   - timestamper
   - workflow-basic-steps
   # Utility
-  - better-pipeline-flowgraph-table
   - compact-columns
   - disable-job-button


### PR DESCRIPTION
https://github.com/jenkinsci/workflow-support-plugin/releases/tag/1010.vb_b_39488a_9841 makes this plugin unnecessary.