### PR TITLE
chore(trusted.ci): remove `mvn` tool installers

### DIFF
--- a/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
@@ -66,6 +66,9 @@ profile::jenkinscontroller::jcasc:
       jdk25:
         installers:
           linux-amd64: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8 || updatecenter || census"
+    maven:
+      mvn:
+        disabled: true
   permanent_agents:
     agent-2:
       remoteFS: /home/jenkins/agent-workspace

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -100,6 +100,9 @@ profile::jenkinscontroller::jcasc:
         installers:
           linux-arm64: "(linux && arm64) || linux-arm64"
           s390x: "s390x || s390xdocker"
+    maven:
+      mvn:
+        disabled: true
   permanent_agents:
     s390x-agent:
       remoteFS: /home/jenkins/agent


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5090#issuecomment-4389794022

### Testing done

```bash
vagrant up --provision jenkins::controller
vagrant ssh jenkins::controller
vagrant@localhost:~$ sudo su -
root@localhost:~$ cat /var/lib/jenkins/casc.d/tools.yaml
```
<details><summary>tools.yaml</summary>

```yaml
tool:
  git:
    installations:
    - home: "git"
      name: "git-native"
    - name: "jgit"
  groovy:
    installations:
    - name: "groovy"
      properties:
      - installSource:
          installers:
          - groovyInstaller:
              id: "2.4.21"
  jdk:
    installations:
    - name: "jdk8"
      properties:
      - installSource:
          installers:

          - command:
              label: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8"
              toolHome: "/opt/jdk-8"
              command: "echo /opt/jdk-8"

          - batchFile:
              label: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-8-windows"
              toolHome: "C:/Tools/jdk-8"
              command: "echo C:/Tools/jdk-8"

          - command:
              label: "(linux && arm64) || linux-arm64"
              toolHome: "/opt/jdk-8"
              command: "echo /opt/jdk-8"
    - name: "jdk11"
      properties:
      - installSource:
          installers:

          - command:
              label: "(linux && amd64) || linux-amd64 || jdk11 || jdk-11 || maven-11"
              toolHome: "/opt/jdk-11"
              command: "echo /opt/jdk-11"

          - batchFile:
              label: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-11-windows"
              toolHome: "C:/Tools/jdk-11"
              command: "echo C:/Tools/jdk-11"

          - command:
              label: "(linux && arm64) || linux-arm64"
              toolHome: "/opt/jdk-11"
              command: "echo /opt/jdk-11"

          - command:
              label: "s390x || s390xdocker"
              toolHome: "/opt/jdk-11"
              command: "echo /opt/jdk-11"
    - name: "jdk17"
      properties:
      - installSource:
          installers:

          - command:
              label: "(linux && amd64) || linux-amd64 || jdk17 || jdk-17 || maven-17"
              toolHome: "/opt/jdk-17"
              command: "echo /opt/jdk-17"

          - batchFile:
              label: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-17-windows"
              toolHome: "C:/Tools/jdk-17"
              command: "echo C:/Tools/jdk-17"

          - command:
              label: "(linux && arm64) || linux-arm64"
              toolHome: "/opt/jdk-17"
              command: "echo /opt/jdk-17"

          - command:
              label: "s390x || s390xdocker"
              toolHome: "/opt/jdk-17"
              command: "echo /opt/jdk-17"
    - name: "jdk21"
      properties:
      - installSource:
          installers:

          - command:
              label: "(linux && amd64) || linux-amd64 || jdk21 || jdk-21 || maven-21"
              toolHome: "/opt/jdk-21"
              command: "echo /opt/jdk-21"

          - batchFile:
              label: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-21-windows"
              toolHome: "C:/Tools/jdk-21"
              command: "echo C:/Tools/jdk-21"

          - command:
              label: "(linux && arm64) || linux-arm64"
              toolHome: "/opt/jdk-21"
              command: "echo /opt/jdk-21"

          - command:
              label: "s390x || s390xdocker"
              toolHome: "/opt/jdk-21"
              command: "echo /opt/jdk-21"
    - name: "jdk25"
      properties:
      - installSource:
          installers:

          - command:
              label: "(linux && amd64) || linux-amd64 || jdk25 || jdk-25 || maven-25"
              toolHome: "/opt/jdk-25"
              command: "echo /opt/jdk-25"

          - batchFile:
              label: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-25-windows"
              toolHome: "C:/Tools/jdk-25"
              command: "echo C:/Tools/jdk-25"

          - command:
              label: "(linux && arm64) || linux-arm64"
              toolHome: "/opt/jdk-25"
              command: "echo /opt/jdk-25"

          - command:
              label: "s390x || s390xdocker"
              toolHome: "/opt/jdk-25"
              command: "echo /opt/jdk-25"
  maven:
    installations:
  mavenGlobalConfig:
    globalSettingsProvider: "standard"
    settingsProvider: "standard"
```

</details>

http://127.0.0.1:8080/manage/configureTools:
> <img width="352" height="161" alt="image" src="https://github.com/user-attachments/assets/17beee47-1116-40d0-92ed-3f5ff40793b1" />
