### PR TITLE
feat(agent-2.trusted.ci.jenkins.io) rotate SSH key for user 'jenkins'

### DIFF
--- a/hieradata/clients/agent-2.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/agent-2.trusted.ci.jenkins.io.yaml
@@ -5,7 +5,7 @@ datadog_agent::host: "agent-2.trusted.ci.jenkins.io"
 profile::buildagent::ssh_keys:
   trusted.ci.jenkins.io:
     type: ed25519
-    key: AAAAC3NzaC1lZDI1NTE5AAAAINdeZJh/nqgNvkhSph152vK/9vWzEzYXd6GWk68edm2E
+    key: AAAAC3NzaC1lZDI1NTE5AAAAIItJB1E9CwGG+/bVRToJAH0rdSKNnYmmnhskKwxPVD9u
 profile::buildagent::trusted_agent: true
 profile::awscli::version: 2.34.36
 profile::aznfs::mounts:


### PR DESCRIPTION
https://github.com/jenkins-infra/helpdesk/issues/5067#issuecomment-4307752144

Requires:
- https://github.com/jenkins-infra/charts-secrets/commit/8fbf38e3c90f2f714ce32d41c45be711d94374fb (storing the new private key encrypted in our private SOPS Vault)
- Updating the credential `` in trusted.ci.jenkins.io

Once merged:

- Ensure puppet apply ran and replaced the old public key by the new one
- Disconnect/Reconnect the agent-2 in trusted.ci to ensure everything is good