### PR TITLE
fix(ci.jenkins.io): set Windows 2025 AMI to packer v2.82.0

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -227,7 +227,9 @@ profile::jenkinscontroller::jcasc:
       windows-2019-amd64: ami-048dc6275fbb80327
       ubuntu-22.04-arm64: ami-047157c8d465f350b
       windows-2022-amd64: ami-0dd12ecdc5f378c7f
-      windows-2025-amd64: ami-0129431719c13b3c7
+      # Windows 2025 set to packer-images 2.82.0 with working Launchable to get passing core builds on ci.jenkins.io
+      # See https://github.com/jenkins-infra/helpdesk/issues/5030#issuecomment-4010368309
+      windows-2025-amd64: ami-00f4d6e1eed03cc91
     azure_vms_gallery_image:
       version: 2.85.0
       subscription_id: dff2ec18-6a8e-405c-8e45-b7df7465acf0


### PR DESCRIPTION
This change sets Windows 2025 agents to use the packer-images AMI version 2.82.0 as the last current one (2.85.0) results in Launchable errors when building jenkinsci/jenkins on ci.jenkins.io

Hardcoded value to be reverted when a Core build passes on ci.jenkins.io with a more recent packer AMI.

cert.ci.jenkins.io which needs 2.85.0 at least (replicated in Sweden) is not impacted as not using ec2 VMs for its agents, only Azure VMs.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5030#issuecomment-4010368309