### PR TITLE
fix(aws.ci.jenkins.io): don't override common `agentJavaBin` in `jnlp-packaging` template

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -233,7 +233,6 @@ profile::jenkinscontroller::jcasc:
                 mountPath: "/cache"
                 readOnly: true
           - name: jnlp-packaging
-            agentJavaBin: /opt/jdk-25
             javaHome: /opt/jdk-21
             labels:
               - packaging


### PR DESCRIPTION
This change removes the override of `agentJavaBin` as it wasn't working as intended on ci.jenkins.io.
Logs from pods: "/opt/jdk-25: Is a directory"

It should have had `/opt/jdk-25/bin/java` as proper value (and `/opt/jdk-25/bin/java` before), but as it's already the default value for all agents in hieradata/common.yaml, no need to override it.

https://github.com/jenkins-infra/jenkins-infra/blob/d67a8d37006ab46c60af82e69771993ca7a12d6b/hieradata/common.yaml#L217

https://github.com/jenkins-infra/jenkins-infra/blob/d67a8d37006ab46c60af82e69771993ca7a12d6b/dist/profile/templates/jenkinscontroller/casc/clouds-kubernetes.yaml.erb#L44-L45

Follow-up of:
- #4752

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4941

#### Testing done

Manually updated jnlp-template env var configuration on ci.jenkins.io and replayed a check-agent-availability job with `jnlp-packaging` and `packaging` in https://ci.jenkins.io/job/Infra/job/acceptance-tests/job/check-agent-availability/6022: agents successfully provisioned