### PR TITLE
feat(trusted.ci.jenkins.io, cert.ci.jenkins.io and aws.ci.jenkins.io)! Switch to JDK25

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -22,7 +22,7 @@ class profile::jenkinscontroller (
   Hash $additional_fqdns                       = {},
   String $ci_resource_domain                   = '',
   String $docker_image                         = 'jenkins/jenkins',
-  String $docker_tag                           = 'lts-jdk21',
+  String $docker_tag                           = 'lts-jdk25',
   String $docker_container_name                = 'jenkins',
   Boolean $letsencrypt                         = true,
   Optional[Array] $plugins                     = undef,

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -24,7 +24,7 @@ profile::jenkinscontroller::additional_fqdns:
   ci.jenkins-ci.org: null
 profile::jenkinscontroller::letsencrypt: true
 profile::jenkinscontroller::docker_image: 'jenkins/jenkins'
-profile::jenkinscontroller::docker_tag: 'lts-jdk21'
+profile::jenkinscontroller::docker_tag: 'lts-jdk25'
 profile::jenkinscontroller::groovy_init_enabled: true
 profile::jenkinscontroller::block_remote_access_api: true
 profile::jenkinscontroller::groovy_d_lock_down_jenkins: 'present'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -153,7 +153,7 @@ datadog_agent::integrations:
 docker_hub_key: |
   ENC[PKCS7,MIICCwYJKoZIhvcNAQcDoIIB/DCCAfgCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAOkIizRCPVrwnvnwibEmMCIfXFsYJQCZKqIVujP0N8IbVhVeieb41055u/MFYSmbqBXb0ummeMiZ7y9NAymAROfz32wY8IM/d005oBMp8JCbSbEGBEApDY22SL4osIk7JNJe2Ru0mhVqIP0sm412frklI1acP3575GvfCvU+JY8xszi9wT28WKT0aIO1nj8WwEET6c0xw4s3XhE99EuakWtvlqhcS+ViXc7LT/iMdWZDeObw12K+B3usOzJsX/u7eG6jr1AR/UKwIjS71qPhO59MKayAs8RoD/L5BtTWIavLSvrbIx2qn5yjQn/U1c6FSdMGAyL7SjPTYEflmvsGvkDCBzQYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQ7Foo3dyKQiNVrsMCbnYXO4CBoMjaW4RIBAkNA8Mv/ngH1vzf/dImaPkVpWVomYJ0CSktOjLt6qSPAHLIcL2pU0FAtNF/Css0kll7uhV3oUtwoIsUbz21CYVZPJs88HsZChNl6mE5Awg3MooX3OLcQHn4293rRFZOaRNGL+iA35m0fT1LUWvP/sYjrdOABVmRdFQ+J/tCBsECaqh+CMP4FztPIS8+0ZeNBbC7xxs2MvKVF18=]
 profile::jenkinscontroller::docker_image: jenkins/jenkins
-profile::jenkinscontroller::docker_tag: 2.541.2-jdk21
+profile::jenkinscontroller::docker_tag: 2.541.2-jdk25
 # WARNING: this list is not deep merged by hieradata (will be overwritten!)
 profile::jenkinscontroller::plugins:
   - workflow-aggregator

--- a/updatecli/updatecli.d/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/jenkins-lts.yaml
@@ -20,7 +20,7 @@ sources:
     spec:
       release: stable
     transformers:
-      - addsuffix: "-jdk21"
+      - addsuffix: "-jdk25"
 
 conditions:
   defaultCidockerimage:


### PR DESCRIPTION
Related to:

- https://github.com/jenkins-infra/helpdesk/issues/4941

migrate to jdk25 as runtime for controllers trusted.ci.jenkins.io, cert.ci.jenkins.io and aws.ci.jenkins.io