### PR TITLE
fix(`updatecli`): make openvpn route generation atomic to prevent `image_tag` reverting

### DIFF
--- a/updatecli/scripts/update-vpn-routes.sh
+++ b/updatecli/scripts/update-vpn-routes.sh
@@ -57,8 +57,11 @@ result=""
 
     yaml_target=./hieradata/common.yaml
     result="$(echo "${server_routes_yaml}" | yq eval-all \
-      'select(fileIndex == 1) as $routes | select(fileIndex == 0) | .["profile::openvpn::external_ips_vpn_restricted"] = $routes' \
-      "${yaml_target}" -)"
+    'select(fileIndex == 1) as $routes 
+    | select(fileIndex == 0)
+    | .["profile::openvpn::external_ips_vpn_restricted"] = $routes
+    | .["profile::openvpn::image_tag"] = "'"${vpn_image_version}"'"' \
+    "${yaml_target}" -)"
   else
     # Extract network routes (without a /32) mapping to internal peered vnet or subnets
     network_routes="$(echo "${routes}" \


### PR DESCRIPTION
Related to 

- https://github.com/jenkins-infra/jenkins-infra/issues/4694

The OpenVPN updatecli pipeline was still reverting `profile::openvpn::image_tag` to a stale value (e.g. 3.7.16 → 3.7.12) during production runs.

Root cause: updateNetworkRoutes rewrites the entire common.yaml file. Since the script was not explicitly setting image_tag, the rewrite could reintroduce the version that existed in the checked-in file instead of the latest release detected by updatecli.

This change updates `update-vpn-routes.sh` to also set `profile::openvpn::image_tag` during the same yq operation that updates external routes.

By generating both values together, the file is updated atomically and the version can no longer flip back due to execution order.

This makes the pipeline deterministic and removes the stale tag issue.



Testing done locally, the script injects the correct tag

`bash ./updatecli/scripts/update-vpn-routes.sh 3.7.16 servers | grep openvpn::image_tag`

`profile::openvpn::image_tag: 3.7.16`
