### PR TITLE
fix: temporary revert packer azure images to 2.99.0 (before docker 29)

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -229,7 +229,7 @@ profile::jenkinscontroller::jcasc:
       windows-2022-amd64: ami-045e6196fa564930b
       windows-2025-amd64: ami-06fcdadab95d9160c
     azure_vms_gallery_image:
-      version: 2.101.3
+      version: 2.99.0
       subscription_id: 1e7d5219-acbc-4495-8629-bdbb22e9b3ed
     container_images:
       # All in one image (same as VM templates)


### PR DESCRIPTION
The Azure linux images haven't been published, and Ubuntu PPA are currently under DDoS, reverting to the latest packer images version with a proper `buildx` install (before docker 29).

Refs:
- https://github.com/jenkins-infra/packer-images/releases/tag/2.99.0
- https://github.com/jenkins-infra/helpdesk/issues/5088#issuecomment-4377465076 