### PR TITLE
feat: add Datadog tags on ec2 & Azure VMs to collect their controller FQDN and agent type

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-azurevm.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-azurevm.yaml.erb
@@ -9,6 +9,11 @@ jenkins:
       existingResourceGroupName: "<%= cloudsetup['resourceGroup'] %>"
       resourceGroupReferenceType: "existing"
       maxVirtualMachinesLimit: <%= cloudsetup['maxInstances'] %>
+      nodeProperties:
+        - envVars:
+            env:
+            - key: "DD_TAGS"
+              value: "jenkins_controller:<%= @ci_fqdn %> jenkins_agent_type:ephemeral_azurevm"
       vmTemplates:
     <%- @jcasc['cloud_agents']['azure_vm_agents']['agent_definitions'].each do |agent| -%>
       <%- $os = agent['os'] ? agent['os'] : 'ubuntu' -%>

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-azurevm.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-azurevm.yaml.erb
@@ -9,11 +9,6 @@ jenkins:
       existingResourceGroupName: "<%= cloudsetup['resourceGroup'] %>"
       resourceGroupReferenceType: "existing"
       maxVirtualMachinesLimit: <%= cloudsetup['maxInstances'] %>
-      nodeProperties:
-        - envVars:
-            env:
-            - key: "DD_TAGS"
-              value: "jenkins_controller:<%= @ci_fqdn %> jenkins_agent_type:ephemeral_azurevm"
       vmTemplates:
     <%- @jcasc['cloud_agents']['azure_vm_agents']['agent_definitions'].each do |agent| -%>
       <%- $os = agent['os'] ? agent['os'] : 'ubuntu' -%>
@@ -24,6 +19,7 @@ jenkins:
         initScript: |
           # Setup datadog
           (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: <%= @jcasc['datadog_api_key'] %>' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+          Add-Content -Path C:\ProgramData\Datadog\datadog.yaml -Value "tags: [\"jenkins_controller:<%= @ci_fqdn %>\", \"jenkins_agent_type:ephemeral_azurevm\"]" -PassThru
           & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart-service
 
         <%- if agent['launcher'] && agent['launcher'] == "inbound" -%>
@@ -85,6 +81,7 @@ jenkins:
             systemctl stop datadog-agent.service
             mkdir -p /var/log/datadog /etc/datadog-agent
             sed 's/api_key:.*/api_key: <%= @jcasc['datadog_api_key'] %>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+            echo "tags: [\"jenkins_controller:<%= @ci_fqdn %>\", \"jenkins_agent_type:ephemeral_azurevm\"]" >> /etc/datadog-agent/datadog.yaml
             sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
             chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
             chmod 640 /etc/datadog-agent/datadog.yaml

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -86,8 +86,6 @@ jenkins:
               value: "<%= $javaHome %>"
             - key: "PATH"
               value: "<%= $javaHome %>/bin<%= $os == 'windows' ? ";" : ":" %>$PATH"
-            - key: "DD_TAGS"
-              value: "jenkins_controller:<%= @ci_fqdn %> jenkins_agent_type:ephemeral_ec2"
       <%- if $os == "windows" -%>
             - key: "TMP"
               value: "<%= $tempDir %>"
@@ -130,6 +128,7 @@ jenkins:
 
                 ## Setup datadog
                 (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: <%= @jcasc['datadog_api_key'] %>' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+                Add-Content -Path C:\ProgramData\Datadog\datadog.yaml -Value "tags: [\"jenkins_controller:<%= @ci_fqdn %>\", \"jenkins_agent_type:ephemeral_ec2\"]" -PassThru
                 & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart-service
                 Write-Output 'Datadog service setup'
                 Get-Date
@@ -262,6 +261,7 @@ jenkins:
             mkdir -p /var/log/datadog /etc/datadog-agent
             sed 's/api_key:.*/api_key: <%= @jcasc['datadog_api_key'] %>/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
             sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+            echo "tags: [\"jenkins_controller:<%= @ci_fqdn %>\", \"jenkins_agent_type:ephemeral_ec2\"]" >> /etc/datadog-agent/datadog.yaml
             chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
             chmod 640 /etc/datadog-agent/datadog.yaml
             chown dd-agent:dd-agent /var/log/datadog

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -86,6 +86,8 @@ jenkins:
               value: "<%= $javaHome %>"
             - key: "PATH"
               value: "<%= $javaHome %>/bin<%= $os == 'windows' ? ";" : ":" %>$PATH"
+            - key: "DD_TAGS"
+              value: "jenkins_controller:<%= @ci_fqdn %> jenkins_agent_type:ephemeral_ec2"
       <%- if $os == "windows" -%>
             - key: "TMP"
               value: "<%= $tempDir %>"


### PR DESCRIPTION
This change adds Datadog tags to VMs spawned by Jenkins controllers so we can filter them out in https://github.com/jenkins-infra/datadog/blob/1f4e8f1da9cc5c0b83b118548c388457d35061de/datadog-monitors.tf#L22-L27 to avoid PagerDuty when an ephemeral agent disk is almost full (and which we don't care about as it's expected for some builds to almost fill their agent disk)

Refs:
- https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=noncontainerizedenvironments
- https://github.com/jenkins-infra/helpdesk/issues/5056
