### PR TITLE
fix(trusted.ci.jenkins.io) use correct instance size for arm64 Azure VM template

### DIFF
--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -180,7 +180,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8pds_v5 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: arm64


### PR DESCRIPTION
Fixup of a754f695 (#4596)

Ref. https://github.com/jenkins-infra/helpdesk/issues/4934#issuecomment-3715666716 and https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dpdsv5-series?tabs=sizebasic
