### PR TITLE
Revert "hotfix((trusted|cert].ci.jenkins.io) disable secondary domain""

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -9,7 +9,7 @@ lookup_options:
       strategy: deep
       merge_hash_arrays: true
 profile::jenkinscontroller::ci_fqdn: 'cert.ci.jenkins.io'
-# profile::jenkinscontroller::ci_resource_domain: 'assets.cert.ci.jenkins.io'
+profile::jenkinscontroller::ci_resource_domain: 'assets.cert.ci.jenkins.io'
 docker::log_opt::max-size: "100m"
 docker::log_opt::max-file: 2
 # Per-host Datadog configuration

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -24,7 +24,7 @@ docker::log_opt::max-file: 2
 # Per-host Datadog configuration
 datadog_agent::host: "controller.trusted.ci.jenkins.io"
 profile::jenkinscontroller::ci_fqdn: "trusted.ci.jenkins.io"
-#profile::jenkinscontroller::ci_resource_domain: 'assets.trusted.ci.jenkins.io'
+profile::jenkinscontroller::ci_resource_domain: 'assets.trusted.ci.jenkins.io'
 profile::jenkinscontroller::anonymous_access: false
 profile::jenkinscontroller::admin_ldap_groups:
   - admins


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4959#issuecomment-3785938028

Following https://github.com/jenkins-infra/azure/pull/1289, we were able to successfully author the TLS certificates for `assets.cert.ci.jenkins.io ` and `assets.trusted.ci.jenkins.io`.