### PR TITLE
feat(trusted.ci) add the new controller-sponsored VM

### DIFF
--- a/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
@@ -1,0 +1,419 @@
+---
+lookup_options:
+  "^profile::jenkinscontroller::jcasc$":
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+  "^letsencrypt":
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+accounts:
+  notmyfault:
+    ssh_keys:
+      notmyfault_rsa:
+        key: AAAAB3NzaC1yc2EAAAADAQABAAABgQD4jyaQucbqLmDZ+WiAS0bjXTTlOr7Jx+1gUs4pT5LzlL/ijg7Fa7FGK/96U5lUJKvmuF2oGI53n3JfwJuRsuKe2yTdlMrRKREn/jUBP4LnNeVs77Fau25jPERJAgo+lz3BBlRfPJ6AYdMRiVWr9ZsKJILGB9UpALjSJkN3F+W66Dm51Xjw7SiScKs5xKb+s5WisIlJp6MC1T0z24DFAu/X08f2A2jGpHloF6R6FHUPVYewc5bjj72DrFIP+6M+1k1mBzyr/5COBgbFxStrT+wk+spA9U8fhOiFWDcmpEnfJa8qwMBDwSkiwWdDgEeEbepFgeNgzfBxY0vSbBtV2rbm2Chy8yUj0EKERZIIGHo3yowP6pyK78QJceuBFd3jzzlaOotdI1ce5tFDR51FMbAAKY2YYm//LmwZcxXVC0k2Vd5kMOmRtM3Iv4WT836ZvkhMxUi+fC0HbKXMsEwXnitNmGO0c9JKe9XbMYqKCsCVoeEjL0+8nMiLkId5ZMxFyKc=
+    groups:
+      - sudo
+  kevingrdj:
+    ssh_keys:
+      potatoes:
+        key: AAAAB3NzaC1yc2EAAAADAQABAAACAQDSNxU0LGimqU7fngTWhdVPk13uvG+Ek/NrYOF/EiuKiYsW3ifoSUR7f/ha6Y/EdzGrfix+fsQSX8nf5O8y9qXPthmyTydsXINA4+pfxnfv+7NOtlo81k1+SAwvAflNX/cUeGc1Mih6kLTCNgO5JYfYtwDdvVBdchR5JSjwZx8McVNvCqu57f3R4STYKMTh0Tavb2jH3omEUz+mTtS8MxjyXNH14KqfHEWiyZB+LBpOjW5AVn5SfWjH17a0ukZc5BJfvB5Lk11isNXO9rliJg/gxAoCXNl+XmZOLGPXTQ2ANW1dfEtJ/bT5dhNTemj0KPeOncCGZLheHyRveSwF6laSGJ+vE2xrY5bjg6suwmxLyA04E7kwmTEvbW2eMwtk4/wJe5j9wmUSrkK1icYK5t5gQcKbla734yhbri+JIN1ygXundJdi/QsGYNvWZnBZDF3KRt216siP5hPJfJ3L2xAoqWuMpin86rnSNLfbCP1jTDgVexjcynivpgT7jbJ3H5CfFohpEuTyPRG2NbI/3nQf1SAW64OqVPoq+2e0be5sCGUcUqk333w3GTPRhX+duKKhEPlaphaL+H3QrdTwlvVjklJAyB6Li/k0TExA7hDoPyLNdj9iaWRopFEgrQzXrek1QR8O0T3nFAPOBA1DDfWgw2U/oylcPIBCuoZwAePx6Q==
+docker::log_opt::max-size: "100m"
+docker::log_opt::max-file: 2
+# Per-host Datadog configuration
+datadog_agent::host: "controller-sponsored.trusted.ci.jenkins.io"
+profile::jenkinscontroller::ci_fqdn: "trusted.ci.jenkins.io"
+profile::jenkinscontroller::ci_resource_domain: 'assets.trusted.ci.jenkins.io'
+profile::jenkinscontroller::admin_ldap_groups:
+  - admins
+  - trusted-admins
+profile::jenkinscontroller::letsencrypt: true
+profile::letsencrypt::plugin: dns-multi
+profile::letsencrypt::dns_azure:
+  use_workload_identity: true
+  tenant_id: "4c45fef2-1ba7-4120-80a0-9e2d03e9c2b6" # application_tenant_id
+  zone:
+    name: "trusted.ci.jenkins.io"
+    subscription: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+    resource_group_name: "proddns_jenkinsio"
+profile::jenkinscontroller::groovy_init_enabled: true
+profile::jenkinscontroller::groovy_d_lock_down_jenkins: "present"
+profile::jenkinscontroller::groovy_d_set_up_git: "present"
+profile::jenkinscontroller::memory_limit: '8g'
+profile::jenkinscontroller::jcasc:
+  enabled: true
+  reload_token: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAlreoLMhSaHCcZZaL1r7BQgmqUVbqWs+e2kaj0cn+r8o4N/qKZGXkkYBN9xhK+b5MRe2cTlfQ9J3gFFLFa6i1n1GrM/WwNMUm/cVYA2eGFNcV3ruUfigyriIrIaQVm7KIQZqv+RIQoZHJ1cWy+CdKg2hXi4KUBSawl1V3VXjSD4ZJEWv96KSceJZRTzVjZW66iD8i8Uq50WvHhvivMfHkaghowz626w/ejz0AettIKCVL9/j0B1iVv+ghOyd4A5kyIYJKR0BwQLpfKFoXY/0uhB7toZWSe7TUS7hzTAfYNhyTbS0aaczsa7pshiFZzxHAdvMeU7om4N1Dj+5LDUgAsDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBByyf8QkfPXbWYxJbMykP8SgCAQ5ncRq7jZddH/cFcb+xHJzKluSoRQU3fnSKJ8fnbEQA==]
+  datadog_api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEADyo2YPgZgSJTKYK+zqkBcrmKKDuMOkZ1PqeCbCjHaJEJpM41lUGTe0s9wZfKV0poQZxF+REOhrV4wisuvt9tTMZpPUgG+Z5tetLO9GDJ8Ml0t7P/OHooFt4gebBwZQAPnUN35R87FQcS69XDKVCrp/RepteuicPSqUozjPls652mHiaR+OqBzqVr0+jlRfprt7UG8UthT+rih89OfVzmnTj9PSmbt1q5R3kMFg8/7yQTTf8yvS9XPthNLXTC/3/3ygdA+Md6Le9kzknIrJGFcide8S2JO3CLuf5LFo9/8RViCAhDmZulXOmm8GbCe7M+/Ok7NRJrcFZz0mN7yK4lxjBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBByYY131KQj7XGZAvJLNH+ngDBqKvrxjSNhJ2gzQPlVrur+mYzqf3avlfwUqKFuGTK/9kQ/7vwqI1DfvqiRTy3EJpM=]
+  appearance:
+    pipeline_graph_view:
+      on_build_page: true
+      on_job_page: false
+  tools:
+    groovy:
+      groovy: # Default version is named "groovy"
+        version: "2.4.21"
+    jdk:
+      jdk8:
+        installers:
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
+      jdk17:
+        installers:
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
+      jdk21:
+        installers:
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
+      jdk25:
+        installers:
+          linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
+  ## Commented until production migration
+  # permanent_agents:
+  #   agent-2:
+  #     remoteFS: /home/jenkins/agent-workspace
+  #     numExecutors: 2
+  #     mode: EXCLUSIVE
+  #     labels:
+  #       - updatecenter
+  #       - census
+  #     ssh:
+  #       host: "agent-2.trusted.ci.jenkins.io"
+  #       credentialsId: "trusted-agent-2-ssh-key"
+  #       maxNumRetries: 0
+  #       retryWaitTime: 0
+  #       hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+0teBZr3lKADKAGECDTLpZl5Z8Y+YM7J+HmJk2B/bx"
+  cloud_agents:
+    azure_vm_agents:
+      clouds:
+        azure-vms-jenkins-sponsored:
+          azureCredentialsId: azure-jenkins-sponsored-managed-identity # Managed manually
+          # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+          resourceGroup: trusted-ci-jenkins-io-ephemeral-agents
+          maxInstances: 50
+          # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+          virtualNetworkName: trusted-ci-jenkins-io-sponsored-vnet
+          # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+          virtualNetworkResourceGroupName: trusted-ci-jenkins-io-sponsored
+          # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+          subnetName: trusted-ci-jenkins-io-sponsored-vnet-ephemeral-agents
+          disableSpot: true # Not enough quota available
+          # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+          storageAccount: trustedciagentssponso
+          # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+          userInstanceIdentity: '/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/trusted-ci-jenkins-io-sponsored-commons/providers/Microsoft.ManagedIdentity/userAssignedIdentities/trusted-ci-jenkins-io-agents-sponsored'
+      agent_definitions:
+        - name: "ubuntu-22-amd64-maven-11"
+          description: "Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          javaHome: "/opt/jdk-11"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - java
+            - linux
+            - docker
+            - ubuntu
+            - ubuntu-22
+            - ubuntu-amd64-maven-11
+            - ubuntu-22-amd64-maven-11
+            - maven-11
+            - jdk11
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "ubuntu-22-amd64-maven-17"
+          description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - ubuntu-amd64-maven-17
+            - ubuntu-22-amd64-maven-17
+            - maven-17
+            - jdk17
+          javaHome: '/opt/jdk-17'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "ubuntu-22-amd64-maven-21"
+          description: "Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - ubuntu-amd64-maven-21
+            - ubuntu-22-amd64-maven-21
+            - maven-21
+            - jdk21
+          javaHome: '/opt/jdk-21'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "ubuntu-22-arm64-maven-21"
+          description: "Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
+          imageDefinition: jenkins-agent-ubuntu-22.04-arm64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8pds_v6 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: arm64
+          labels:
+            - ubuntu-arm64-maven-21
+            - ubuntu-22-arm64-maven-21
+            - arm64docker # Same label as ci.jenkins.io docker arm64 agent template
+          javaHome: '/opt/jdk-21'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "ubuntu-22-amd64-maven-25"
+          description: "Ubuntu 22.04 LTS x86_64 with JDK25 set as default java CLI"
+          imageDefinition: jenkins-agent-ubuntu-22.04-amd64
+          os: "ubuntu"
+          os_version: "22.04"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - ubuntu-amd64-maven-25
+            - ubuntu-22-amd64-maven-25
+            - maven-25
+            - jdk25
+          javaHome: '/opt/jdk-25'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2019-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2019 Maven-11"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2019
+            - windows-2019
+            - win-2019-amd64-maven-11
+            - maven-11-windows
+            # Labels indicating it is the default VM template for Windows & Docker, and Windows & Maven
+            - docker-windows
+            - maven-windows
+          javaHome: 'C:/tools/jdk-11'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2019-amd64-maven-17"
+          description: "Windows 2019 Maven-17"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2019-amd64-maven-17
+            - maven-17-windows
+          javaHome: 'C:/tools/jdk-17'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2019-amd64-maven-21"
+          description: "Windows 2019 Maven-21"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2019-amd64-maven-21
+            - maven-21-windows
+          javaHome: 'C:/tools/jdk-21'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2019-amd64-maven-25"
+          description: "Windows 2019 Maven-25"
+          imageDefinition: jenkins-agent-windows-2019-amd64
+          os: "windows"
+          os_version: "2019"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2019-amd64-maven-25
+            - maven-25-windows
+          javaHome: 'C:/tools/jdk-25'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2022-amd64-maven-11" # The name must not contains "windows" or Azure API complains :facepalm:
+          description: "Windows 2022 Maven-11"
+          imageDefinition: jenkins-agent-windows-2022-amd64
+          os: "windows"
+          os_version: "2022"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - docker-windows-2022
+            - win-2022
+            - windows-2022
+            - win-2022-amd64-maven-11
+          javaHome: 'C:/tools/jdk-11'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2022-amd64-maven-17"
+          description: "Windows 2022 Maven-17"
+          imageDefinition: jenkins-agent-windows-2022-amd64
+          os: "windows"
+          os_version: "2022"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2022-amd64-maven-17
+          javaHome: 'C:/tools/jdk-17'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2022-amd64-maven-21"
+          description: "Windows 2022 Maven-21"
+          imageDefinition: jenkins-agent-windows-2022-amd64
+          os: "windows"
+          os_version: "2022"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2022-amd64-maven-21
+          javaHome: 'C:/tools/jdk-21'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2022-amd64-maven-25"
+          description: "Windows 2022 Maven-25"
+          imageDefinition: jenkins-agent-windows-2022-amd64
+          os: "windows"
+          os_version: "2022"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2022-amd64-maven-25
+          javaHome: 'C:/tools/jdk-25'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+        - name: "win-2025-amd64-maven-25"
+          description: "Windows 2025 Maven-25"
+          imageDefinition: jenkins-agent-windows-2025-amd64
+          os: "windows"
+          os_version: "2025"
+          launcher: "ssh"
+          location: "East US 2"
+          instanceType: Standard_D8ads_v7 # 8 vCPUS / 32 Gb
+          ephemeralOSDisk: true
+          spot: true
+          architecture: amd64
+          labels:
+            - win-2025-amd64-maven-25
+            # Labels indicating it is the default VM template for Windows 2025 (but not windows)
+            - docker-windows-2025
+            - win-2025
+          javaHome: 'C:/tools/jdk-25'
+          maxInstances: 7
+          useAsMuchAsPossible: true
+          credentialsId: "azure-jenkins-user"
+          usePrivateIP: true
+# These are plugins we need only in our trusted-ci environment
+profile::jenkinscontroller::plugins:
+  - ansicolor
+  - azure-vm-agents
+  - build-timeout
+  - buildtriggerbadge
+  - cloudbees-folder
+  - configuration-as-code
+  - credentials
+  - credentials-binding
+  - docker-workflow
+  - disable-job-button
+  - git-client
+  - git
+  - github
+  - github-branch-source
+  - groovy
+  - jobConfigHistory
+  - ldap
+  - lockable-resources
+  - mailer
+  - parallel-test-executor
+  - pipeline-stage-view
+  - pipeline-utility-steps
+  - ssh-agent # SSH Agent to allow loading SSH credentials on a local agent for jobs
+  - ssh-slaves # SSH Build Agent to implement "outbound agents"
+  - throttle-concurrents
+  - timestamper
+  - workflow-aggregator
+  - workflow-multibranch

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -99,3 +99,13 @@ node 'controller.trusted.ci.jenkins.io' {
   }
   include role::jenkins::controller
 }
+
+node 'controller-sponsored.trusted.ci.jenkins.io' {
+  mount { '/var/lib/jenkins':
+    ensure => 'mounted',
+    atboot => 'true',
+    device => 'UUID=9e5149e7-5eae-4deb-9f16-f32bc4f2370a',
+    fstype => 'ext4',
+  }
+  include role::jenkins::controller
+}


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5084#issuecomment-4343922083

Hieradata is a copy of current `controller.trusted.ci.jenkins.io` with the following changes:

- `agent-2` commented out
- hostnames adapted

UUID already set up as well in the `site.pp`