### PR TITLE
feat(jenkinscontroller) introduces `authenticated_access` property to set up `READ` access for any authenticated user

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -16,7 +16,8 @@
 class profile::jenkinscontroller (
   Boolean $anonymous_access                    = false,
   Boolean $authenticated_access                = false,
-  Array $admin_ldap_groups                     = ['admins'],
+  Array $admin_ldap_groups                     = [],
+  Array $admin_users                           = [],
   Stdlib::Fqdn $ci_fqdn                        = '',
   Hash $additional_fqdns                       = {},
   String $ci_resource_domain                   = '',

--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -15,6 +15,7 @@
 #
 class profile::jenkinscontroller (
   Boolean $anonymous_access                    = false,
+  Boolean $authenticated_access                = false,
   Array $admin_ldap_groups                     = ['admins'],
   Stdlib::Fqdn $ci_fqdn                        = '',
   Hash $additional_fqdns                       = {},

--- a/dist/profile/templates/jenkinscontroller/lockbox.groovy.erb
+++ b/dist/profile/templates/jenkinscontroller/lockbox.groovy.erb
@@ -66,6 +66,10 @@ AuthorizationStrategy strategy = new GlobalMatrixAuthorizationStrategy()
 strategy.add(Jenkins.ADMINISTER, PermissionEntry.group('<%= group %>'))
 <%end%>
 
+<% @admin_users.each do |user|%>
+strategy.add(Jenkins.ADMINISTER, PermissionEntry.user('<%= user %>'))
+<%end%>
+
 instance.authorizationStrategy = strategy
 
 instance.save()

--- a/dist/profile/templates/jenkinscontroller/lockbox.groovy.erb
+++ b/dist/profile/templates/jenkinscontroller/lockbox.groovy.erb
@@ -53,6 +53,15 @@ AuthorizationStrategy strategy = new GlobalMatrixAuthorizationStrategy()
 }
 <%end%>
 
+<%if @authenticated_access %>
+[
+    Jenkins.READ,
+    Item.READ,
+].each { permission ->
+    strategy.add(permission, PermissionEntry.user('authenticated'))
+}
+<%end%>
+
 <% @admin_ldap_groups.each do |group|%>
 strategy.add(Jenkins.ADMINISTER, PermissionEntry.group('<%= group %>'))
 <%end%>

--- a/dist/profile/templates/jenkinscontroller/lockbox.groovy.erb
+++ b/dist/profile/templates/jenkinscontroller/lockbox.groovy.erb
@@ -44,23 +44,18 @@ if (instance.securityRealm == SecurityRealm.NO_AUTHENTICATION) {
  */
 AuthorizationStrategy strategy = new GlobalMatrixAuthorizationStrategy()
 
-<%if @anonymous_access %>
-[
-    Jenkins.READ,
-    Item.READ,
-].each { permission ->
-    strategy.add(permission, PermissionEntry.user('anonymous'))
-}
-<%end%>
 
-<%if @authenticated_access %>
 [
     Jenkins.READ,
     Item.READ,
 ].each { permission ->
-    strategy.add(permission, PermissionEntry.user('authenticated'))
+<%- if @anonymous_access -%>
+    strategy.add(permission, PermissionEntry.user('anonymous'))
+<%- end -%>
+<%- if @authenticated_access -%>
+    strategy.add(permission, PermissionEntry.group('authenticated'))
+<%- end -%>
 }
-<%end%>
 
 <% @admin_ldap_groups.each do |group|%>
 strategy.add(Jenkins.ADMINISTER, PermissionEntry.group('<%= group %>'))

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -11,7 +11,6 @@ datadog_agent::apm_non_local_traffic: true # Allow jenkins container to contact 
 datadog_agent::agent_extra_options:
   bind_host: "0.0.0.0" # All hosts interfaces to allow container access
 profile::jenkinscontroller::anonymous_access: true
-profile::jenkinscontroller::authenticated_access: true
 profile::jenkinscontroller::admin_ldap_groups:
   - admins
   - jenkins-admins

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -11,6 +11,7 @@ datadog_agent::apm_non_local_traffic: true # Allow jenkins container to contact 
 datadog_agent::agent_extra_options:
   bind_host: "0.0.0.0" # All hosts interfaces to allow container access
 profile::jenkinscontroller::anonymous_access: true
+profile::jenkinscontroller::authenticated_access: true
 profile::jenkinscontroller::admin_ldap_groups:
   - admins
   - jenkins-admins

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -25,7 +25,6 @@ docker::log_opt::max-file: 2
 datadog_agent::host: "controller.trusted.ci.jenkins.io"
 profile::jenkinscontroller::ci_fqdn: "trusted.ci.jenkins.io"
 profile::jenkinscontroller::ci_resource_domain: 'assets.trusted.ci.jenkins.io'
-profile::jenkinscontroller::anonymous_access: false
 profile::jenkinscontroller::admin_ldap_groups:
   - admins
   - trusted-admins

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -35,9 +35,12 @@ profile::jenkinscontroller::additional_fqdns:
   foo.localhost:
     isalias: true
   legacy.localhost: null
-profile::jenkinscontroller::groovy_init_enabled: false
 profile::jenkinscontroller::memory_limit: '14g'
 profile::jenkinscontroller::authenticated_access: true
+profile::jenkinscontroller::groovy_init_enabled: true
+profile::jenkinscontroller::groovy_d_lock_down_jenkins: present
+profile::jenkinscontroller::admin_users:
+  - vagrantadmin
 profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: SuperSecretThatShouldBeEncryptedInProduction
@@ -61,8 +64,10 @@ profile::jenkinscontroller::jcasc:
           local:
             allowsSignup: false
             users:
-              - id: "admin"
-                password: "butler"
+              - id: vagrantadmin
+                password: butler
+              - id: developer
+                password: butler
   jenkins_global:
     location: http://127.0.0.1:8080
     resourceRootUrl: http://localhost:8080

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -37,6 +37,7 @@ profile::jenkinscontroller::additional_fqdns:
   legacy.localhost: null
 profile::jenkinscontroller::groovy_init_enabled: false
 profile::jenkinscontroller::memory_limit: '14g'
+profile::jenkinscontroller::authenticated_access: true
 profile::jenkinscontroller::jcasc:
   enabled: true
   reload_token: SuperSecretThatShouldBeEncryptedInProduction
@@ -54,6 +55,14 @@ profile::jenkinscontroller::jcasc:
         # but hierdata is behaving weirdly (bug in YAML parser?)
         defaultDisplayUrlProvider:
           providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
+      # Allow to check authenticated_access in http://localhost:8080/manage/configureSecurity/
+      jenkins:
+        securityRealm:
+          local:
+            allowsSignup: false
+            users:
+              - id: "admin"
+                password: "butler"
   jenkins_global:
     location: http://127.0.0.1:8080
     resourceRootUrl: http://localhost:8080


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4971#issuecomment-3812361021

This PR introduces, in the profile `jenkinscontroller`, a new hieradata attribute `authenticated_access` which sets up READ access (Overall and Job) for **any** authenticated user.

- Initial commit is a cherry pick of https://github.com/jenkins-infra/jenkins-infra/pull/4447 with no changes except conflict resolution in Vagrant: https://github.com/jenkins-infra/jenkins-infra/pull/4651/changes/1f2d3312608119954471789c3db08f39ed0b76a1 
- Ensure we can fully test any permission setup on Vagrant:
  - Set up the default list of LDAP admin groups to "empty" (https://github.com/jenkins-infra/jenkins-infra/pull/4651/changes/d813c42a8cc1bbfde109bc126a5cfb63ebdae168). Both ci.jenkins.io and trusted.ci.jenkins.io overrides it with their own list and cert.ci.jenkins.io does have Groovy scripts enabled.
    - Avoids a "red" line in the Vagrant authorization Matrix with "group not found"
  - Allow to define a list of users to be granted admin. permissions instead of groups. Only used on Vagrant. (https://github.com/jenkins-infra/jenkins-infra/pull/4651/changes/d813c42a8cc1bbfde109bc126a5cfb63ebdae168)
    - Includes renaming the local user `admin` to `vagrantadmin` to avoid user/group confusion
  - Adds a `developer` local user in Vagrant to test the "authenticated user but not admin" case
- Update the lockbox groovy script (https://github.com/jenkins-infra/jenkins-infra/pull/4651/changes/31499e98ae0b16c4e6163460f07c78c1f71e5d74) with:
  - A fix to use `group` instead of `user` for authenticated users
  - A nitpick to factorize the setup between anonymous and authenticated users. Avoids duplication of the permissions list.
- Ensure we don't enable this new feature yet (https://github.com/jenkins-infra/jenkins-infra/pull/4651/changes/394268762193d6deae80c37feee5beeb37b9d4a5):
  - Remove the `profile::jenkinscontroller::authenticated_access` from ci.jenkins.io (fall back to the default `false` value)
  - Remove the `profile::jenkinscontroller::anonymous_access` from trusted.ci.jenkins.io (it's already the default `false` value and we'll remove this soon)


----

Tests:

- Local unit tests + CI checks
- Vagrant local setup with the code here:

<img width="1687" height="725" alt="Capture d’écran 2026-01-28 à 17 23 13" src="https://github.com/user-attachments/assets/2b2f3d17-cb69-46e0-ac03-f3618716d67d" />

- Will deploy this step by step (need to disable puppet agent on each controller before merging, and then use no-op)