### PR TITLE
fix(jenkinscontroller/groovy/lockbox) do not generate any groovy permission closure when both anonymous and authenticated access are disabled

### DIFF
--- a/dist/profile/templates/jenkinscontroller/lockbox.groovy.erb
+++ b/dist/profile/templates/jenkinscontroller/lockbox.groovy.erb
@@ -44,26 +44,27 @@ if (instance.securityRealm == SecurityRealm.NO_AUTHENTICATION) {
  */
 AuthorizationStrategy strategy = new GlobalMatrixAuthorizationStrategy()
 
-
+<%- if @anonymous_access || @authenticated_access -%>
 [
     Jenkins.READ,
     Item.READ,
 ].each { permission ->
-<%- if @anonymous_access -%>
+    <%- if @anonymous_access -%>
     strategy.add(permission, PermissionEntry.user('anonymous'))
-<%- end -%>
-<%- if @authenticated_access -%>
+    <%- end -%>
+    <%- if @authenticated_access -%>
     strategy.add(permission, PermissionEntry.group('authenticated'))
-<%- end -%>
+    <%- end -%>
 }
+<%- end -%>
 
-<% @admin_ldap_groups.each do |group|%>
+<%- @admin_ldap_groups.each do |group| -%>
 strategy.add(Jenkins.ADMINISTER, PermissionEntry.group('<%= group %>'))
-<%end%>
+<%- end -%>
 
-<% @admin_users.each do |user|%>
+<%- @admin_users.each do |user| -%>
 strategy.add(Jenkins.ADMINISTER, PermissionEntry.user('<%= user %>'))
-<%end%>
+<%- end -%>
 
 instance.authorizationStrategy = strategy
 


### PR DESCRIPTION
Amends #4651 (fixup as it was not deployed).

This PR makes sure no invalid Groovy code is set in the `locakbox` groovy init script in the `jenkinscontroller` profile.
It's the case for trusted.ci.jenkins.io which has both anonymous and authenticated access disabled, which is a bug in the template I wrote in #4651.

Ref. https://github.com/jenkins-infra/jenkins-infra/pull/4651/changes#r2737763003 for details.


----


Tests:

- Unit tests locally
- Local Vagrant unchanged since #4651
- Tried on trusted.ci with a valid change now:

```diff
--- /var/lib/jenkins/init.groovy.d/lock-down-jenkins.groovy     2022-02-14 19:09:35.635848096 +0000
+++ /tmp/puppet-file20260128-821973-1nl725o     2026-01-28 17:36:09.286755800 +0000
@@ -45,13 +45,11 @@
 AuthorizationStrategy strategy = new GlobalMatrixAuthorizationStrategy()
 
 
-
-
 strategy.add(Jenkins.ADMINISTER, PermissionEntry.group('admins'))
-
 strategy.add(Jenkins.ADMINISTER, PermissionEntry.group('trusted-admins'))
 
 
 instance.authorizationStrategy = strategy
 
 instance.save()
+
```