### PR TITLE
feat(jenkinscontroller/(ci|trusted|cert).jio) ensure resources root URL is defined from ci_resource_domain or custom 'jcasc.jenkins_global' property

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/jenkins.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/jenkins.yaml.erb
@@ -4,7 +4,14 @@ jenkins:
   numExecutors: 0
 unclassified:
   location:
-    url: "https://<%= @ci_fqdn %>"
+    url: "<%= @jcasc['jenkins_global'] && @jcasc['jenkins_global']['location'] ? @jcasc['jenkins_global']['location'] : 'https://' + @ci_fqdn %>"
+  <%- if @jcasc['jenkins_global'] && @jcasc['jenkins_global']['resourceRootUrl'] -%>
+  resourceRoot:
+    url: "<%= @jcasc['jenkins_global']['resourceRootUrl'] %>"
+  <%- elsif @ci_resource_domain -%>
+  resourceRoot:
+    url: "<%= 'https://' + @ci_resource_domain %>"
+  <%- end -%>
   shell:
     shell: "/bin/bash"
 <%- end -%>

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -9,6 +9,7 @@ lookup_options:
       strategy: deep
       merge_hash_arrays: true
 profile::jenkinscontroller::ci_fqdn: 'cert.ci.jenkins.io'
+profile::jenkinscontroller::ci_resource_domain: 'assets.cert.ci.jenkins.io'
 docker::log_opt::max-size: "100m"
 docker::log_opt::max-file: 2
 # Per-host Datadog configuration

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -24,6 +24,7 @@ docker::log_opt::max-file: 2
 # Per-host Datadog configuration
 datadog_agent::host: "controller.trusted.ci.jenkins.io"
 profile::jenkinscontroller::ci_fqdn: "trusted.ci.jenkins.io"
+profile::jenkinscontroller::ci_resource_domain: 'assets.trusted.ci.jenkins.io'
 profile::jenkinscontroller::anonymous_access: false
 profile::jenkinscontroller::admin_ldap_groups:
   - admins

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -54,10 +54,9 @@ profile::jenkinscontroller::jcasc:
         # but hierdata is behaving weirdly (bug in YAML parser?)
         defaultDisplayUrlProvider:
           providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
-  csp-plugin:
-    reportOnly: true
-    rule: |-
-      "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: avatars.githubusercontent.com; media-src 'self' data: ; script-src 'self' 'report-sample' usage.jenkins.io;"
+  jenkins_global:
+    location: http://127.0.0.1:8080
+    resourceRootUrl: http://localhost:8080
   appearance:
     pipeline_graph_view:
       on_build_page: true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4959

None of the changes deserves a single commit as they do not make sense alone.

This PR introduces the following changes:

- `profile::jenkinscontroller` set up the JCasC directive `unclassified.resourceRoot.url` in the following case:
  - If the hieradata property `profile::jenkinscontroller.jcasc.jenkins_global.resourceRootUrl` is defined (as top priority in the conditions)
    - Required to allow testing with a different scheme than the default `https` or with a custom port (`8080` in our Vagrant setup)
  - Or if the hieradata property `ci_resource_domain` is set, to `https://<ci_resource_domain value>` (already the case on ci.jenkins.io by default). This existing property drives the ability for the Apache in front of Jenkins to serve requests from this alternate hostname: it will also be used to autoconfigure Jenkins.
- `profile::jenkinscontroller` set up the JCasC directive `unclassified.location.url` to the value of `profile::jenkinscontroller.jcasc.jenkins_global.location` or fallback to the value of (mandatory property) `profile::jenkinscontroller.ci_fqdn`
  - Required to allow testing of resourceRootUrl as the Jenkins location is needed. Both with a different scheme than the default `https` or with a custom port (`8080` in our Vagrant setup).
- Disable CSP (v1) plugin setup in Vagrant (otherwise it does not work since 2.541.1 LTS.
- Set up the secondary DNS for trusted.ci.jenkins.io and cert.ci.jenkins.io using their `profile::jenkinscontroller::ci_resource_domain` hieradata properties


---

Tests ran:

- ✅  CI checks (unit tests - unchanged)
- ✅ Vagrant with the setup in this PR:

  ```yaml
  # /var/lib/jenkins/casc.d/jenkins.yaml 
  jenkins:
    # No builds on controller
    numExecutors: 0
  unclassified:
    location:
      url: "https://localhost"
    resourceRoot:
      url: "https://assets.localhost"
    shell:
      shell: "/bin/bash"
  ```

- ✅ Vagrant with the `profile::jenkinscontroller.jcasc.jenkins_global` section commented out (to have the same setup as the production controllers):

  ```yaml
  # /var/lib/jenkins/casc.d/jenkins.yaml 
  jenkins:
    # No builds on controller
    numExecutors: 0
  unclassified:
    location:
      url: "http://127.0.0.1:8080"
    resourceRoot:
      url: "http://localhost:8080"
    shell:
      shell: "/bin/bash"
  ```

