### PR TITLE
chore(updatecli): track jenkins lts jdk25 version

### DIFF
--- a/updatecli/updatecli.d/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/jenkins-lts.yaml
@@ -20,7 +20,7 @@ sources:
     spec:
       release: stable
     transformers:
-      - addsuffix: "-jdk21"
+      - addsuffix: "-jdk25"
 
 conditions:
   defaultCidockerimage:


### PR DESCRIPTION
As per 

- https://github.com/jenkins-infra/helpdesk/issues/4941

we update the manifest track jenkins lts latest jdk25 version.

This closes the unexpected PR opened by updatecli 

- https://github.com/jenkins-infra/jenkins-infra/pull/4749/