### PR TITLE
feat(trusted.ci.jenkins.io) migrate azure-vm agents to the Azure Jenkins Sponsored subscription

### DIFF
--- a/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.trusted.ci.jenkins.io.yaml
@@ -84,22 +84,21 @@ profile::jenkinscontroller::jcasc:
     azure_vm_agents:
       clouds:
         azure-vms-jenkins-cdf:
-          azureCredentialsId: azure-jenkins-cdf-managed-identity # Managed manually
+          azureCredentialsId: azure-jenkins-sponsored-managed-identity # Managed manually
           # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
           resourceGroup: trusted-ci-jenkins-io-ephemeral-agents
           maxInstances: 50
           # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-          virtualNetworkName: trusted-ci-jenkins-io-vnet
+          virtualNetworkName: trusted-ci-jenkins-io-sponsored-vnet
           # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-          virtualNetworkResourceGroupName: trusted-ci-jenkins-io
+          virtualNetworkResourceGroupName: trusted-ci-jenkins-io-sponsored
           # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-          subnetName: trusted-ci-jenkins-io-vnet-ephemeral-agents
-          # TODO: enable Spot after implementing retries to ondemand
+          subnetName: trusted-ci-jenkins-io-sponsored-vnet-ephemeral-agents
           disableSpot: true # Not enough quota available
           # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-          storageAccount: trustedcijenkinsioagents
+          storageAccount: trustedciagentssponso
           # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-          userInstanceIdentity: '/subscriptions/dff2ec18-6a8e-405c-8e45-b7df7465acf0/resourceGroups/jenkinsinfra-trusted-ci-controller/providers/Microsoft.ManagedIdentity/userAssignedIdentities/trusted-ci-jenkins-io-agents'
+          userInstanceIdentity: '/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/jenkinsinfra-trusted-ci-controller/providers/Microsoft.ManagedIdentity/userAssignedIdentities/trusted-ci-jenkins-io-agents-sponsored'
       agent_definitions:
         - name: "ubuntu-22-amd64-maven-11"
           description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
@@ -109,7 +108,7 @@ profile::jenkinscontroller::jcasc:
           launcher: "ssh"
           javaHome: "/opt/jdk-11"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -134,7 +133,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -155,7 +154,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -176,7 +175,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8pds_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8pds_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: arm64
@@ -196,7 +195,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -217,7 +216,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -241,7 +240,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -260,7 +259,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -279,7 +278,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -298,7 +297,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2022"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -319,7 +318,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2022"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -337,7 +336,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2022"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -355,7 +354,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2022"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64
@@ -373,7 +372,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: true
           architecture: amd64


### PR DESCRIPTION
Blocked by https://github.com/jenkins-infra/helpdesk/issues/5045

Ref. https://github.com/jenkins-infra/helpdesk/issues/5015

- Data comes from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
- All x86_64 instances are using v7 family to fulfill quota

<img width="1920" height="470" alt="Capture d’écran 2026-03-20 à 08 39 57" src="https://github.com/user-attachments/assets/4d1e0fc0-dba6-42bd-bed5-b8ba262d1f2f" />

- The arm64 template is using v6 family (no v7 yet) which are also within quota for East US 2

<img width="1918" height="473" alt="Capture d’écran 2026-03-20 à 08 39 42" src="https://github.com/user-attachments/assets/d6520615-ec74-4295-8976-4922569642ae" />
