### PR TITLE
feat(trusted.ci): use Maven from agents instead of installing it

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
@@ -68,15 +68,15 @@ tool:
           installers:
           <%- setup['installers'].each do |installer_name, installer_label| -%>
             <%- if installer_name =~ /windows/ -%>
-          - command:
-              command: "echo /usr/share/apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>"
-              label: "<%= installer_label %>"
-              toolHome: "/usr/share/apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>"
-            <%- else -%>
           - batchFile:
               command: "echo C:/tools/apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>/bin"
               label: "<%= installer_label %>"
               toolHome: "C:/tools/apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>/bin"
+            <%- else -%>
+          - command:
+              command: "echo /usr/share/apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>"
+              label: "<%= installer_label %>"
+              toolHome: "/usr/share/apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>"
             <%- end -%>
           <%- end -%>
         <%- elsif setup['version'] || setup['default_version'] -%>

--- a/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
@@ -70,6 +70,18 @@ tool:
               id: "<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>"
         <%- elsif setup['home'] -%>
       home: "<%= setup['home'] %>"
+        <%- elsif setup['useMavenFromAgentLabels'] -%>
+      properties:
+      - installSource:
+          installers:
+          - command:
+              command: "echo /usr/bin"
+              label: "<%= setup['useMavenFromAgentLabels'] %>"
+              toolHome: "/usr/bin"
+          - batchFile:
+              command: "echo C:\tools\apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>\bin"
+              label: "<%= setup['useMavenFromAgentLabels'] %>s"
+              toolHome: "C:\tools\apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>\bin"
         <%- end -%>
       <%- end -%>
     <%- end -%>

--- a/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
@@ -67,14 +67,17 @@ tool:
       - installSource:
           installers:
           <%- setup['installers'].each do |installer_name, installer_label| -%>
+            <%- if installer_name =~ /windows/ -%>
           - command:
-              command: "echo /usr/bin"
+              command: "echo /usr/share/apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>"
               label: "<%= installer_label %>"
-              toolHome: "/usr/bin"
+              toolHome: "/usr/share/apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>"
+            <%- else -%>
           - batchFile:
-              command: "echo C:\tools\apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>\bin"
+              command: "echo C:/tools/apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>/bin"
               label: "<%= installer_label %>"
-              toolHome: "C:\tools\apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>\bin"
+              toolHome: "C:/tools/apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>/bin"
+            <%- end -%>
           <%- end -%>
         <%- elsif setup['version'] || setup['default_version'] -%>
       properties:

--- a/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
@@ -62,7 +62,21 @@ tool:
     <%- @jcasc['tools']['maven'].each do |name, setup| -%>
       <%- unless setup['disabled'] -%>
     - name: "<%= name %>"
-        <%- if setup['version'] || setup['default_version'] -%>
+        <%- if setup['installers'] -%>
+      properties:
+      - installSource:
+          installers:
+          <%- setup['installers'].each do |installer_name, installer_label| -%>
+          - command:
+              command: "echo /usr/bin"
+              label: "<%= installer_label %>"
+              toolHome: "/usr/bin"
+          - batchFile:
+              command: "echo C:\tools\apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>\bin"
+              label: "<%= installer_label %>"
+              toolHome: "C:\tools\apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>\bin"
+          <%- end -%>
+        <%- elsif setup['version'] || setup['default_version'] -%>
       properties:
       - installSource:
           installers:
@@ -70,18 +84,6 @@ tool:
               id: "<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>"
         <%- elsif setup['home'] -%>
       home: "<%= setup['home'] %>"
-        <%- elsif setup['useMavenFromAgentLabels'] -%>
-      properties:
-      - installSource:
-          installers:
-          - command:
-              command: "echo /usr/bin"
-              label: "<%= setup['useMavenFromAgentLabels'] %>"
-              toolHome: "/usr/bin"
-          - batchFile:
-              command: "echo C:\tools\apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>\bin"
-              label: "<%= setup['useMavenFromAgentLabels'] %>s"
-              toolHome: "C:\tools\apache-maven-<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>\bin"
         <%- end -%>
       <%- end -%>
     <%- end -%>

--- a/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
@@ -67,7 +67,7 @@ profile::jenkinscontroller::jcasc:
         installers:
           linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
     maven:
-      maven:
+      mvn:
         useMavenFromAgentLabels: "maven-17 || maven-21 || maven-25 || maven-17-windows || maven-21-windows || maven-25-windows"
   permanent_agents:
     agent-2:

--- a/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
@@ -66,6 +66,9 @@ profile::jenkinscontroller::jcasc:
       jdk25:
         installers:
           linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
+    maven:
+      maven:
+        useMavenFromAgentLabels: "maven-17 || maven-21 || maven-25 || maven-17-windows || maven-21-windows || maven-25-windows"
   permanent_agents:
     agent-2:
       remoteFS: /home/jenkins/agent-workspace

--- a/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
@@ -69,7 +69,8 @@ profile::jenkinscontroller::jcasc:
     maven:
       mvn:
         installers:
-          ephemeral-agents: "maven-17 || maven-21 || maven-25 || maven-17-windows || maven-21-windows || maven-25-windows"
+          ephemeral-agents: "maven-17 || maven-21 || maven-25"
+          ephemeral-agents-windows: "maven-17-windows || maven-21-windows || maven-25-windows"
           permanent-agents: "updatecenter || census"
   permanent_agents:
     agent-2:

--- a/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
@@ -68,7 +68,9 @@ profile::jenkinscontroller::jcasc:
           linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
     maven:
       mvn:
-        useMavenFromAgentLabels: "maven-17 || maven-21 || maven-25 || maven-17-windows || maven-21-windows || maven-25-windows"
+        installers:
+          ephemeral-agents: "maven-17 || maven-21 || maven-25 || maven-17-windows || maven-21-windows || maven-25-windows"
+          permanent-agents: "updatecenter || census"
   permanent_agents:
     agent-2:
       remoteFS: /home/jenkins/agent-workspace

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -114,6 +114,10 @@ profile::jenkinscontroller::jcasc:
           ephemeral-agents: "maven-17 || maven-21 || maven-25"
           ephemeral-agents-windows: "maven-17-windows || maven-21-windows || maven-25-windows"
           permanent-agents: "updatecenter || census"
+      mvnCustomInstallerAndVersion:
+        version: 4.0.0
+        installers:
+          ephemeral-agents: "maven4"
   permanent_agents:
     s390x-agent:
       remoteFS: /home/jenkins/agent

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -101,8 +101,18 @@ profile::jenkinscontroller::jcasc:
           linux-arm64: "(linux && arm64) || linux-arm64"
           s390x: "s390x || s390xdocker"
     maven:
-      mvn:
-        useMavenFromAgentLabels: "maven-17 || maven-21 || maven-25 || maven-17-windows || maven-21-windows || maven-25-windows"
+      # default "mvn" form the global common.yaml ala ci.jenkins.io
+      # Custom version ala cert.ci.jenkins.io
+      mvnCustomVersion:
+        version: "3.5.4"
+      # Custom home ala cert.ci.jenkins.io
+      mvnCustomHome:
+        home: "/usr/share/apache-maven-3.8.8"
+      # Custom installers ala trusted.ci.jenkins.io
+      mvnCustomInstaller:
+        installers:
+          ephemeral-agents: "maven-17 || maven-21 || maven-25 || maven-17-windows || maven-21-windows || maven-25-windows"
+          permanent-agents: "updatecenter || census"
   permanent_agents:
     s390x-agent:
       remoteFS: /home/jenkins/agent

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -100,6 +100,9 @@ profile::jenkinscontroller::jcasc:
         installers:
           linux-arm64: "(linux && arm64) || linux-arm64"
           s390x: "s390x || s390xdocker"
+    maven:
+      mvn:
+        useMavenFromAgentLabels: "maven-17 || maven-21 || maven-25 || maven-17-windows || maven-21-windows || maven-25-windows"
   permanent_agents:
     s390x-agent:
       remoteFS: /home/jenkins/agent

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -111,7 +111,8 @@ profile::jenkinscontroller::jcasc:
       # Custom installers ala trusted.ci.jenkins.io
       mvnCustomInstaller:
         installers:
-          ephemeral-agents: "maven-17 || maven-21 || maven-25 || maven-17-windows || maven-21-windows || maven-25-windows"
+          ephemeral-agents: "maven-17 || maven-21 || maven-25"
+          ephemeral-agents-windows: "maven-17-windows || maven-21-windows || maven-25-windows"
           permanent-agents: "updatecenter || census"
   permanent_agents:
     s390x-agent:


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5090

#### Testing done
```bash
vagrant up --provision jenkins::controller
vagrant ssh jenkins::controller
vagrant@localhost:~$ sudo su -
root@localhost:~$ cat /var/lib/jenkins/casc.d/tools.yaml
```
```yaml
tool:
  maven:
    installations:
    - name: "mvn"
      properties:
      - installSource:
          installers:
          - maven:
              id: "3.9.15"
    - name: "mvnCustomVersion"
      properties:
      - installSource:
          installers:
          - maven:
              id: "3.5.4"
    - name: "mvnCustomHome"
      home: "/usr/share/apache-maven-3.8.8"
    - name: "mvnCustomInstaller"
      properties:
      - installSource:
          installers:
          - command:
              command: "echo /usr/share/apache-maven-3.9.15"
              label: "maven-17 || maven-21 || maven-25"
              toolHome: "/usr/share/apache-maven-3.9.15"
          - batchFile:
              command: "echo C:/tools/apache-maven-3.9.15/bin"
              label: "maven-17-windows || maven-21-windows || maven-25-windows"
              toolHome: "C:/tools/apache-maven-3.9.15/bin"
          - command:
              command: "echo /usr/share/apache-maven-3.9.15"
              label: "updatecenter || census"
              toolHome: "/usr/share/apache-maven-3.9.15"
    - name: "mvnCustomInstallerAndVersion"
      properties:
      - installSource:
          installers:
          - command:
              command: "echo /usr/share/apache-maven-4.0.0"
              label: "maven4"
              toolHome: "/usr/share/apache-maven-4.0.0"
```
<details><summary>UI screenshot</summary>

<img width="2600" height="10264" alt="image" src="https://github.com/user-attachments/assets/721ea4f9-fe64-4625-83ba-c12eed948528" />

</details>