### PR TITLE
fix(awscli) only cleanup `install_dir` content, not the directory itself

### DIFF
--- a/dist/profile/manifests/awscli.pp
+++ b/dist/profile/manifests/awscli.pp
@@ -53,7 +53,7 @@ class profile::awscli (
       ],
       ## Note: deleting the content of the $install_dir prior to the installation avoid the installer to pile-up installation filling the disk
       ## As such, no need for the --update flag for the installer: it will fail if something already exist
-      command => "/usr/bin/unzip -o ${aws_temp_zip} -d /tmp && rm -rf ${install_dir} && /bin/bash /tmp/aws/install --install-dir ${install_dir} --bin-dir ${bin_dir}",
+      command => "/usr/bin/unzip -o ${aws_temp_zip} -d /tmp && rm -rf ${install_dir}/* && /bin/bash /tmp/aws/install --install-dir ${install_dir} --bin-dir ${bin_dir}",
       unless  => $aws_check_command,
     }
     exec { 'Cleanup AWS CLI Installer':


### PR DESCRIPTION
Amends https://github.com/jenkins-infra/jenkins-infra/pull/4638 which caused:
- https://github.com/jenkins-infra/helpdesk/issues/4973
- https://github.com/jenkins-infra/helpdesk/issues/4970 

when the `aws` CLI was bumped.

It fixes the `awscli` profile by cleaning up its `install_dir` directory content instead of the directory itself.

Before this PR, when the `aws` CLI is upgraded (or downgraded), the `${install_dir}` directory is wiped (its content recursively but also the inode itself).

Since this directory [is bind-mounted in the `jenkins` controller on ci.jenkins.io](https://github.com/jenkins-infra/jenkins-infra/blob/0ee76003b22096d2bd2421d4c514b9ed009e17c8/dist/profile/manifests/jenkinscontroller.pp#L327-L328), wiping it ends in the container seing the bind-mounted directory empty (since its inode was removed):

```
root@ci.jenkins.io:/var/jenkins_kubeconfigs$ ls -l /var/awscli/
total 4
drwxr-xr-x 3 root root 4096 Jan 28 14:11 v2
root@ci.jenkins.io:/var/jenkins_kubeconfigs$ docker exec -ti jenkins ls -l /var/awscli
total 0
```

Then, as soon as the Kubernetes plugin needs to emit a request, it fails to find the `aws` CLI in its `PATH`:

```
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]: 2026-01-28 14:15:06.106+0000 [id=9173]        WARNING        i.f.k.c.internal.KubeConfigUtils#getExecCredentialFromExecConfig: sh: 1: aws: not found
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]: 2026-01-28 14:15:06.106+0000 [id=9173]        WARNING        i.f.k.c.internal.KubeConfigUtils#getExecCredentialFromExecConfig: Error unmarshalling ExecCredential
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]: mapping values are not allowed here
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]: [LF]>  in reader, line 1, column 6:
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]: [LF]>     sh: 1: aws: not found
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]: [LF]>          ^
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.scanner.ScannerImpl.fetchValue(ScannerImpl.java:854)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.scanner.ScannerImpl.fetchMoreTokens(ScannerImpl.java:377)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.scanner.ScannerImpl.checkToken(ScannerImpl.java:193)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.parser.ParserImpl$ParseBlockMappingKey.produce(ParserImpl.java:712)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.parser.ParserImpl.lambda$produce$1(ParserImpl.java:232)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.Optional.ifPresent(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.parser.ParserImpl.produce(ParserImpl.java:232)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.parser.ParserImpl.peekEvent(ParserImpl.java:206)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.comments.CommentEventsCollector$1.peek(CommentEventsCollector.java:57)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.comments.CommentEventsCollector$1.peek(CommentEventsCollector.java:43)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.comments.CommentEventsCollector.collectEvents(CommentEventsCollector.java:135)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.comments.CommentEventsCollector.collectEvents(CommentEventsCollector.java:115)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.composer.Composer.composeScalarNode(Composer.java:244)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.composer.Composer.composeNode(Composer.java:206)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.composer.Composer.composeValueNode(Composer.java:364)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.composer.Composer.composeMappingChildren(Composer.java:343)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.composer.Composer.composeMappingNode(Composer.java:321)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.composer.Composer.composeNode(Composer.java:210)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.composer.Composer.next(Composer.java:162)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//org.snakeyaml.engine.v2.api.Load$YamlIterator.next(Load.java:234)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.utils.KubernetesSerialization.parseYaml(KubernetesSerialization.java:289)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.utils.KubernetesSerialization.unmarshal(KubernetesSerialization.java:270)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.utils.KubernetesSerialization.unmarshal(KubernetesSerialization.java:360)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.utils.KubernetesSerialization.unmarshal(KubernetesSerialization.java:345)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.utils.Serialization.unmarshal(Serialization.java:186)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.internal.KubeConfigUtils.getExecCredentialFromExecConfig(KubeConfigUtils.java:362)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.internal.KubeConfigUtils.mergeKubeConfigExecCredential(KubeConfigUtils.java:319)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.internal.KubeConfigUtils.merge(KubeConfigUtils.java:235)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.Config.autoConfigure(Config.java:280)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.Config.autoConfigure(Config.java:270)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.Config.refresh(Config.java:837)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.utils.TokenRefreshInterceptor.refreshToken(TokenRefreshInterceptor.java:123)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.utils.TokenRefreshInterceptor.before(TokenRefreshInterceptor.java:77)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$buildWebSocketOnce$19(StandardHttpClient.java:267)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.LinkedHashMap$LinkedValues.forEach(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.http.StandardHttpClient.buildWebSocketOnce(StandardHttpClient.java:267)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$buildWebSocket$13(StandardHttpClient.java:243)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.utils.AsyncUtils.retryWithExponentialBackoff(AsyncUtils.java:75)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.utils.AsyncUtils.retryWithExponentialBackoff(AsyncUtils.java:68)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.http.StandardHttpClient.retryWithExponentialBackoff(StandardHttpClient.java:163)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.http.StandardHttpClient.buildWebSocket(StandardHttpClient.java:241)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.http.StandardWebSocketBuilder.buildAsync(StandardWebSocketBuilder.java:44)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager.start(WatchConnectionManager.java:75)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.startWatch(AbstractWatchManager.java:323)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.dsl.internal.AbstractWatchManager.<init>(AbstractWatchManager.java:146)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.dsl.internal.WatchConnectionManager.<init>(WatchConnectionManager.java:53)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.dsl.internal.BaseOperation.submitWatch(BaseOperation.java:662)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.informers.impl.cache.Reflector.startWatcher(Reflector.java:222)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.informers.impl.cache.Reflector.lambda$listSyncAndWatch$5(Reflector.java:139)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture.thenCompose(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.informers.impl.cache.Reflector.lambda$listSyncAndWatch$6(Reflector.java:139)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$completeOrCancel$10(StandardHttpClient.java:141)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.http.ByteArrayBodyHandler.onBodyDone(ByteArrayBodyHandler.java:51)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture.postComplete(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.CompletableFuture.complete(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at PluginClassLoader for kubernetes-client-api//io.fabric8.kubernetes.client.okhttp.OkHttpClientImpl$OkHttpAsyncBody.doConsume(OkHttpClientImpl.java:134)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
Jan 28 14:15:06 ip-10-0-0-177 docker-jenkins[1525444]:         at java.base/java.lang.Thread.run(Unknown Source)
```

