### PR TITLE
hotfix(cert.ci) use v6 Azure instance family for azure-vm agents as v7 are not available in Sweden

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -74,7 +74,7 @@ profile::jenkinscontroller::jcasc:
           launcher: "ssh"
           javaHome: "/opt/jdk-11"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -97,7 +97,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -118,7 +118,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -139,7 +139,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "22.04"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -161,7 +161,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -180,7 +180,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -198,7 +198,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -216,7 +216,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2019"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -234,7 +234,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -254,7 +254,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -274,7 +274,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -294,7 +294,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64
@@ -314,7 +314,7 @@ profile::jenkinscontroller::jcasc:
           os_version: "2025"
           launcher: "ssh"
           location: "Sweden Central"
-          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          instanceType: Standard_D8ads_v6 # 8 vCPUS / 32 Gb
           ephemeralOSDisk: true
           spot: false
           architecture: amd64


### PR DESCRIPTION
Fixup of #4771 