### PR TITLE
Revert "Revert "Do not mirror the `incrementals` repo""

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb
@@ -11,7 +11,7 @@ unclassified:
               <mirror>
                   <id>artifact-caching-proxy</id>
                   <url><%= serverConfig['url']%></url>
-                  <mirrorOf>external:*,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven</mirrorOf>
+                  <mirrorOf>external:*,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven</mirrorOf>
               </mirror>
             </mirrors>
             <profiles>


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#4727

Ref. https://github.com/jenkins-infra/helpdesk/issues/4998.

Since we fully removed the incremental repository from ACP, let's take a new shot at this one

(Retrying https://github.com/jenkins-infra/jenkins-infra/pull/4669)