### PR TITLE
feat(ci.jenkins.io) Allow `jenkins` user to create symlinks on EC2 Windows agents

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -190,6 +190,9 @@ jenkins:
                 Get-Date
 
                 <%- if $remoteAdmin != 'Administrator' -%>
+                # Enable Developer mode to allow creating symlinks for non-admin users
+                reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /v "AllowDevelopmentWithoutDevLicense" /t REG_DWORD /d 1 /f
+                
                   <%- if agent['customDataDisk'] -%>
                 # Set up Windows default Users profiles location to the custom data disk drive
                 $userpath = '<%= agent['customDataDisk'] %>\Users'


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4972#issuecomment-3806346639

Tested with success in https://ci.jenkins.io/job/Infra/job/acceptance-tests/job/infra-checks/829/ with the `infratest-windows` template.