### PR TITLE
chore(updatecli/ci-jenkins-io): updated source keys

### DIFF
--- a/updatecli/updatecli.d/ci-jenkins-io.yaml
+++ b/updatecli/updatecli.d/ci-jenkins-io.yaml
@@ -24,13 +24,13 @@ sources:
     kind: json
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
-      key: .aws\.ci\.jenkins\.io.cijenkinsio-agents-2.maven_cache_pvcs.jenkins-agents-bom
+      key: .aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio\-agents\-2.agents_namespaces.jenkins\-agents\-bom.maven_cache_pvc
 
   containerAgentsVolume:
     kind: json
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
-      key: .aws\.ci\.jenkins\.io.cijenkinsio-agents-2.maven_cache_pvcs.jenkins-agents
+      key: .aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio\-agents\-2.agents_namespaces.jenkins\-agents.maven_cache_pvc
 
 targets:
   setArtifactManagerBucketName:
@@ -52,7 +52,7 @@ targets:
       key: $.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2-bom'].agent_definitions[?(@.name == 'jnlp-maven-bom')].additionalPVCs[?(@.mountPath == '/cache')].claimName
     scmid: default
   setContainerAgentsVolume:
-    name: Set the PVC name for the Maven Cache in jenkins-agents-bom container agents
+    name: Set the PVC name for the Maven Cache in jenkins-agents container agents
     sourceid: containerAgentsVolume
     kind: yaml
     spec:

--- a/updatecli/updatecli.d/ci-jenkins-io.yaml
+++ b/updatecli/updatecli.d/ci-jenkins-io.yaml
@@ -68,3 +68,5 @@ actions:
       labels:
         - enhancement
         - ci.jenkins.io
+        - artifact-manager-bucket-name
+        - container-agents-pvc

--- a/updatecli/updatecli.d/ci-jenkins-io.yaml
+++ b/updatecli/updatecli.d/ci-jenkins-io.yaml
@@ -19,18 +19,16 @@ sources:
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: .aws\.ci\.jenkins\.io.artifacts_manager.s3_bucket_name
-
-  containerAgentsBOMVolume:
-    kind: json
-    spec:
-      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
-      key: .aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio\-agents\-2.agents_namespaces.jenkins\-agents\-bom.maven_cache_pvc
-
   containerAgentsVolume:
     kind: json
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: .aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio\-agents\-2.agents_namespaces.jenkins\-agents.maven_cache_pvc
+  containerAgentsBOMVolume:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: .aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio\-agents\-2.agents_namespaces.jenkins\-agents\-bom.maven_cache_pvc
 
 targets:
   setArtifactManagerBucketName:
@@ -42,15 +40,6 @@ targets:
       engine: yamlpath
       key: $.profile::jenkinscontroller::jcasc.artifacts_manager.storage_name
     scmid: default
-  setContainerAgentsBOMVolume:
-    name: Set the PVC name for the Maven Cache in jenkins-agents-bom container agents
-    sourceid: containerAgentsBOMVolume
-    kind: yaml
-    spec:
-      file: hieradata/clients/aws.ci.jenkins.io.yaml
-      engine: yamlpath
-      key: $.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2-bom'].agent_definitions[?(@.name == 'jnlp-maven-bom')].additionalPVCs[?(@.mountPath == '/cache')].claimName
-    scmid: default
   setContainerAgentsVolume:
     name: Set the PVC name for the Maven Cache in jenkins-agents container agents
     sourceid: containerAgentsVolume
@@ -59,6 +48,15 @@ targets:
       file: hieradata/clients/aws.ci.jenkins.io.yaml
       engine: yamlpath
       key: $.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName
+    scmid: default
+  setContainerAgentsBOMVolume:
+    name: Set the PVC name for the Maven Cache in jenkins-agents-bom container agents
+    sourceid: containerAgentsBOMVolume
+    kind: yaml
+    spec:
+      file: hieradata/clients/aws.ci.jenkins.io.yaml
+      engine: yamlpath
+      key: $.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2-bom'].agent_definitions[?(@.name == 'jnlp-maven-bom')].additionalPVCs[?(@.mountPath == '/cache')].claimName
     scmid: default
 
 actions:


### PR DESCRIPTION
This change fixes existing manifest sources and target name (680100f808315bfa67b65f98726545492df491e3), reorders them and adds labels.

Extracted from:
- #4666 

#### Testing done

`updatecli diff --config ./updatecli/updatecli.d/ci-jenkins-io.yaml --values ./updatecli/values.yaml`

<details>

```


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/ci-jenkins-io.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


################################################
# UPDATE CI.JENKINS.IO HIERADATA CONFIGURATION #
################################################

Pipeline ID	: a0bdb0f80b5d22171a756be0c31ba0d8bba7c1ba1dbacdbda919b75cff9f074d
Dry Run		: enabled

source: containerAgentsVolume
-----------------------------

WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.
✔ value "ci-jenkins-io-maven-cache", found in file "https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json", for key ".aws\\.ci\\.jenkins\\.io.agents_kubernetes_clusters.cijenkinsio\\-agents\\-2.agents_namespaces.jenkins\\-agents.maven_cache_pvc"
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

source: containerAgentsBOMVolume
--------------------------------

WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.
✔ value "ci-jenkins-io-maven-cache", found in file "https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json", for key ".aws\\.ci\\.jenkins\\.io.agents_kubernetes_clusters.cijenkinsio\\-agents\\-2.agents_namespaces.jenkins\\-agents\\-bom.maven_cache_pvc"
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

source: artifactManagerBucketName
---------------------------------

WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.
✔ value "aws-ci-jenkins-io-artifacts", found in file "https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json", for key ".aws\\.ci\\.jenkins\\.io.artifacts_manager.s3_bucket_name"
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

target: setArtifactManagerBucketName
------------------------------------

Repository	: github.com/jenkins-infra/jenkins-infra@production

✔ - no change detected:
	* key "$.profile::jenkinscontroller::jcasc.artifacts_manager.storage_name" already set to "aws-ci-jenkins-io-artifacts", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

target: setContainerAgentsVolume
--------------------------------

Repository	: github.com/jenkins-infra/jenkins-infra@production

✔ - no change detected:
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2'].agent_definitions[*].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.

target: setContainerAgentsBOMVolume
-----------------------------------

Repository	: github.com/jenkins-infra/jenkins-infra@production

✔ - no change detected:
	* key "$.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes['ci.jenkins.io-agents-2-bom'].agent_definitions[?(@.name == 'jnlp-maven-bom')].additionalPVCs[?(@.mountPath == '/cache')].claimName" already set to "ci-jenkins-io-maven-cache", from file "hieradata/clients/aws.ci.jenkins.io.yaml" (doc 0)
WARNING: Engine "dasel/v1" is deprecated and will be removed in a future updatecli version. Please use "dasel/v2" instead.


ACTIONS
========

---
Pipeline Name	: Update ci.jenkins.io hieradata configuration
Pipeline ID	: a0bdb0f80b5d22171a756be0c31ba0d8bba7c1ba1dbacdbda919b75cff9f074d
Dry run		: true
Repository	: github.com/jenkins-infra/jenkins-infra@production
Action		: Update ci.jenkins.io hieradata configuration
---

No follow up action needed

=============================

SUMMARY:

✔ Update ci.jenkins.io hieradata configuration:
	Source:
		✔ [artifactManagerBucketName] 
		✔ [containerAgentsBOMVolume] 
		✔ [containerAgentsVolume] 
	Target:
		✔ [setArtifactManagerBucketName] Set the S3 Bucket name of the artifact-manager-s3
		      * Repository: https://github.com/jenkins-infra/jenkins-infra.git (branch: production)
		✔ [setContainerAgentsBOMVolume] Set the PVC name for the Maven Cache in jenkins-agents-bom container agents
		      * Repository: https://github.com/jenkins-infra/jenkins-infra.git (branch: production)
		✔ [setContainerAgentsVolume] Set the PVC name for the Maven Cache in jenkins-agents container agents
		      * Repository: https://github.com/jenkins-infra/jenkins-infra.git (branch: production)


Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	0
  * Succeeded:	1
  * Total:	1


```

</details>