### PR TITLE
cleanup: remove last references of the old pkg.origin.jenkins.io VM 

### DIFF
--- a/hieradata/clients/archives.do.jenkins.io.yaml
+++ b/hieradata/clients/archives.do.jenkins.io.yaml
@@ -5,7 +5,6 @@ profile::archives::rsync_hosts_allow:
 ## TODO: uncomment and add values from our mirrors to allow them to download data
 #   - localhost
 #   - archives.jenkins.io
-#   - pkg.origin.jenkins.io
 #   - get.jenkins.io
 #   - 46.101.121.132 # archives.do.jenkins.io
 # Per-host Datadog configuration

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -271,7 +271,7 @@ limits:
       soft: "65536"
       hard: "65536"
 profile::openvpn::image: dockerhubmirror.azurecr.io/jenkinsciinfra/openvpn
-profile::openvpn::image_tag: 3.7.1
+profile::openvpn::image_tag: 3.7.3
 # TODO: track with updatecli from https://github.com/jenkins-infra/docker-openvpn/blob/main/config.yaml
 profile::openvpn::external_ips_vpn_restricted:
   archives.jenkins.io: 46.101.121.132
@@ -280,7 +280,6 @@ profile::openvpn::external_ips_vpn_restricted:
   dockerhubmirror.azurecr.io: 20.49.102.154
   eks_cijenkinsioagents2_1: 3.149.48.23
   eks_cijenkinsioagents2_2: 3.149.71.89
-  pkg.origin.jenkins.io: 52.202.51.185
   usage.jenkins.io: 64.227.123.95
 apt::update:frequency: 'daily'
 # vim: ft=yaml ts=2 sw=2 nowrap et

--- a/html/README.md
+++ b/html/README.md
@@ -1,7 +1,7 @@
 # Jenkins Downloads HTML Content
 
 This directory contains HTML files manually deployed to:
-- https://archives.jenkins.io (through pkg.origin VM)
+- https://archives.jenkins.io
 - https://get.jenkins.io
 
 These files are not the real content but only a few HTML pages to improve user UX.

--- a/html/index.html
+++ b/html/index.html
@@ -1,6 +1,6 @@
 <html lang="en">
 <!-- Source file tracked in https://github.com/jenkins-infra/jenkins-infra -->
-<!-- File manually deployed to archives.jenkins.io (through pkg.origin VM) and get.jenkins.io -->
+<!-- File manually deployed to archives.jenkins.io and get.jenkins.io -->
 <!-- Ref. https://github.com/jenkins-infra/helpdesk/issues/4834 -->
 <head>
   <meta charset="UTF-8" />


### PR DESCRIPTION
Includes openvpn update to remove the old route (https://github.com/jenkins-infra/docker-openvpn/releases/tag/3.7.3)

Ref. https://github.com/jenkins-infra/helpdesk/issues/3705