### PR TITLE
feat(ci.jenkins.io|trusted.ci agents)! Switch permanent agents to JDK25 runtime

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/permanent-agents.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/permanent-agents.yaml.erb
@@ -14,7 +14,7 @@ jenkins:
         ssh:
           credentialsId: "<%= agent['ssh']['credentialsId'] %>"
           host: "<%= agent['ssh']['host'] %>"
-          javaPath: "<%= agent['ssh']['javaPath'] ? agent['ssh']['javaPath'] : '/opt/jdk-21/bin/java' %>"
+          javaPath: "<%= agent['ssh']['javaPath'] ? agent['ssh']['javaPath'] : '/opt/jdk-25/bin/java' %>"
           launchTimeoutSeconds: "<%= agent['ssh']['timeout'] ? agent['ssh']['timeout'] : '60' %>"
           port: "<%= agent['ssh']['port'] ? agent['ssh']['port'] : '22' %>"
           retryWaitTime: "<%= agent['ssh']['retryWaitTime'] ? agent['ssh']['retryWaitTime'] : '60' %>"


### PR DESCRIPTION
Related to:

- https://github.com/jenkins-infra/helpdesk/issues/4941

migrate to jdk25 as runtime for permanent agents trusted.ci.jenkins.io agents