### PR TITLE
cleanup(trusted.ci.jenkins.io/tests) remove the `toolenv` plugin

### DIFF
--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -378,6 +378,5 @@ profile::jenkinscontroller::plugins:
   - ssh-slaves # SSH Build Agent to implement "outbound agents"
   - throttle-concurrents
   - timestamper
-  - toolenv
   - workflow-aggregator
   - workflow-multibranch

--- a/hieradata/rspec/profile_jenkinscontroller.yaml
+++ b/hieradata/rspec/profile_jenkinscontroller.yaml
@@ -166,7 +166,6 @@ profile::jenkinscontroller::plugins:
   - matrix-auth
   - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs
   - ssh-slaves # SSH Build Agent to implement "outbound agents"
-  - toolenv
   - workflow-aggregator
   - workflow-multibranch
 ldap_url: "ldap://localhost:389"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -498,7 +498,6 @@ profile::jenkinscontroller::plugins:
   - ssh-slaves # SSH Build Agent to implement "outbound agents"
   - throttle-concurrents
   - timestamper
-  - toolenv
   - warnings-ng
   - workflow-aggregator
 profile::buildagent::tools_versions:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4890