### PR TITLE
Revert "Bump Packer Agent Templates (All-In-One) Version to 2.108.0"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -227,17 +227,17 @@ profile::jenkinscontroller::jcasc:
       registryMirror: https://dockerhubmirror.azurecr.io
   agent_images:
     ec2_amis:
-      ubuntu-22.04-amd64: ami-06a2abc537a049120
-      ubuntu-22.04-arm64: ami-0330ef98be0479e40
-      windows-2019-amd64: ami-00f1837b41290f5fe
-      windows-2022-amd64: ami-0dd9f1101f7275faf
-      windows-2025-amd64: ami-06fc7e29f2f7c3d4d
+      ubuntu-22.04-amd64: ami-00ca69f942b830ab4
+      ubuntu-22.04-arm64: ami-024c5036a7dfa28f6
+      windows-2019-amd64: ami-0cbf1e3dc587e1643
+      windows-2022-amd64: ami-084d8275d29d0ab4f
+      windows-2025-amd64: ami-0271ccb107c864969
     azure_vms_gallery_image:
-      version: 2.108.0
+      version: 2.107.0
       subscription_id: 1e7d5219-acbc-4495-8629-bdbb22e9b3ed
     container_images:
       # All in one image (same as VM templates)
-      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.108.0@sha256:5a2aca3344b562d204cf1a946606f8954c5457d9dbf0f1e4a6163382ca70b738
+      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.107.0@sha256:a6ed2d6e95aece979ec8d2bf8c5f51a186d267a488773ba28b29bcb30c65f415
       jnlp-packaging: jenkinsciinfra/packaging:latest
   tools_default_versions:
     jdk21:


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#4885 as it breaks NodeJS (Ref. https://github.com/jenkins-infra/helpdesk/issues/5093#issuecomment-4646255283)