### PR TITLE
chore: remove default `mvn` tool installer from ci.jenkins.io and trusted.ci.jenkins.io

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
@@ -62,12 +62,12 @@ tool:
     <%- @jcasc['tools']['maven'].each do |name, setup| -%>
       <%- unless setup['disabled'] -%>
     - name: "<%= name %>"
-        <%- if setup['version'] || setup['default_version'] -%>
+        <%- if setup['version'] -%>
       properties:
       - installSource:
           installers:
           - maven:
-              id: "<%= setup['version'] ? setup['version'] : @jcasc['tools_default_versions']['maven'] %>"
+              id: "<%= setup['version'] %>"
         <%- elsif setup['home'] -%>
       home: "<%= setup['home'] %>"
         <%- end -%>

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -111,9 +111,6 @@ profile::jenkinscontroller::jcasc:
       envVars:
         PATH+MAVEN: /home/jenkins/tools/apache-maven-3.9.15/bin
         JAVA_HOME: /opt/jdk-21
-      toolLocation:
-        - home: /home/jenkins/tools/apache-maven-3.9.15
-          key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
   cloud_agents:
     kubernetes:
       ci.jenkins.io-agents-2:

--- a/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller-sponsored.trusted.ci.jenkins.io.yaml
@@ -80,6 +80,9 @@ profile::jenkinscontroller::jcasc:
         maxNumRetries: 0
         retryWaitTime: 0
         hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO+0teBZr3lKADKAGECDTLpZl5Z8Y+YM7J+HmJk2B/bx"
+      envVars:
+        PATH+MAVEN: /usr/share/apache-maven-3/bin
+        JAVA_HOME: /opt/jdk-21
   cloud_agents:
     azure_vm_agents:
       clouds:

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -168,9 +168,6 @@ profile::jenkinscontroller::jcasc:
       cache-ttl: 180
       allow-pull-requests: true
   tools:
-    maven:
-      mvn:
-        default_version: true
     jdk:
       jdk8:
         major_version: 8

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -243,7 +243,6 @@ profile::jenkinscontroller::jcasc:
       linux:
         amd64: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_linux_hotspot_25.0.3_9.tar.gz
         arm64: https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.3_9.tar.gz
-    maven: 3.9.15
 ssh::server::storeconfigs_enabled: false
 ssh::server::options:
   PasswordAuthentication: no

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -112,11 +112,8 @@ profile::jenkinscontroller::jcasc:
         credentialsId: "jenkins-s390x"
         hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIaGnnWz9Q/MvlscCUZslFxH8JJ01OQ6FXyuQMQWVuNe"
       envVars:
-        PATH+MAVEN: /home/jenkins/tools/apache-maven-3.9.9/bin
-        JAVA_HOME: /opt/jdk-17
-      toolLocation:
-        - home: /home/jenkins/tools/apache-maven-3.9.9
-          key: "hudson.tasks.Maven$MavenInstallation$DescriptorImpl@mvn"
+        PATH+MAVEN: /home/jenkins/tools/apache-maven-3.9.15/bin
+        JAVA_HOME: /opt/jdk-21
   cloud_agents:
     ec2:
       aws-us-east-2:

--- a/updatecli/updatecli.d/jenkinscontroller-tools-maven.yaml
+++ b/updatecli/updatecli.d/jenkinscontroller-tools-maven.yaml
@@ -39,14 +39,6 @@ conditions:
       command: curl --connect-timeout 5 --location --head --fail --silent --show-error https://archive.apache.org/dist/maven/maven-3/{{ source `getMavenVersionFromPackerImages` }}/binaries/apache-maven-{{ source `getMavenVersionFromPackerImages` }}-bin.tar.gz
 
 targets:
-  setMavenToolVersion:
-    name: "Bump Maven version on tools"
-    kind: yaml
-    sourceid: getMavenVersionFromPackerImages
-    spec:
-      file: hieradata/common.yaml
-      key: $.profile::jenkinscontroller::jcasc.tools_default_versions.maven
-    scmid: default
   setMavenPathFors390x:
     name: "Bump Maven path on s390x permanent agent setup"
     kind: yaml
@@ -58,17 +50,6 @@ targets:
       files:
         - hieradata/clients/aws.ci.jenkins.io.yaml
       key: $.profile::jenkinscontroller::jcasc.permanent_agents.s390x-agent.envVars.PATH+MAVEN
-    scmid: default
-  setMavenToolVersionFors390x:
-    name: "Bump Maven path on s390x permanent agent setup"
-    kind: yaml
-    sourceid: getMavenVersionFromPackerImages
-    transformers:
-      - addprefix: /home/jenkins/tools/apache-maven-
-    spec:
-      files:
-        - hieradata/clients/aws.ci.jenkins.io.yaml
-      key: $.profile::jenkinscontroller::jcasc.permanent_agents.s390x-agent.toolLocation[0].home
     scmid: default
 
 actions:


### PR DESCRIPTION
This change can replace #4840 to remove `mvn` tool installer from both controllers while keeping its custom definitions in cert.ci.jenkins.io: https://github.com/jenkins-infra/jenkins-infra/blob/9264111f4cbc76125b5c20b2f9ccd0165f804853/hieradata/clients/controller.cert.ci.jenkins.io.yaml#L34-L48

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5090#issuecomment-4389794022

> <img width="378" height="145" alt="image" src="https://github.com/user-attachments/assets/5f4208de-ace9-49c7-85d6-1b50e4c0d26a" />


<details><summary>Resulting tools.yaml:</summary>

```diff
tool:
  git:
    installations:
    - home: "git"
      name: "git-native"
    - name: "jgit"
  groovy:
    installations:
    - name: "groovy"
      properties:
      - installSource:
          installers:
          - groovyInstaller:
              id: "2.4.21"
  jdk:
    installations:
    - name: "jdk8"
      properties:
      - installSource:
          installers:

          - command:
              label: "(linux && amd64) || linux-amd64 || jdk8 || jdk-8 || maven-8"
              toolHome: "/opt/jdk-8"
              command: "echo /opt/jdk-8"

          - batchFile:
              label: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-8-windows"
              toolHome: "C:/Tools/jdk-8"
              command: "echo C:/Tools/jdk-8"

          - command:
              label: "(linux && arm64) || linux-arm64"
              toolHome: "/opt/jdk-8"
              command: "echo /opt/jdk-8"
    - name: "jdk11"
      properties:
      - installSource:
          installers:

          - command:
              label: "(linux && amd64) || linux-amd64 || jdk11 || jdk-11 || maven-11"
              toolHome: "/opt/jdk-11"
              command: "echo /opt/jdk-11"

          - batchFile:
              label: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-11-windows"
              toolHome: "C:/Tools/jdk-11"
              command: "echo C:/Tools/jdk-11"

          - command:
              label: "(linux && arm64) || linux-arm64"
              toolHome: "/opt/jdk-11"
              command: "echo /opt/jdk-11"

          - command:
              label: "s390x || s390xdocker"
              toolHome: "/opt/jdk-11"
              command: "echo /opt/jdk-11"
    - name: "jdk17"
      properties:
      - installSource:
          installers:

          - command:
              label: "(linux && amd64) || linux-amd64 || jdk17 || jdk-17 || maven-17"
              toolHome: "/opt/jdk-17"
              command: "echo /opt/jdk-17"

          - batchFile:
              label: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-17-windows"
              toolHome: "C:/Tools/jdk-17"
              command: "echo C:/Tools/jdk-17"

          - command:
              label: "(linux && arm64) || linux-arm64"
              toolHome: "/opt/jdk-17"
              command: "echo /opt/jdk-17"

          - command:
              label: "s390x || s390xdocker"
              toolHome: "/opt/jdk-17"
              command: "echo /opt/jdk-17"
    - name: "jdk21"
      properties:
      - installSource:
          installers:

          - command:
              label: "(linux && amd64) || linux-amd64 || jdk21 || jdk-21 || maven-21"
              toolHome: "/opt/jdk-21"
              command: "echo /opt/jdk-21"

          - batchFile:
              label: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-21-windows"
              toolHome: "C:/Tools/jdk-21"
              command: "echo C:/Tools/jdk-21"

          - command:
              label: "(linux && arm64) || linux-arm64"
              toolHome: "/opt/jdk-21"
              command: "echo /opt/jdk-21"

          - command:
              label: "s390x || s390xdocker"
              toolHome: "/opt/jdk-21"
              command: "echo /opt/jdk-21"
    - name: "jdk25"
      properties:
      - installSource:
          installers:

          - command:
              label: "(linux && amd64) || linux-amd64 || jdk25 || jdk-25 || maven-25"
              toolHome: "/opt/jdk-25"
              command: "echo /opt/jdk-25"

          - batchFile:
              label: "(windows && amd64) || windows-amd64 || windows-2019 || windows-2022 || windows-2025 || maven-25-windows"
              toolHome: "C:/Tools/jdk-25"
              command: "echo C:/Tools/jdk-25"

          - command:
              label: "(linux && arm64) || linux-arm64"
              toolHome: "/opt/jdk-25"
              command: "echo /opt/jdk-25"

          - command:
              label: "s390x || s390xdocker"
              toolHome: "/opt/jdk-25"
              command: "echo /opt/jdk-25"
-  maven:
-    installations:
-    - name: "mvn"
-      properties:
-      - installSource:
-          installers:
-          - maven:
-              id: "3.9.15"
```

</details>