### PR TITLE
chore: make `agent_definitions` a subsection of `azure_vm_agents.clouds`

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-azurevm.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-azurevm.yaml.erb
@@ -10,7 +10,7 @@ jenkins:
       resourceGroupReferenceType: "existing"
       maxVirtualMachinesLimit: <%= cloudsetup['maxInstances'] %>
       vmTemplates:
-    <%- @jcasc['cloud_agents']['azure_vm_agents']['agent_definitions'].each do |agent| -%>
+    <%- cloudsetup['agent_definitions'].each do |agent| -%>
       <%- $os = agent['os'] ? agent['os'] : 'ubuntu' -%>
       - agentWorkspace: "<%= agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir'] %>"
       <%- if $os == 'windows' -%>

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -71,272 +71,272 @@ profile::jenkinscontroller::jcasc:
           storageAccount: certcijenkinsioagents
           # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
           userInstanceIdentity: '/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/cert-ci-jenkins-io/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cert-ci-jenkins-io-agents'
-      agent_definitions:
-        ## Linux agent templates
-        - name: "ubuntu-22-amd64-maven-11"
-          description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          javaHome: "/opt/jdk-11"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - linux
-            - docker
-            - ubuntu
-            - ubuntu-amd64-maven-11
-            - ubuntu-22-amd64-maven-11
-            - maven-11
-            - jdk11
-          maxInstances: 10 # Quota of 80 vCPUs
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "ubuntu-22-amd64-maven-17"
-          description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - ubuntu-amd64-maven-17
-            - ubuntu-22-amd64-maven-17
-            - maven-17
-            - jdk17
-          javaHome: '/opt/jdk-17'
-          maxInstances: 10
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "ubuntu-22-amd64-maven-21"
-          description: "Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - ubuntu-amd64-maven-21
-            - ubuntu-22-amd64-maven-21
-            - maven-21
-            - jdk21
-          javaHome: '/opt/jdk-21'
-          maxInstances: 10
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "ubuntu-22-amd64-maven-25"
-          description: "Ubuntu 22.04 LTS x86_64 with JDK25 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - ubuntu-amd64-maven-25
-            - ubuntu-22-amd64-maven-25
-            - maven-25
-            - jdk25
-          javaHome: '/opt/jdk-25'
-          maxInstances: 10
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        ## Windows agent templates
-        - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2019 Maven-11"
-          imageDefinition: jenkins-agent-windows-2019-amd64
-          os: "windows"
-          os_version: "2019"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - win-2019
-            - win-2019-amd64-maven-11
-          javaHome: 'C:/tools/jdk-11'
-          maxInstances: 10 # Quota of 80 vCPUs
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "win-2019-amd64-maven-17" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2019 Maven-17"
-          imageDefinition: jenkins-agent-windows-2019-amd64
-          os: "windows"
-          os_version: "2019"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - win-2019-amd64-maven-17
-          javaHome: 'C:/tools/jdk-17'
-          maxInstances: 10 # Quota of 80 vCPUs
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "win-2019-amd64-maven-21" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2019 Maven-21"
-          imageDefinition: jenkins-agent-windows-2019-amd64
-          os: "windows"
-          os_version: "2019"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - win-2019-amd64-maven-21
-          javaHome: 'C:/tools/jdk-21'
-          maxInstances: 10 # Quota of 80 vCPUs
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "win-2019-amd64-maven-25" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2019 Maven-25"
-          imageDefinition: jenkins-agent-windows-2019-amd64
-          os: "windows"
-          os_version: "2019"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - win-2019-amd64-maven-25
-          javaHome: 'C:/tools/jdk-25'
-          maxInstances: 10 # Quota of 80 vCPUs
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "win-2025-amd64-maven-8" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2025 Maven-8"
-          imageDefinition: jenkins-agent-windows-2025-amd64
-          os: "windows"
-          os_version: "2025"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - win-2025-amd64-maven-8
-            # Label(s) indicating default VM templates
-            - maven-8-windows
-          javaHome: 'C:/tools/jdk-8'
-          maxInstances: 10 # Quota of 80 vCPUs
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "win-2025-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2025 Maven-11"
-          imageDefinition: jenkins-agent-windows-2025-amd64
-          os: "windows"
-          os_version: "2025"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - win-2025-amd64-maven-11
-            # Label(s) indicating default VM templates
-            - maven-11-windows
-          javaHome: 'C:/tools/jdk-11'
-          maxInstances: 10 # Quota of 80 vCPUs
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "win-2025-amd64-maven-17" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2025 Maven-17"
-          imageDefinition: jenkins-agent-windows-2025-amd64
-          os: "windows"
-          os_version: "2025"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - win-2025-amd64-maven-17
-            # Label(s) indicating default VM templates
-            - maven-17-windows
-          javaHome: 'C:/tools/jdk-17'
-          maxInstances: 10 # Quota of 80 vCPUs
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "win-2025-amd64-maven-21" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2025 Maven-21"
-          imageDefinition: jenkins-agent-windows-2025-amd64
-          os: "windows"
-          os_version: "2025"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - win-2025-amd64-maven-21
-            # Label(s) indicating default VM templates
-            - maven-21-windows
-          javaHome: 'C:/tools/jdk-21'
-          maxInstances: 10 # Quota of 80 vCPUs
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
-        - name: "win-2025-amd64-maven-25" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2025 Maven-25"
-          imageDefinition: jenkins-agent-windows-2025-amd64
-          os: "windows"
-          os_version: "2025"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: false
-          architecture: amd64
-          labels:
-            - win-2025-amd64-maven-25
-            # Label(s) indicating default VM templates
-            - maven-25-windows
-            - docker-windows
-            # TODO: check if still used
-            - windows
-          javaHome: 'C:/tools/jdk-25'
-          maxInstances: 10 # Quota of 80 vCPUs
-          useAsMuchAsPossible: true
-          credentialsId: "azure-login"
-          usePrivateIP: true
+          agent_definitions:
+            ## Linux agent templates
+            - name: "ubuntu-22-amd64-maven-11"
+              description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "ssh"
+              javaHome: "/opt/jdk-11"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - linux
+                - docker
+                - ubuntu
+                - ubuntu-amd64-maven-11
+                - ubuntu-22-amd64-maven-11
+                - maven-11
+                - jdk11
+              maxInstances: 10 # Quota of 80 vCPUs
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "ubuntu-22-amd64-maven-17"
+              description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - ubuntu-amd64-maven-17
+                - ubuntu-22-amd64-maven-17
+                - maven-17
+                - jdk17
+              javaHome: '/opt/jdk-17'
+              maxInstances: 10
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "ubuntu-22-amd64-maven-21"
+              description: "Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - ubuntu-amd64-maven-21
+                - ubuntu-22-amd64-maven-21
+                - maven-21
+                - jdk21
+              javaHome: '/opt/jdk-21'
+              maxInstances: 10
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "ubuntu-22-amd64-maven-25"
+              description: "Ubuntu 22.04 LTS x86_64 with JDK25 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - ubuntu-amd64-maven-25
+                - ubuntu-22-amd64-maven-25
+                - maven-25
+                - jdk25
+              javaHome: '/opt/jdk-25'
+              maxInstances: 10
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            ## Windows agent templates
+            - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2019 Maven-11"
+              imageDefinition: jenkins-agent-windows-2019-amd64
+              os: "windows"
+              os_version: "2019"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - win-2019
+                - win-2019-amd64-maven-11
+              javaHome: 'C:/tools/jdk-11'
+              maxInstances: 10 # Quota of 80 vCPUs
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "win-2019-amd64-maven-17" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2019 Maven-17"
+              imageDefinition: jenkins-agent-windows-2019-amd64
+              os: "windows"
+              os_version: "2019"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - win-2019-amd64-maven-17
+              javaHome: 'C:/tools/jdk-17'
+              maxInstances: 10 # Quota of 80 vCPUs
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "win-2019-amd64-maven-21" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2019 Maven-21"
+              imageDefinition: jenkins-agent-windows-2019-amd64
+              os: "windows"
+              os_version: "2019"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - win-2019-amd64-maven-21
+              javaHome: 'C:/tools/jdk-21'
+              maxInstances: 10 # Quota of 80 vCPUs
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "win-2019-amd64-maven-25" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2019 Maven-25"
+              imageDefinition: jenkins-agent-windows-2019-amd64
+              os: "windows"
+              os_version: "2019"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - win-2019-amd64-maven-25
+              javaHome: 'C:/tools/jdk-25'
+              maxInstances: 10 # Quota of 80 vCPUs
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "win-2025-amd64-maven-8" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2025 Maven-8"
+              imageDefinition: jenkins-agent-windows-2025-amd64
+              os: "windows"
+              os_version: "2025"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - win-2025-amd64-maven-8
+                # Label(s) indicating default VM templates
+                - maven-8-windows
+              javaHome: 'C:/tools/jdk-8'
+              maxInstances: 10 # Quota of 80 vCPUs
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "win-2025-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2025 Maven-11"
+              imageDefinition: jenkins-agent-windows-2025-amd64
+              os: "windows"
+              os_version: "2025"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - win-2025-amd64-maven-11
+                # Label(s) indicating default VM templates
+                - maven-11-windows
+              javaHome: 'C:/tools/jdk-11'
+              maxInstances: 10 # Quota of 80 vCPUs
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "win-2025-amd64-maven-17" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2025 Maven-17"
+              imageDefinition: jenkins-agent-windows-2025-amd64
+              os: "windows"
+              os_version: "2025"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - win-2025-amd64-maven-17
+                # Label(s) indicating default VM templates
+                - maven-17-windows
+              javaHome: 'C:/tools/jdk-17'
+              maxInstances: 10 # Quota of 80 vCPUs
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "win-2025-amd64-maven-21" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2025 Maven-21"
+              imageDefinition: jenkins-agent-windows-2025-amd64
+              os: "windows"
+              os_version: "2025"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - win-2025-amd64-maven-21
+                # Label(s) indicating default VM templates
+                - maven-21-windows
+              javaHome: 'C:/tools/jdk-21'
+              maxInstances: 10 # Quota of 80 vCPUs
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
+            - name: "win-2025-amd64-maven-25" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2025 Maven-25"
+              imageDefinition: jenkins-agent-windows-2025-amd64
+              os: "windows"
+              os_version: "2025"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: false
+              architecture: amd64
+              labels:
+                - win-2025-amd64-maven-25
+                # Label(s) indicating default VM templates
+                - maven-25-windows
+                - docker-windows
+                # TODO: check if still used
+                - windows
+              javaHome: 'C:/tools/jdk-25'
+              maxInstances: 10 # Quota of 80 vCPUs
+              useAsMuchAsPossible: true
+              credentialsId: "azure-login"
+              usePrivateIP: true
 ## Ensure we override the default plugins to install defined from hieradata/common.yaml
 profile::jenkinscontroller::plugins:
   # System configuration

--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -100,293 +100,293 @@ profile::jenkinscontroller::jcasc:
           storageAccount: trustedcijenkinsioagents
           # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
           userInstanceIdentity: '/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/jenkinsinfra-trusted-ci-controller/providers/Microsoft.ManagedIdentity/userAssignedIdentities/trusted-ci-jenkins-io-agents'
-      agent_definitions:
-        - name: "ubuntu-22-amd64-maven-11"
-          description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          javaHome: "/opt/jdk-11"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - java
-            - linux
-            - docker
-            - ubuntu
-            - ubuntu-22
-            - ubuntu-amd64-maven-11
-            - ubuntu-22-amd64-maven-11
-            - maven-11
-            - jdk11
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "ubuntu-22-amd64-maven-17"
-          description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - ubuntu-amd64-maven-17
-            - ubuntu-22-amd64-maven-17
-            - maven-17
-            - jdk17
-          javaHome: '/opt/jdk-17'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "ubuntu-22-amd64-maven-21"
-          description: "Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - ubuntu-amd64-maven-21
-            - ubuntu-22-amd64-maven-21
-            - maven-21
-            - jdk21
-          javaHome: '/opt/jdk-21'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "ubuntu-22-arm64-maven-21"
-          description: "Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-arm64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8pds_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: arm64
-          labels:
-            - ubuntu-arm64-maven-21
-            - ubuntu-22-arm64-maven-21
-            - arm64docker # Same label as ci.jenkins.io docker arm64 agent template
-          javaHome: '/opt/jdk-21'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "ubuntu-22-amd64-maven-25"
-          description: "Ubuntu 22.04 LTS x86_64 with JDK25 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - ubuntu-amd64-maven-25
-            - ubuntu-22-amd64-maven-25
-            - maven-25
-            - jdk25
-          javaHome: '/opt/jdk-25'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2019 Maven-11"
-          imageDefinition: jenkins-agent-windows-2019-amd64
-          os: "windows"
-          os_version: "2019"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - win-2019
-            - windows-2019
-            - win-2019-amd64-maven-11
-            - maven-11-windows
-            # Labels indicating it is the default VM template for Windows & Docker, and Windows & Maven
-            - docker-windows
-            - maven-windows
-          javaHome: 'C:/tools/jdk-11'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "win-2019-amd64-maven-17"
-          description: "Windows 2019 Maven-17"
-          imageDefinition: jenkins-agent-windows-2019-amd64
-          os: "windows"
-          os_version: "2019"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - win-2019-amd64-maven-17
-            - maven-17-windows
-          javaHome: 'C:/tools/jdk-17'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "win-2019-amd64-maven-21"
-          description: "Windows 2019 Maven-21"
-          imageDefinition: jenkins-agent-windows-2019-amd64
-          os: "windows"
-          os_version: "2019"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - win-2019-amd64-maven-21
-            - maven-21-windows
-          javaHome: 'C:/tools/jdk-21'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "win-2019-amd64-maven-25"
-          description: "Windows 2019 Maven-25"
-          imageDefinition: jenkins-agent-windows-2019-amd64
-          os: "windows"
-          os_version: "2019"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - win-2019-amd64-maven-25
-            - maven-25-windows
-          javaHome: 'C:/tools/jdk-25'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "win-2022-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2022 Maven-11"
-          imageDefinition: jenkins-agent-windows-2022-amd64
-          os: "windows"
-          os_version: "2022"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - docker-windows-2022
-            - win-2022
-            - windows-2022
-            - win-2022-amd64-maven-11
-          javaHome: 'C:/tools/jdk-11'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "win-2022-amd64-maven-17"
-          description: "Windows 2022 Maven-17"
-          imageDefinition: jenkins-agent-windows-2022-amd64
-          os: "windows"
-          os_version: "2022"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - win-2022-amd64-maven-17
-          javaHome: 'C:/tools/jdk-17'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "win-2022-amd64-maven-21"
-          description: "Windows 2022 Maven-21"
-          imageDefinition: jenkins-agent-windows-2022-amd64
-          os: "windows"
-          os_version: "2022"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - win-2022-amd64-maven-21
-          javaHome: 'C:/tools/jdk-21'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "win-2022-amd64-maven-25"
-          description: "Windows 2022 Maven-25"
-          imageDefinition: jenkins-agent-windows-2022-amd64
-          os: "windows"
-          os_version: "2022"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - win-2022-amd64-maven-25
-          javaHome: 'C:/tools/jdk-25'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
-        - name: "win-2025-amd64-maven-25"
-          description: "Windows 2025 Maven-25"
-          imageDefinition: jenkins-agent-windows-2025-amd64
-          os: "windows"
-          os_version: "2025"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
-          ephemeralOSDisk: true
-          spot: true
-          architecture: amd64
-          labels:
-            - win-2025-amd64-maven-25
-            # Labels indicating it is the default VM template for Windows 2025 (but not windows)
-            - docker-windows-2025
-            - win-2025
-          javaHome: 'C:/tools/jdk-25'
-          maxInstances: 7
-          useAsMuchAsPossible: true
-          credentialsId: "azure-jenkins-user"
-          usePrivateIP: true
+          agent_definitions:
+            - name: "ubuntu-22-amd64-maven-11"
+              description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "ssh"
+              javaHome: "/opt/jdk-11"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - java
+                - linux
+                - docker
+                - ubuntu
+                - ubuntu-22
+                - ubuntu-amd64-maven-11
+                - ubuntu-22-amd64-maven-11
+                - maven-11
+                - jdk11
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "ubuntu-22-amd64-maven-17"
+              description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - ubuntu-amd64-maven-17
+                - ubuntu-22-amd64-maven-17
+                - maven-17
+                - jdk17
+              javaHome: '/opt/jdk-17'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "ubuntu-22-amd64-maven-21"
+              description: "Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - ubuntu-amd64-maven-21
+                - ubuntu-22-amd64-maven-21
+                - maven-21
+                - jdk21
+              javaHome: '/opt/jdk-21'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "ubuntu-22-arm64-maven-21"
+              description: "Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-arm64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8pds_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: arm64
+              labels:
+                - ubuntu-arm64-maven-21
+                - ubuntu-22-arm64-maven-21
+                - arm64docker # Same label as ci.jenkins.io docker arm64 agent template
+              javaHome: '/opt/jdk-21'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "ubuntu-22-amd64-maven-25"
+              description: "Ubuntu 22.04 LTS x86_64 with JDK25 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - ubuntu-amd64-maven-25
+                - ubuntu-22-amd64-maven-25
+                - maven-25
+                - jdk25
+              javaHome: '/opt/jdk-25'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2019 Maven-11"
+              imageDefinition: jenkins-agent-windows-2019-amd64
+              os: "windows"
+              os_version: "2019"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - win-2019
+                - windows-2019
+                - win-2019-amd64-maven-11
+                - maven-11-windows
+                # Labels indicating it is the default VM template for Windows & Docker, and Windows & Maven
+                - docker-windows
+                - maven-windows
+              javaHome: 'C:/tools/jdk-11'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "win-2019-amd64-maven-17"
+              description: "Windows 2019 Maven-17"
+              imageDefinition: jenkins-agent-windows-2019-amd64
+              os: "windows"
+              os_version: "2019"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - win-2019-amd64-maven-17
+                - maven-17-windows
+              javaHome: 'C:/tools/jdk-17'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "win-2019-amd64-maven-21"
+              description: "Windows 2019 Maven-21"
+              imageDefinition: jenkins-agent-windows-2019-amd64
+              os: "windows"
+              os_version: "2019"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - win-2019-amd64-maven-21
+                - maven-21-windows
+              javaHome: 'C:/tools/jdk-21'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "win-2019-amd64-maven-25"
+              description: "Windows 2019 Maven-25"
+              imageDefinition: jenkins-agent-windows-2019-amd64
+              os: "windows"
+              os_version: "2019"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - win-2019-amd64-maven-25
+                - maven-25-windows
+              javaHome: 'C:/tools/jdk-25'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "win-2022-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2022 Maven-11"
+              imageDefinition: jenkins-agent-windows-2022-amd64
+              os: "windows"
+              os_version: "2022"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - docker-windows-2022
+                - win-2022
+                - windows-2022
+                - win-2022-amd64-maven-11
+              javaHome: 'C:/tools/jdk-11'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "win-2022-amd64-maven-17"
+              description: "Windows 2022 Maven-17"
+              imageDefinition: jenkins-agent-windows-2022-amd64
+              os: "windows"
+              os_version: "2022"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - win-2022-amd64-maven-17
+              javaHome: 'C:/tools/jdk-17'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "win-2022-amd64-maven-21"
+              description: "Windows 2022 Maven-21"
+              imageDefinition: jenkins-agent-windows-2022-amd64
+              os: "windows"
+              os_version: "2022"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - win-2022-amd64-maven-21
+              javaHome: 'C:/tools/jdk-21'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "win-2022-amd64-maven-25"
+              description: "Windows 2022 Maven-25"
+              imageDefinition: jenkins-agent-windows-2022-amd64
+              os: "windows"
+              os_version: "2022"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - win-2022-amd64-maven-25
+              javaHome: 'C:/tools/jdk-25'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
+            - name: "win-2025-amd64-maven-25"
+              description: "Windows 2025 Maven-25"
+              imageDefinition: jenkins-agent-windows-2025-amd64
+              os: "windows"
+              os_version: "2025"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+              ephemeralOSDisk: true
+              spot: true
+              architecture: amd64
+              labels:
+                - win-2025-amd64-maven-25
+                # Labels indicating it is the default VM template for Windows 2025 (but not windows)
+                - docker-windows-2025
+                - win-2025
+              javaHome: 'C:/tools/jdk-25'
+              maxInstances: 7
+              useAsMuchAsPossible: true
+              credentialsId: "azure-jenkins-user"
+              usePrivateIP: true
 # These are plugins we need only in our trusted-ci environment
 profile::jenkinscontroller::plugins:
   - ansicolor

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -325,136 +325,136 @@ profile::jenkinscontroller::jcasc:
           storageAccount: SuperSecretEncryptedInProductionSecondary
           acpServerId: external
           userInstanceIdentity: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}'
-      agent_definitions:
-        - name: "ubuntu-22-inbound"
-          description: "Ubuntu 22.04 LTS"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "inbound"
-          location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
-          ephemeralOSDisk: true
-          architecture: amd64
-          labels:
-            - java
-            - docker
-            - linux-amd64
-          maxInstances: 50
-          useAsMuchAsPossible: true
-          credentialsId: "jenkinsvmagents-userpass"
-          usePrivateIP: true
-          spot: true
-        - name: "ubuntu-22-amd64-maven17"
-          description: "Ubuntu 22.04 LTS with JDK17 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "inbound"
-          location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
-          ephemeralOSDisk: true
-          architecture: amd64
-          labels:
-            - ubuntu-22-amd64-maven17
-          javaHome: /opt/jdk-17
-          maxInstances: 50
-          useAsMuchAsPossible: true
-          credentialsId: "jenkinsvmagents-userpass"
-          usePrivateIP: true
-          spot: true
-        - name: "ubuntu-22-amd64-maven21"
-          description: "Ubuntu 22.04 LTS with JDK21 set as default java CLI"
-          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "inbound"
-          location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
-          ephemeralOSDisk: true
-          architecture: amd64
-          labels:
-            - ubuntu-22-amd64-maven21
-          javaHome: /opt/jdk-21
-          maxInstances: 50
-          useAsMuchAsPossible: true
-          credentialsId: "jenkinsvmagents-userpass"
-          usePrivateIP: true
-          spot: true
-        - name: "ubuntu-22-arm64-ssh"
-          description: "Ubuntu 22.04 LTS ARM64"
-          imageDefinition: jenkins-agent-ubuntu-22.04-arm64
-          os: "ubuntu"
-          os_version: "22.04"
-          launcher: "ssh"
-          location: "East US 2"
-          instanceType: Standard_D4pds_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
-          ephemeralOSDisk: true
-          architecture: arm64
-          labels:
-            - arm64docker
-            - arm64linux
-          maxInstances: 50
-          useAsMuchAsPossible: true
-          credentialsId: "jenkinsvmagents-userpass"
-          usePrivateIP: true
-          javaHome: /opt/jdk-11 # Test override of the default JDK for builds
-          agentJavaBin: /opt/jdk-17 # Test override of the default JDK for builds
-          userInstanceIdentity: '/specific/value/which/overrides/cloud/default'
-        - name: "win-2019-inbound" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2019"
-          imageDefinition: jenkins-agent-windows-2019-amd64
-          os: "windows"
-          os_version: "2019"
-          launcher: "inbound"
-          location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
-          ephemeralOSDisk: true
-          architecture: amd64
-          labels:
-            - docker-windows
-            - docker-windows-2019
-            - win-2019
-            - win-2019-amd64-maven-11
-          javaHome: 'C:/Tools/openjdk-11' # Test override of the default JDK for builds
-          maxInstances: 50
-          useAsMuchAsPossible: true
-          credentialsId: "jenkinsvmagents-userpass"
-          usePrivateIP: true
-          spot: true
-          agentJavaBin: 'C:/Tools/openjdk-17' # Test override of the default JDK for builds
-        - name: "win-2022-ssh" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2022"
-          imageDefinition: jenkins-agent-windows-2022-amd64
-          os: "windows"
-          os_version: "2022"
-          location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
-          ephemeralOSDisk: true
-          architecture: amd64
-          labels:
-            - docker-windows-2022
-          maxInstances: 50
-          useAsMuchAsPossible: true
-          credentialsId: "jenkinsvmagents-userpass"
-          usePrivateIP: true
-          spot: false
-        - name: "win-2025-ssh" # The name must not contains "windows" or Azure API complains :facepalm:
-          description: "Windows 2025"
-          imageDefinition: jenkins-agent-windows-2025-amd64
-          os: "windows"
-          os_version: "2025"
-          location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
-          ephemeralOSDisk: true
-          architecture: amd64
-          labels:
-            - docker-windows-2025
-          maxInstances: 50
-          useAsMuchAsPossible: true
-          credentialsId: "jenkinsvmagents-userpass"
-          usePrivateIP: true
-          spot: false
+          agent_definitions:
+            - name: "ubuntu-22-inbound"
+              description: "Ubuntu 22.04 LTS"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "inbound"
+              location: "East US 2"
+              instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+              ephemeralOSDisk: true
+              architecture: amd64
+              labels:
+                - java
+                - docker
+                - linux-amd64
+              maxInstances: 50
+              useAsMuchAsPossible: true
+              credentialsId: "jenkinsvmagents-userpass"
+              usePrivateIP: true
+              spot: true
+            - name: "ubuntu-22-amd64-maven17"
+              description: "Ubuntu 22.04 LTS with JDK17 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "inbound"
+              location: "East US 2"
+              instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+              ephemeralOSDisk: true
+              architecture: amd64
+              labels:
+                - ubuntu-22-amd64-maven17
+              javaHome: /opt/jdk-17
+              maxInstances: 50
+              useAsMuchAsPossible: true
+              credentialsId: "jenkinsvmagents-userpass"
+              usePrivateIP: true
+              spot: true
+            - name: "ubuntu-22-amd64-maven21"
+              description: "Ubuntu 22.04 LTS with JDK21 set as default java CLI"
+              imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "inbound"
+              location: "East US 2"
+              instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+              ephemeralOSDisk: true
+              architecture: amd64
+              labels:
+                - ubuntu-22-amd64-maven21
+              javaHome: /opt/jdk-21
+              maxInstances: 50
+              useAsMuchAsPossible: true
+              credentialsId: "jenkinsvmagents-userpass"
+              usePrivateIP: true
+              spot: true
+            - name: "ubuntu-22-arm64-ssh"
+              description: "Ubuntu 22.04 LTS ARM64"
+              imageDefinition: jenkins-agent-ubuntu-22.04-arm64
+              os: "ubuntu"
+              os_version: "22.04"
+              launcher: "ssh"
+              location: "East US 2"
+              instanceType: Standard_D4pds_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+              ephemeralOSDisk: true
+              architecture: arm64
+              labels:
+                - arm64docker
+                - arm64linux
+              maxInstances: 50
+              useAsMuchAsPossible: true
+              credentialsId: "jenkinsvmagents-userpass"
+              usePrivateIP: true
+              javaHome: /opt/jdk-11 # Test override of the default JDK for builds
+              agentJavaBin: /opt/jdk-17 # Test override of the default JDK for builds
+              userInstanceIdentity: '/specific/value/which/overrides/cloud/default'
+            - name: "win-2019-inbound" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2019"
+              imageDefinition: jenkins-agent-windows-2019-amd64
+              os: "windows"
+              os_version: "2019"
+              launcher: "inbound"
+              location: "East US 2"
+              instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+              ephemeralOSDisk: true
+              architecture: amd64
+              labels:
+                - docker-windows
+                - docker-windows-2019
+                - win-2019
+                - win-2019-amd64-maven-11
+              javaHome: 'C:/Tools/openjdk-11' # Test override of the default JDK for builds
+              maxInstances: 50
+              useAsMuchAsPossible: true
+              credentialsId: "jenkinsvmagents-userpass"
+              usePrivateIP: true
+              spot: true
+              agentJavaBin: 'C:/Tools/openjdk-17' # Test override of the default JDK for builds
+            - name: "win-2022-ssh" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2022"
+              imageDefinition: jenkins-agent-windows-2022-amd64
+              os: "windows"
+              os_version: "2022"
+              location: "East US 2"
+              instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+              ephemeralOSDisk: true
+              architecture: amd64
+              labels:
+                - docker-windows-2022
+              maxInstances: 50
+              useAsMuchAsPossible: true
+              credentialsId: "jenkinsvmagents-userpass"
+              usePrivateIP: true
+              spot: false
+            - name: "win-2025-ssh" # The name must not contains "windows" or Azure API complains :facepalm:
+              description: "Windows 2025"
+              imageDefinition: jenkins-agent-windows-2025-amd64
+              os: "windows"
+              os_version: "2025"
+              location: "East US 2"
+              instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+              ephemeralOSDisk: true
+              architecture: amd64
+              labels:
+                - docker-windows-2025
+              maxInstances: 50
+              useAsMuchAsPossible: true
+              credentialsId: "jenkinsvmagents-userpass"
+              usePrivateIP: true
+              spot: false
   artifact_caching_proxy:
     enabled: true
     servers:


### PR DESCRIPTION
This change moves the `agent_definitions` under `azure_vm_agents.clouds` so we can get agent templates linked to one cloud only instead of having them duplicated across all clouds but without any possibility to change a template property for templates of only one of those `clouds`. (Ex: setting the region)

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5004