### PR TITLE
feat(buildagent): install `mvn` if defined in `$tools_versions`

### DIFF
--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -153,6 +153,110 @@ class profile::buildagent (
         unless  => "/usr/bin/test -f ${java_bin} && ${java_bin} -version 2>&1 | /bin/grep --quiet '${jdk_version_to_check}'",
       }
     }
+
+    $maven_version = lookup('profile::jenkinscontroller::jcasc.tools_default_versions.maven', { default_value => undef })
+
+    if $maven_version {
+
+      $maven_major   = regsubst($maven_version, '^([0-9]+)\..*$', '\1')
+      $maven_archive = "apache-maven-${maven_version}-bin.tar.gz"
+
+      $base_url = "https://archive.apache.org/dist/maven/maven-${maven_major}/${maven_version}/binaries"
+
+      $maven_url       = "${base_url}/${maven_archive}"
+      $maven_checksum  = "${maven_url}.sha512"
+      $maven_signature = "${maven_url}.asc"
+
+      $maven_dir = "/usr/share/apache-maven-${maven_major}"
+      $maven_bin = "${maven_dir}/bin/mvn"
+
+      $temp_archive  = "/tmp/${maven_archive}"
+      $temp_checksum = "${temp_archive}.sha512"
+      $temp_sig      = "${temp_archive}.asc"
+      $maven_keys_file = '/tmp/maven-keys.gpg'
+
+      exec { 'Download Apache Maven key':
+        command => "/usr/bin/curl --silent --show-error --location https://downloads.apache.org/maven/KEYS --output ${maven_keys_file}",
+        creates => $maven_keys_file,
+        require => Package['curl'],
+        unless  => "/usr/bin/gpg --list-keys | /bin/grep 'Apache Maven'",
+      }
+
+      exec { 'Import Apache Maven key':
+        command => "/usr/bin/gpg --import ${maven_keys_file}",
+        require => [
+          Package['gpg'],
+          Exec['Download Apache Maven key'],
+        ],
+        unless  => "/usr/bin/gpg --list-keys | /bin/grep 'Apache Maven'",
+      }
+
+      exec { "Download Maven ${maven_version}":
+        command => "/usr/bin/curl --silent --show-error --location ${maven_url} --output ${temp_archive}",
+        require => Package['curl'],
+        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+      }
+
+      exec { "Download Maven ${maven_version} checksum":
+        command => "/usr/bin/curl --silent --show-error --location ${maven_checksum} --output ${temp_checksum}",
+        require => Package['curl'],
+        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+      }
+
+      exec { "Download Maven ${maven_version} signature":
+        command => "/usr/bin/curl --silent --show-error --location ${maven_signature} --output ${temp_sig}",
+        require => Package['curl'],
+        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+      }
+
+      exec { "Verify Maven ${maven_version} signature":
+        command => "/usr/bin/gpg --verify ${temp_sig}",
+        require => [
+          Exec['Import Apache Maven key'],
+          Exec["Download Maven ${maven_version}"],
+          Exec["Download Maven ${maven_version} signature"],
+        ],
+        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+      }
+
+      exec { "Verify Maven ${maven_version} checksum":
+        command => "/bin/bash -c \"echo \\$(cat ${temp_checksum})  ${temp_archive} | sha512sum --check\"",
+        cwd     => '/tmp',
+        require => [
+          Exec["Download Maven ${maven_version} checksum"],
+          Exec["Download Maven ${maven_version}"],
+        ],
+        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+      }
+
+      file { $maven_dir:
+        ensure => directory,
+        owner  => 'root',
+      }
+
+      exec { "Extract Maven ${maven_version}":
+        command => "/usr/bin/tar --extract --gunzip --file=${temp_archive} --directory=${maven_dir} --strip-components=1 && /usr/bin/rm -f ${temp_archive} ${temp_checksum} ${temp_sig}",
+        require => [
+          Exec["Verify Maven ${maven_version} signature"],
+          Exec["Verify Maven ${maven_version} checksum"],
+          File[$maven_dir],
+          Package['tar'],
+        ],
+        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+      }
+
+      file { '/etc/profile.d/maven.sh':
+        ensure  => file,
+        mode    => '0755',
+        content => "export PATH=${maven_dir}/bin:\$PATH\n",
+      }
+
+      file { '/etc/profile.d/java.sh':
+        ensure  => file,
+        mode    => '0755',
+        content => "export JAVA_HOME=/opt/jdk-21\nexport PATH=\$JAVA_HOME/bin:\$PATH\n",
+      }
+    }
   }
 
   # https://help.github.com/articles/what-are-github-s-ssh-key-fingerprints/

--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -154,7 +154,7 @@ class profile::buildagent (
       }
     }
 
-    $maven_version = lookup('profile::jenkinscontroller::jcasc.tools_default_versions.maven', { default_value => undef })
+    $maven_version = pick($tools_versions['maven'], undef)
 
     if $maven_version {
 
@@ -244,7 +244,6 @@ class profile::buildagent (
         ],
         unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
       }
-
     }
   }
 

--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -156,6 +156,8 @@ class profile::buildagent (
 
     if $tools_versions['maven'] {
 
+      $maven_version = $tools_versions['maven']
+
       $maven_major   = regsubst($maven_version, '^([0-9]+)\..*$', '\1')
       $maven_archive = "apache-maven-${maven_version}-bin.tar.gz"
 

--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -245,17 +245,6 @@ class profile::buildagent (
         unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
       }
 
-      file { '/etc/profile.d/maven.sh':
-        ensure  => file,
-        mode    => '0755',
-        content => "export PATH=${maven_dir}/bin:\$PATH\n",
-      }
-
-      file { '/etc/profile.d/java.sh':
-        ensure  => file,
-        mode    => '0755',
-        content => "export JAVA_HOME=/opt/jdk-21\nexport PATH=\$JAVA_HOME/bin:\$PATH\n",
-      }
     }
   }
 

--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -154,9 +154,7 @@ class profile::buildagent (
       }
     }
 
-    $maven_version = pick($tools_versions['maven'], undef)
-
-    if $maven_version {
+    if $tools_versions['maven'] {
 
       $maven_major   = regsubst($maven_version, '^([0-9]+)\..*$', '\1')
       $maven_archive = "apache-maven-${maven_version}-bin.tar.gz"

--- a/dist/profile/manifests/buildagent.pp
+++ b/dist/profile/manifests/buildagent.pp
@@ -194,19 +194,19 @@ class profile::buildagent (
       exec { "Download Maven ${maven_version}":
         command => "/usr/bin/curl --silent --show-error --location ${maven_url} --output ${temp_archive}",
         require => Package['curl'],
-        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+        unless  => "/usr/bin/test -f ${maven_bin} && JAVA_HOME=/opt/jdk-25 ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
       }
 
       exec { "Download Maven ${maven_version} checksum":
         command => "/usr/bin/curl --silent --show-error --location ${maven_checksum} --output ${temp_checksum}",
         require => Package['curl'],
-        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+        unless  => "/usr/bin/test -f ${maven_bin} && JAVA_HOME=/opt/jdk-25 ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
       }
 
       exec { "Download Maven ${maven_version} signature":
         command => "/usr/bin/curl --silent --show-error --location ${maven_signature} --output ${temp_sig}",
         require => Package['curl'],
-        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+        unless  => "/usr/bin/test -f ${maven_bin} && JAVA_HOME=/opt/jdk-25 ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
       }
 
       exec { "Verify Maven ${maven_version} signature":
@@ -216,7 +216,7 @@ class profile::buildagent (
           Exec["Download Maven ${maven_version}"],
           Exec["Download Maven ${maven_version} signature"],
         ],
-        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+        unless  => "/usr/bin/test -f ${maven_bin} && JAVA_HOME=/opt/jdk-25 ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
       }
 
       exec { "Verify Maven ${maven_version} checksum":
@@ -226,7 +226,7 @@ class profile::buildagent (
           Exec["Download Maven ${maven_version} checksum"],
           Exec["Download Maven ${maven_version}"],
         ],
-        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+        unless  => "/usr/bin/test -f ${maven_bin} && JAVA_HOME=/opt/jdk-25 ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
       }
 
       file { $maven_dir:
@@ -242,7 +242,7 @@ class profile::buildagent (
           File[$maven_dir],
           Package['tar'],
         ],
-        unless  => "/usr/bin/test -f ${maven_bin} && ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
+        unless  => "/usr/bin/test -f ${maven_bin} && JAVA_HOME=/opt/jdk-25 ${maven_bin} --version | /bin/grep --quiet '${maven_version}'",
       }
     }
   }

--- a/hieradata/clients/agent-2.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/agent-2.trusted.ci.jenkins.io.yaml
@@ -7,8 +7,6 @@ profile::buildagent::ssh_keys:
     type: ed25519
     key: AAAAC3NzaC1lZDI1NTE5AAAAIItJB1E9CwGG+/bVRToJAH0rdSKNnYmmnhskKwxPVD9u
 profile::buildagent::trusted_agent: true
-profile::buildagent::tools_versions:
-  maven: 3.9.15
 profile::awscli::version: 2.34.44
 profile::aznfs::mounts:
   - mountpoint: "/data-storage-jenkins-io"

--- a/hieradata/clients/agent-2.trusted.ci.jenkins.io.yaml
+++ b/hieradata/clients/agent-2.trusted.ci.jenkins.io.yaml
@@ -7,6 +7,8 @@ profile::buildagent::ssh_keys:
     type: ed25519
     key: AAAAC3NzaC1lZDI1NTE5AAAAIItJB1E9CwGG+/bVRToJAH0rdSKNnYmmnhskKwxPVD9u
 profile::buildagent::trusted_agent: true
+profile::buildagent::tools_versions:
+  maven: 3.9.15
 profile::awscli::version: 2.34.44
 profile::aznfs::mounts:
   - mountpoint: "/data-storage-jenkins-io"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -289,5 +289,7 @@ profile::openvpn::external_ips_vpn_restricted:
   eks_cijenkinsioagents2_1: 3.149.48.23
   eks_cijenkinsioagents2_2: 3.149.71.89
   usage.jenkins.io: 64.227.123.95
+profile::buildagent::tools_versions:
+  maven: 3.9.15
 apt::update:frequency: 'daily'
 # vim: ft=yaml ts=2 sw=2 nowrap et


### PR DESCRIPTION
This change ensures the default Maven version defined in `profile::jenkinscontroller::jcasc::tools_default_versions` is installed on `jenkins::agent` profile (ex: agent-2.trusted.ci.jenkins.io).

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5090#issuecomment-4398089621

### Testing done

```bash
$ vagrant up --provision jenkins::agent
$ vagrant ssh jenkins::agent
>> no serverspec defined for privateci
Last login: Thu May  7 18:40:06 2026 from 172.17.0.1
vagrant@db28cfe37370:~$ mvn --version
Apache Maven 3.9.15 (98b2cdbfdb5f1ac8781f537ea9acccaed7922349)
Maven home: /usr/share/apache-maven-3
Java version: 21.0.11, vendor: Eclipse Adoptium, runtime: /opt/jdk-21
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.12.76-linuxkit", arch: "aarch64", family: "unix"
vagrant@db28cfe37370:~$ echo $PATH
/usr/share/apache-maven-3/bin:/opt/jdk-21/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/opt/puppetlabs/bin
```