### PR TITLE
feat(trusted.ci.jenkins.io): add `arm64docker` agent template

### DIFF
--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -127,6 +127,7 @@ profile::jenkinscontroller::jcasc:
             - ubuntu-22-amd64-maven-11
             - maven-11
             - jdk11
+            - amd64 # For parity with ci.jenkins.io default docker amd agent template
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -174,6 +174,26 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
+        - name: "ubuntu-22-arm64-maven-21"
+          description: "Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
+          imageDefinition: jenkins-agent-ubuntu-22.04-arm64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: arm64
+          labels:
+            - ubuntu-arm64-maven-21
+            - ubuntu-22-arm64-maven-21
+            - arm64docker # Same label as ci.jenkins.io docker arm64 agent template
+          javaHome: '/opt/jdk-21'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
         - name: "ubuntu-22-amd64-maven-25"
           description: "Ubuntu 22.04 LTS x86_64 with JDK25 set as default java CLI"
           imageDefinition: jenkins-agent-ubuntu-22.04-amd64
@@ -191,26 +211,6 @@ profile::jenkinscontroller::jcasc:
             - maven-25
             - jdk25
           javaHome: '/opt/jdk-25'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "ubuntu-22-arm64-maven-21"
-          description: "Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-arm64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: arm64
-          labels:
-            - ubuntu-arm64-maven-21
-            - ubuntu-22-arm64-maven-21
-            - arm64docker # Same label as ci.jenkins.io docker arm64 agent template
-          javaHome: '/opt/jdk-21'
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -194,6 +194,26 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
+        - name: "ubuntu-22-arm64-maven-25"
+          description: "Ubuntu 22.04 LTS arm64 with JDK25 set as default java CLI"
+          imageDefinition: jenkins-agent-ubuntu-22.04-arm64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: arm64
+          labels:
+            - ubuntu-arm64-maven-25
+            - ubuntu-22-arm64-maven-25
+            - arm64docker # Same label as ci.jenkins.io docker arm64 agent template
+          javaHome: '/opt/jdk-25'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
         - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
           description: "Windows 2019 Maven-11"
           imageDefinition: jenkins-agent-windows-2019-amd64

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -127,7 +127,6 @@ profile::jenkinscontroller::jcasc:
             - ubuntu-22-amd64-maven-11
             - maven-11
             - jdk11
-            - amd64 # For parity with ci.jenkins.io default docker amd agent template
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -195,8 +195,8 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"
           usePrivateIP: true
-        - name: "ubuntu-22-arm64-maven-25"
-          description: "Ubuntu 22.04 LTS arm64 with JDK25 set as default java CLI"
+        - name: "ubuntu-22-arm64-maven-21"
+          description: "Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
           imageDefinition: jenkins-agent-ubuntu-22.04-arm64
           os: "ubuntu"
           os_version: "22.04"
@@ -207,10 +207,10 @@ profile::jenkinscontroller::jcasc:
           spot: true
           architecture: arm64
           labels:
-            - ubuntu-arm64-maven-25
-            - ubuntu-22-arm64-maven-25
+            - ubuntu-arm64-maven-21
+            - ubuntu-22-arm64-maven-21
             - arm64docker # Same label as ci.jenkins.io docker arm64 agent template
-          javaHome: '/opt/jdk-25'
+          javaHome: '/opt/jdk-21'
           maxInstances: 7
           useAsMuchAsPossible: true
           credentialsId: "azure-jenkins-user"


### PR DESCRIPTION
This PR adds an arm64 agent template (based on the newer ubuntu one), ~~and adds an `amd64` label to the default `docker` one for parity with the corresponding ci.jenkins.io agent template (not sure about that change, I haven't found the corresponding ci.jenkins.io agent template label 🤔~~ see https://github.com/jenkins-infra/jenkins-infra/pull/4596#discussion_r2662409010).

Note: I've reused the same `arm64docker` label as the AWS ci.jenkins.io agent template one so we can use the same labels in both ci.jenkins.io & trusted.ci.jenkins.io in docker image pipeline:
https://github.com/jenkins-infra/jenkins-infra/blob/f67283f8dc6dac49954ba5407796bce2e1562eb8/hieradata/clients/aws.ci.jenkins.io.yaml#L409-L420

https://github.com/jenkinsci/docker/blob/52d8ee8b73d046decfcbf97cd16582e187c86fa2/Jenkinsfile#L18-L20

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/4934
- https://github.com/jenkinsci/docker/issues/2154#issuecomment-3709445653