### PR TITLE
feat(ci.jenkins.io/s390x)! Switch permanent agent to JDK25 runtime

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -109,7 +109,7 @@ profile::jenkinscontroller::jcasc:
         hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIaGnnWz9Q/MvlscCUZslFxH8JJ01OQ6FXyuQMQWVuNe"
       envVars:
         PATH+MAVEN: /home/jenkins/tools/apache-maven-3.9.12/bin
-        JAVA_HOME: /opt/jdk-21
+        JAVA_HOME: /opt/jdk-25
       toolLocation:
         - home: /home/jenkins/tools/apache-maven-3.9.12
           key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"


### PR DESCRIPTION
Related to:

- https://github.com/jenkins-infra/helpdesk/issues/4941

migrate to jdk25 as runtime for permanent agent s390x