### PR TITLE
feat(jenkinscontroller,trusted.ci,cert.ci) ensure we use the most recent instance family with trusted launch enabled to support Windows 2025 and NVMe ephemeral OS disk

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-azurevm.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-azurevm.yaml.erb
@@ -212,6 +212,7 @@ jenkins:
         templateDesc: "Dynamically provisioned <%= agent['description'] %> machine"
         templateDisabled: false
         templateName: "<%= agent['name'] %>"
+        trustedLaunch: true
       <%- if agent['userInstanceIdentity'] -%>
         enableUAMI: true
         uamiID: "<%= agent['userInstanceIdentity'] %>"

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -74,7 +74,7 @@ profile::jenkinscontroller::jcasc:
           launcher: "ssh"
           javaHome: "/opt/jdk-11"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -97,7 +97,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -118,7 +118,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -139,7 +139,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -161,7 +161,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -180,7 +180,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -198,7 +198,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -216,7 +216,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -234,7 +234,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -254,7 +254,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -274,7 +274,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -294,7 +294,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -314,7 +314,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v5 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -333,7 +333,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "inbound"
           location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          instanceType: Standard_D4ads_v7 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
           architecture: amd64
           labels:
@@ -352,7 +352,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "inbound"
           location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          instanceType: Standard_D4ads_v7 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
           architecture: amd64
           labels:
@@ -370,7 +370,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "inbound"
           location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          instanceType: Standard_D4ads_v7 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
           architecture: amd64
           labels:
@@ -388,7 +388,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "East US 2"
-          instanceType: Standard_D4pds_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          instanceType: Standard_D4pds_v7 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
           architecture: arm64
           labels:
@@ -408,7 +408,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "inbound"
           location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          instanceType: Standard_D4ads_v7 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
           architecture: amd64
           labels:
@@ -429,7 +429,7 @@ profile::jenkinscontroller::jcasc:
           os: "windows"
           os_version: "2022"
           location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          instanceType: Standard_D4ads_v7 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
           architecture: amd64
           labels:
@@ -445,7 +445,7 @@ profile::jenkinscontroller::jcasc:
           os: "windows"
           os_version: "2025"
           location: "East US 2"
-          instanceType: Standard_D4ads_v5 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+          instanceType: Standard_D4ads_v7 # 4 vCPUS / 16 Gb / Max 150 Gb local storage
           ephemeralOSDisk: true
           architecture: amd64
           labels:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5045 and https://github.com/jenkins-infra/helpdesk/issues/5015

- Ubuntu 22.04 and Windows 2019/2022 (bare images and our custom images) can boot a v6/v7 instance with a NVMe ephemeral OS disk without requiring TPM (Standard boot security instead of Trusted Launch Security).
- cert.ci should us latest generation to support the new gallery image (https://github.com/jenkins-infra/helpdesk/issues/5045)