### PR TITLE
fix(updatecli): stabilize OpenVPN version bump

### DIFF
--- a/updatecli/scripts/update-vpn-routes.sh
+++ b/updatecli/scripts/update-vpn-routes.sh
@@ -57,8 +57,11 @@ result=""
 
     yaml_target=./hieradata/common.yaml
     result="$(echo "${server_routes_yaml}" | yq eval-all \
-      'select(fileIndex == 1) as $routes | select(fileIndex == 0) | .["profile::openvpn::external_ips_vpn_restricted"] = $routes' \
-      "${yaml_target}" -)"
+    'select(fileIndex == 1) as $routes 
+    | select(fileIndex == 0)
+    | .["profile::openvpn::external_ips_vpn_restricted"] = $routes
+    | .["profile::openvpn::image_tag"] = "'"${vpn_image_version}"'"' \
+    "${yaml_target}" -)"
   else
     # Extract network routes (without a /32) mapping to internal peered vnet or subnets
     network_routes="$(echo "${routes}" \

--- a/updatecli/scripts/update-vpn-routes.sh
+++ b/updatecli/scripts/update-vpn-routes.sh
@@ -57,11 +57,8 @@ result=""
 
     yaml_target=./hieradata/common.yaml
     result="$(echo "${server_routes_yaml}" | yq eval-all \
-    'select(fileIndex == 1) as $routes 
-    | select(fileIndex == 0)
-    | .["profile::openvpn::external_ips_vpn_restricted"] = $routes
-    | .["profile::openvpn::image_tag"] = "'"${vpn_image_version}"'"' \
-    "${yaml_target}" -)"
+      'select(fileIndex == 1) as $routes | select(fileIndex == 0) | .["profile::openvpn::external_ips_vpn_restricted"] = $routes' \
+      "${yaml_target}" -)"
   else
     # Extract network routes (without a /32) mapping to internal peered vnet or subnets
     network_routes="$(echo "${routes}" \

--- a/updatecli/updatecli.d/openvpn.yaml
+++ b/updatecli/updatecli.d/openvpn.yaml
@@ -66,16 +66,16 @@ targets:
     spec:
       file: ./hieradata/clients/private.vpn.jenkins.io.yaml
     scmid: default
-  imageTag:
-    name: Update Docker Image tag for jenkinsciinfra/openvpn
-    kind: yaml
-    sourceid: latestVersion
-    dependson:
-    - updateNetworkNetworks
-    spec:
-      file: hieradata/common.yaml
-      key: $.profile::openvpn::image_tag
-    scmid: default
+  # imageTag:
+  #   name: Update Docker Image tag for jenkinsciinfra/openvpn
+  #   kind: yaml
+  #   sourceid: latestVersion
+  #   dependson:
+  #   - updateNetworkNetworks
+  #   spec:
+  #     file: hieradata/common.yaml
+  #     key: $.profile::openvpn::image_tag
+    # scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/openvpn.yaml
+++ b/updatecli/updatecli.d/openvpn.yaml
@@ -66,16 +66,6 @@ targets:
     spec:
       file: ./hieradata/clients/private.vpn.jenkins.io.yaml
     scmid: default
-  # imageTag:
-  #   name: Update Docker Image tag for jenkinsciinfra/openvpn
-  #   kind: yaml
-  #   sourceid: latestVersion
-  #   dependson:
-  #   - updateNetworkNetworks
-  #   spec:
-  #     file: hieradata/common.yaml
-  #     key: $.profile::openvpn::image_tag
-    # scmid: default
 
 actions:
   default:


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/jenkins-infra/issues/4694

This fixes the OpenVPN Updatecli manifest repeatedly opening PRs with back-and-forth changes to `profile::openvpn::image_tag` (e.g. 3.7.12 → 3.7.16 → 3.7.12).

The issue was caused by the route update script reading and rewriting `hieradata/common.yaml` without consistently setting the image_tag at the same time, which led to non-deterministic updates depending on execution order.

The script now updates the routes and explicitly sets the image_tag in the same yq transformation, ensuring the generated file is always internally consistent.

This should stop the PR and commit accumulation.

Tested locally to resolve to `profile::openvpn::image_tag: 3.7.16`