### PR TITLE
chore(updatecli): add `containerAgentsNonSpotVolume` source and target

### DIFF
--- a/updatecli/updatecli.d/ci-jenkins-io.yaml
+++ b/updatecli/updatecli.d/ci-jenkins-io.yaml
@@ -24,6 +24,11 @@ sources:
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: .aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio\-agents\-2.agents_namespaces.jenkins\-agents.maven_cache_pvc
+  containerAgentsNonSpotVolume:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: .aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio\-agents\-2.agents_namespaces.jenkins\-agents\-nonspot.maven_cache_pvc
   containerAgentsBOMVolume:
     kind: json
     spec:
@@ -48,6 +53,15 @@ targets:
       file: hieradata/clients/aws.ci.jenkins.io.yaml
       engine: yamlpath
       key: $.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName
+    scmid: default
+  setContainerAgentsNonSpotVolume:
+    name: Set the PVC name for the Maven Cache in jenkins-agents-nonspot container agents
+    sourceid: containerAgentsNonSpotVolume
+    kind: yaml
+    spec:
+      file: hieradata/clients/aws.ci.jenkins.io.yaml
+      engine: yamlpath
+      key: $.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2-nonspot'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName
     scmid: default
   setContainerAgentsBOMVolume:
     name: Set the PVC name for the Maven Cache in jenkins-agents-bom container agents


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4906#issuecomment-3854617332

#### Testing done

`updatecli diff --config ./updatecli/updatecli.d/ci-jenkins-io.yaml --values ./updatecli/values.yaml`

<details>

```


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/ci-jenkins-io.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


################################################
# UPDATE CI.JENKINS.IO HIERADATA CONFIGURATION #
################################################

Pipeline ID	: a0bdb0f80b5d22171a756be0c31ba0d8bba7c1ba1dbacdbda919b75cff9f074d
Dry Run		: enabled

source: containerAgentsVolume
-----------------------------

WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.
✔ value "ci-jenkins-io-maven-cache", found in file "https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json", for key ".aws\\.ci\\.jenkins\\.io.agents_kubernetes_clusters.cijenkinsio\\-agents\\-2.agents_namespaces.jenkins\\-agents.maven_cache_pvc"
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

source: artifactManagerBucketName
---------------------------------

WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.
✔ value "aws-ci-jenkins-io-artifacts", found in file "https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json", for key ".aws\\.ci\\.jenkins\\.io.artifacts_manager.s3_bucket_name"
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

source: containerAgentsBOMVolume
--------------------------------

WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.
✔ value "ci-jenkins-io-maven-cache", found in file "https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json", for key ".aws\\.ci\\.jenkins\\.io.agents_kubernetes_clusters.cijenkinsio\\-agents\\-2.agents_namespaces.jenkins\\-agents\\-bom.maven_cache_pvc"
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

source: containerAgentsNonSpotVolume
------------------------------------

WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.
✔ value "ci-jenkins-io-maven-cache", found in file "https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json", for key ".aws\\.ci\\.jenkins\\.io.agents_kubernetes_clusters.cijenkinsio\\-agents\\-2.agents_namespaces.jenkins\\-agents\\-nonspot.maven_cache_pvc"
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

target: setContainerAgentsVolume
--------------------------------

Repository	: github.com/jenkins-infra/jenkins-infra@production

✔ - no change detected:
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

target: setArtifactManagerBucketName
------------------------------------

Repository	: github.com/jenkins-infra/jenkins-infra@production

✔ - no change detected:
	* key "$.profile::jenkinscontroller::jcasc.artifacts_manager.storage_name" already set to "aws-ci-jenkins-io-artifacts", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

target: setContainerAgentsBOMVolume
-----------------------------------

Repository	: github.com/jenkins-infra/jenkins-infra@production

✔ - no change detected:
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2-bom'].agent_definitions[?(@.name == 'jnlp-maven-bom')].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

target: setContainerAgentsNonSpotVolume
---------------------------------------

Repository	: github.com/jenkins-infra/jenkins-infra@production

✔ - no change detected:
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2-nonspot'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2-nonspot'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2-nonspot'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.


ACTIONS
========

---
Pipeline Name	: Update ci.jenkins.io hieradata configuration
Pipeline ID	: a0bdb0f80b5d22171a756be0c31ba0d8bba7c1ba1dbacdbda919b75cff9f074d
Dry run		: true
Repository	: github.com/jenkins-infra/jenkins-infra@production
Action		: Update ci.jenkins.io hieradata configuration
---

No follow up action needed

=============================

SUMMARY:

✔ Update ci.jenkins.io hieradata configuration:
	Source:
		✔ [artifactManagerBucketName] 
		✔ [containerAgentsBOMVolume] 
		✔ [containerAgentsNonSpotVolume] 
		✔ [containerAgentsVolume] 
	Target:
		✔ [setArtifactManagerBucketName] Set the S3 Bucket name of the artifact-manager-s3
		      * Repository: https://github.com/jenkins-infra/jenkins-infra.git (branch: production)
		✔ [setContainerAgentsBOMVolume] Set the PVC name for the Maven Cache in jenkins-agents-bom container agents
		      * Repository: https://github.com/jenkins-infra/jenkins-infra.git (branch: production)
		✔ [setContainerAgentsNonSpotVolume] Set the PVC name for the Maven Cache in jenkins-agents-nonspot container agents
		      * Repository: https://github.com/jenkins-infra/jenkins-infra.git (branch: production)
		✔ [setContainerAgentsVolume] Set the PVC name for the Maven Cache in jenkins-agents container agents
		      * Repository: https://github.com/jenkins-infra/jenkins-infra.git (branch: production)


Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	0
  * Succeeded:	1
  * Total:	1


```

</details>