### PR TITLE
feat([trusted|cert].ci.jenkins.io): add Windows Server Core 2025 agent template definitions

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -675,6 +675,23 @@ profile::jenkinscontroller::jcasc:
             remoteAdmin: jenkins
             labels:
               - win-2025-amd64-maven-17
+            spot: true
+            acpServerId: aws-internal
+          - description: "Spot Windows 2025 x86_64 with JDK25"
+            maxInstances: 50
+            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            os: "windows"
+            os_version: "2025"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: 'C:/tools/jdk-25'
+            # Utilizes the local NVMe mounted in Z:
+            customDataDisk: 'Z:'
+            # Don't use local NVMe as data-root for docker
+            customDataDiskNotUsedForDocker: true
+            remoteAdmin: jenkins
+            labels:
+              - win-2025-amd64-maven-25
               # Labels indicating it is the default VM template for Windows 2025 (but not windows)
               - docker-windows-2025
               - win-2025

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -243,6 +243,25 @@ profile::jenkinscontroller::jcasc:
           useAsMuchAsPossible: true
           credentialsId: "azure-login"
           usePrivateIP: true
+        - name: "win-2025-amd64-maven-25" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2025 Maven-25"
+          imageDefinition: jenkins-agent-windows-2025-amd64
+          os: "windows"
+          os_version: "2025"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: false
+          architecture: amd64
+          labels:
+            - win-2025-amd64-maven-25
+            - maven-25-windows
+          javaHome: 'C:/tools/jdk-25'
+          maxInstances: 10 # Quota of 80 vCPUs
+          useAsMuchAsPossible: true
+          credentialsId: "azure-login"
+          usePrivateIP: true
 ## Ensure we override the default plugins to install defined from hieradata/common.yaml
 profile::jenkinscontroller::plugins:
   # System configuration

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -226,12 +226,13 @@ profile::jenkinscontroller::jcasc:
           spot: true
           architecture: amd64
           labels:
-            - docker-windows
             - win-2019
             - windows-2019
             - win-2019-amd64-maven-11
-            - maven-windows
             - maven-11-windows
+            # Labels indicating it is the default VM template for Windows & Docker, and Windows & Maven
+            - docker-windows
+            - maven-windows
           javaHome: 'C:/tools/jdk-11'
           maxInstances: 7
           useAsMuchAsPossible: true
@@ -364,6 +365,27 @@ profile::jenkinscontroller::jcasc:
           architecture: amd64
           labels:
             - win-2022-amd64-maven-25
+          javaHome: 'C:/tools/jdk-25'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2025-amd64-maven-25"
+          description: "Windows 2025 Maven-25"
+          imageDefinition: jenkins-agent-windows-2025-amd64
+          os: "windows"
+          os_version: "2025"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2025-amd64-maven-25
+            # Labels indicating it is the default VM template for Windows 2025 (but not windows)
+            - docker-windows-2025
+            - win-2025
           javaHome: 'C:/tools/jdk-25'
           maxInstances: 7
           useAsMuchAsPossible: true

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -174,27 +174,27 @@ profile::jenkinscontroller::jcasc:
         major_version: 8
         installers:
           linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8"
-          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-8-windows"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-8-windows"
       jdk11:
         major_version: 11
         installers:
           linux-amd64: "(linux && amd64) || linux-amd64 || jdk11 || jdk-11 || maven-11"
-          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-11-windows"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-11-windows"
       jdk17:
         major_version: 17
         installers:
           linux-amd64: "(linux && amd64) || linux-amd64 || jdk17 || jdk-17 || maven-17"
-          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-17-windows"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-17-windows"
       jdk21:
         major_version: 21
         installers:
           linux-amd64: "(linux && amd64) || linux-amd64 || jdk21 || jdk-21 || maven-21"
-          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-21-windows"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-21-windows"
       jdk25:
         major_version: 25
         installers:
           linux-amd64: "(linux && amd64) || linux-amd64 || jdk25 || jdk-25 || maven-25"
-          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || maven-25-windows"
+          windows-amd64: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-25-windows"
   agents_setup:
     windows:
       agentDir: 'C:/Jenkins/agent'


### PR DESCRIPTION
This changes adds Windows Server Core 2025 agent template definitions to trusted.ci.jenkins.io & cert.ci.jenkins.io, and align the ci.jenkins.io 2025 agent definition to them.

It also ensure that all `jdk` tools installers are presents in every Windows agent template.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4791