### PR TITLE
Revert "Bump Packer Agent Templates (All-In-One) Version to 2.96.0"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -223,17 +223,17 @@ profile::jenkinscontroller::jcasc:
       registryMirror: https://dockerhubmirror.azurecr.io
   agent_images:
     ec2_amis:
-      ubuntu-22.04-amd64: ami-09d2aec6be794a27d
-      ubuntu-22.04-arm64: ami-0313d99fb71128eb1
-      windows-2019-amd64: ami-0c9b44b9a84e78756
-      windows-2022-amd64: ami-0d4d50ca152243bc5
-      windows-2025-amd64: ami-0e3ff4bde0ad32bd8
+      ubuntu-22.04-amd64: ami-0ec7ca3919fbc6a8e
+      ubuntu-22.04-arm64: ami-09771b6858263d886
+      windows-2019-amd64: ami-0a9e8c587b9075776
+      windows-2022-amd64: ami-00b76721273d7ff61
+      windows-2025-amd64: ami-0f9c4fff9f61d12e2
     azure_vms_gallery_image:
-      version: 2.96.0
+      version: 2.95.0
       subscription_id: 1e7d5219-acbc-4495-8629-bdbb22e9b3ed
     container_images:
       # All in one image (same as VM templates)
-      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.96.0@sha256:efde85977cc08470ea006db2545f9f0b3e6c1c8cc5876d69953a02df660cacd0
+      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.95.0@sha256:79ddc5434036ce8337ce71cf6a5fbd62dd7f1973fe1347e655db4038c476b3f1
       jnlp-packaging: jenkinsciinfra/packaging:latest
   tools_default_versions:
     jdk21:


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#4794

`pwsh` not found 😭 (cf https://trusted.ci.jenkins.io/job/acceptance-tests-check-agent-availability/902/stages/?selected-node=21)