### PR TITLE
feat(aws.ci.jenkins.io)! Switch controller to JDK25 runtime

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -24,7 +24,7 @@ profile::jenkinscontroller::additional_fqdns:
   ci.jenkins-ci.org: null
 profile::jenkinscontroller::letsencrypt: true
 profile::jenkinscontroller::docker_image: 'jenkins/jenkins'
-profile::jenkinscontroller::docker_tag: 'lts-jdk21'
+profile::jenkinscontroller::docker_tag: 'lts-jdk25'
 profile::jenkinscontroller::groovy_init_enabled: true
 profile::jenkinscontroller::block_remote_access_api: true
 profile::jenkinscontroller::groovy_d_lock_down_jenkins: 'present'


### PR DESCRIPTION
Related to:

- https://github.com/jenkins-infra/helpdesk/issues/4941

migrate to jdk25 as runtime for controller aws.ci.jenkins.io