### PR TITLE
feat(aws.ci.jenkin.io)! Switch jnlp-packaging agent to JDK25 runtime

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -233,7 +233,7 @@ profile::jenkinscontroller::jcasc:
                 mountPath: "/cache"
                 readOnly: true
           - name: jnlp-packaging
-            agentJavaBin: /opt/jdk-21
+            agentJavaBin: /opt/jdk-25
             javaHome: /opt/jdk-21
             labels:
               - packaging


### PR DESCRIPTION
as per 

- https://github.com/jenkins-infra/helpdesk/issues/4941

This PR switches jnlp-packaging agent to JDK25 runtime