### PR TITLE
feat(profile::letsencrypt) golang 1.24+ is required for certbot-dns-multi

### DIFF
--- a/dist/profile/manifests/letsencrypt.pp
+++ b/dist/profile/manifests/letsencrypt.pp
@@ -38,7 +38,7 @@ class profile::letsencrypt (
   }
   $python_weight       = regsubst($python_certbot_version, '\.','')
 
-  ['python3', 'python3-pip', "python${python_certbot_version}", 'python3-augeas', 'libaugeas0', 'python3-cffi-backend', 'python3-cffi'].each | $package_name | {
+  ['python3', 'python3-pip', "python${python_certbot_version}", 'python3-augeas', 'libaugeas0', 'python3-cffi-backend', 'python3-cffi', 'curl', 'tar'].each | $package_name | {
     package { $package_name:
       ensure => 'installed',
     }
@@ -107,8 +107,25 @@ class profile::letsencrypt (
   }
 
   if $plugin == 'dns-multi' {
+    $golang_version='1.26.2'
+    $architecture = $facts['os']['architecture'] ? {
+      'aarch64' => 'arm64',
+      default   => $facts['os']['architecture'],
+    }
+    $golang_dl_url="https://go.dev/dl/go${golang_version}.linux-${architecture}.tar.gz"
+    $golang_dl_archive="/tmp/go${golang_version}.linux-${architecture}.tar.gz"
+    $golang_installation_prefix='/usr/local'
+
+    exec { "Install golang version ${golang_version}":
+      require => [Package['curl'],Package['tar']],
+      command => "/usr/bin/curl --silent --location --verbose --show-error --output ${golang_dl_archive} \"${golang_dl_url}\" && /usr/bin/rm -rf ${golang_installation_prefix}/go && /usr/bin/tar -C ${golang_installation_prefix} -xzf ${golang_dl_archive} && /usr/bin/rm -f ${golang_dl_archive} && ln -s ${golang_installation_prefix}/go/bin/go /usr/local/bin/go",
+      unless  => "/usr/bin/test -f /usr/local/bin/go && /usr/local/bin/go version 2>/dev/null | /bin/grep ${golang_version}",
+    }
+
+    notice "/usr/bin/python${python_certbot_version} -m pip install --upgrade certbot-dns-multi==${certbot_dnsmulti_version}"
+
     exec { 'Install certbot-dns-multi plugin':
-      require => Exec['Install certbot'],
+      require => [Exec['Install certbot'],Exec["Install golang version ${golang_version}"]],
       command => "/usr/bin/python${python_certbot_version} -m pip install --upgrade certbot-dns-multi==${certbot_dnsmulti_version}",
       unless  => "/usr/bin/python${python_certbot_version} -m pip list | /bin/grep --word-regexp certbot-dns-multi | /bin/grep ${certbot_dnsmulti_version}",
     }


### PR DESCRIPTION
This PR adds an installation of golang 1.26.2 to ensure certbot-dns-multi installs properly: since version `4.30.0` it requires golang 1.24+ which is not part of the Ubuntu 22.04 distribution packages.


It's a "quick and dirty": the Golang version is good enough "as it" in the code.