### PR TITLE
feat(ci.jenkins.io) uses Administrator user instead of 'jenkins' for the 2 Windows test EC2 agents - 

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -692,7 +692,7 @@ profile::jenkinscontroller::jcasc:
             customDataDisk: 'Z:'
             # Don't use local NVMe as data-root for docker
             customDataDiskNotUsedForDocker: true
-            remoteAdmin: jenkins
+            remoteAdmin: Administrator
             labels:
               - infratest-windows
             spot: true
@@ -717,7 +717,7 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
-            remoteAdmin: jenkins
+            remoteAdmin: Administrator
             labels:
               - helpdesk-4939
             spot: false


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4939 and https://github.com/jenkinsci/credentials-plugin/pull/999#issuecomment-3715519423