### PR TITLE
feat(agent-2.trusted.ci.jenkins.io) bump Maven to `3.9.16`

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -285,6 +285,6 @@ profile::openvpn::external_ips_vpn_restricted:
   eks_cijenkinsioagents2_2: 3.149.71.89
   usage.jenkins.io: 64.227.123.95
 profile::buildagent::tools_versions:
-  maven: 3.9.15
+  maven: 3.9.16
 apt::update:frequency: 'daily'
 # vim: ft=yaml ts=2 sw=2 nowrap et


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5125

Note: this change should have been part of #4861 , which was an automated `updatecli` PR. But we forgot to update the `updatecli` manifest tracking the Maven version in https://github.com/jenkins-infra/jenkins-infra/pull/4842.
Expect a quick PR to do this after this one is merged