### PR TITLE
cleanup(aws.ci, cert.ci, trusted.ci) remove CSP (1.x) JCasC configuration and stop enforcing `csp` plugin installation

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -47,10 +47,6 @@ profile::jenkinscontroller::jcasc:
         # but hieradata is behaving weirdly (bug in YAML parser?)
         defaultDisplayUrlProvider:
           providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
-  csp-plugin:
-    reportOnly: true
-    rule: |-
-      "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: avatars.githubusercontent.com; media-src 'self' data: ; script-src 'self' 'report-sample' usage.jenkins.io;"
   appearance:
     pipeline_graph_view:
       on_build_page: true
@@ -752,7 +748,6 @@ profile::jenkinscontroller::plugins:
   - coverage-badges-extension # Coverage Badges
   - credentials # Provides Jenkins Credentials management
   - credentials-binding # Bind Jenbkins credentials to variables in jobs
-  - csp # for the security team see https://github.com/jenkins-infra/helpdesk/issues/4776
   - datadog # Datadog plugin
   - dark-theme # Dark theme
   - docker-workflow # Provides the "withDockerContainer" pipeline keyword

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -28,10 +28,6 @@ profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAXpmFyHEJVPfkgY2pUna5kvSxS8/O8b78GKNbCstm5loTtW6Ahgeeaqimiha9zOlr383B3/qursQHv0lYlGQrxGzonQHRblEbXM19hznGKIqtZc2JsXQ7uutgSApIB+aQkNcE7LF5AIbQbag0vfs2VtC18k8k/krqtzqFcd2ioukzdF7Dnf9YXsSbp2Q3gMUt9r1WpmrgxHTXIghZCA8lVsI1c9oo3JnQCvHYAUUxRbfXs/mAyeOKKGnCCmgujvWjNbjCNsLC0+VhVi0Hn3hnT3FTm9cyEWyDxfFfQ3/dffq9ZKbNHbRDkUg0M5sP1Kn0bQK08Nc2UScKsvP00g281TBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBA+RyPMfeLE+gavSoFQen4tgCB2fTgVbu+YezSpWaedB4WQ6gX1eP5G4id2Lh7gOUYOSw==]
   datadog_api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAPHOrzhvtHBDIx0+hew05tezK2pM+fCy1rBzC5BZIBvzeMV5rXJ9p6Ujo7O9bdYeFB1O03wemXfWAN2slD3Ycvi/NEs/2aIxDsWs/qSWhzkEucUDLqcwazcN3lHIf69zsO6fE+0srmA0sdZf+nWyJRKSDj0wDZ2Zsaa0Sz8Y5LPrDW+DMnMo84C7fdqXLJDxlzDGNMOu8kj3zv1GTH89bdNOXxFD44vzBVxX/y64FUi1VmHro1kPicLN7Gde6+X3K8oEJ2ib3Z8H5NSNC8SAGws2bYbLw+pbXyvhdDrATLS9KuVh8Huv3lolyrEyfnCtt2FCfXDvWoRgM50hQ/GElFzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBBX4DRxdnIckeAh69lPWonkgDDJwdm4VegnOcix+MS+AQuBFvVv+SJFTSUTt5GA+yJ+wfI6D4n0UdCqxaLSvyLZQ9U=]
-  csp-plugin:
-    reportOnly: true
-    rule: |-
-      "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: avatars.githubusercontent.com; media-src 'self' data: ; script-src 'self' 'report-sample' usage.jenkins.io;"
   global_libraries:
     disabled: true
   tools:
@@ -267,7 +263,6 @@ profile::jenkinscontroller::plugins:
   # System configuration
   - azure-vm-agents
   - configuration-as-code
-  - csp
   - generic-tool
   - ldap
   - matrix-auth

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -45,10 +45,6 @@ profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAlreoLMhSaHCcZZaL1r7BQgmqUVbqWs+e2kaj0cn+r8o4N/qKZGXkkYBN9xhK+b5MRe2cTlfQ9J3gFFLFa6i1n1GrM/WwNMUm/cVYA2eGFNcV3ruUfigyriIrIaQVm7KIQZqv+RIQoZHJ1cWy+CdKg2hXi4KUBSawl1V3VXjSD4ZJEWv96KSceJZRTzVjZW66iD8i8Uq50WvHhvivMfHkaghowz626w/ejz0AettIKCVL9/j0B1iVv+ghOyd4A5kyIYJKR0BwQLpfKFoXY/0uhB7toZWSe7TUS7hzTAfYNhyTbS0aaczsa7pshiFZzxHAdvMeU7om4N1Dj+5LDUgAsDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBByyf8QkfPXbWYxJbMykP8SgCAQ5ncRq7jZddH/cFcb+xHJzKluSoRQU3fnSKJ8fnbEQA==]
   datadog_api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEADyo2YPgZgSJTKYK+zqkBcrmKKDuMOkZ1PqeCbCjHaJEJpM41lUGTe0s9wZfKV0poQZxF+REOhrV4wisuvt9tTMZpPUgG+Z5tetLO9GDJ8Ml0t7P/OHooFt4gebBwZQAPnUN35R87FQcS69XDKVCrp/RepteuicPSqUozjPls652mHiaR+OqBzqVr0+jlRfprt7UG8UthT+rih89OfVzmnTj9PSmbt1q5R3kMFg8/7yQTTf8yvS9XPthNLXTC/3/3ygdA+Md6Le9kzknIrJGFcide8S2JO3CLuf5LFo9/8RViCAhDmZulXOmm8GbCe7M+/Ok7NRJrcFZz0mN7yK4lxjBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBByYY131KQj7XGZAvJLNH+ngDBqKvrxjSNhJ2gzQPlVrur+mYzqf3avlfwUqKFuGTK/9kQ/7vwqI1DfvqiRTy3EJpM=]
-  csp-plugin:
-    reportOnly: true
-    rule: |-
-      "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: avatars.githubusercontent.com; media-src 'self' data: ; script-src 'self' 'report-sample' usage.jenkins.io;"
   appearance:
     pipeline_graph_view:
       on_build_page: true
@@ -401,7 +397,6 @@ profile::jenkinscontroller::plugins:
   - configuration-as-code
   - credentials
   - credentials-binding
-  - csp # for the security team see https://github.com/jenkins-infra/helpdesk/issues/4776
   - docker-workflow
   - disable-job-button
   - git-client


### PR DESCRIPTION
- Prior to 2.541.1 LTS upgrade (https://github.com/jenkins-infra/jenkins-infra/pull/4627)
- Won't uninstall the plugin (that's what we want! We'll remove it after the LTS upgrade)

Ref. https://github.com/jenkins-infra/helpdesk/issues/4962


Important: we'll have to manually re-setup CSP on ci.jenkins.io after this 

<img width="1814" height="405" alt="Capture d’écran 2026-01-21 à 15 17 49" src="https://github.com/user-attachments/assets/d885a231-47dd-4eda-8463-b03dda500eb9" />
