### PR TITLE
feat(archives.jenkins.io) set up bandwidth rate limit to 10 Mb/s per virtual host

### DIFF
--- a/dist/profile/manifests/archives.pp
+++ b/dist/profile/manifests/archives.pp
@@ -2,10 +2,11 @@
 # Defines an archive server for serving all the archived historical releases
 #
 class profile::archives (
-  Array                $rsync_hosts_allow           = [],
-  Stdlib::Absolutepath $data_disk_mount             = '/srv',
-  Stdlib::Absolutepath $rsync_motd_file             = '/etc/jenkins.motd',
-  Array                $ssh_authorized_keys         = [],
+  Array                $rsync_hosts_allow            = [],
+  Stdlib::Absolutepath $data_disk_mount              = '/srv',
+  Stdlib::Absolutepath $rsync_motd_file              = '/etc/jenkins.motd',
+  Array                $ssh_authorized_keys          = [],
+  Integer              $bandwidth_per_vhost_in_bytes = 1024000, # Defaults to 10 Mb/s
 ) {
   include stdlib # Required to allow using stlib methods and custom datatypes
   include profile::apachemisc
@@ -177,6 +178,13 @@ Host ${$osuosl_mirroring['host']}
     require => Package['libapache2-mod-bw'],
   }
 
+  $mod_bw_config_fragment = "
+BandwidthModule On
+ForceBandWidthModule On
+Bandwidth all \"${bandwidth_per_vhost_in_bytes}\"
+
+"
+
   apache::vhost { "${archives_legacy_fqdn} unsecure":
     servername                   => $archives_legacy_fqdn,
     use_servername_for_filenames => true,
@@ -184,6 +192,7 @@ Host ${$osuosl_mirroring['host']}
     vhost_name                   => '*',
     port                         => 80,
     docroot                      => $archives_dir,
+    custom_fragment              => $mod_bw_config_fragment,
 
     access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_legacy_fqdn}/access_unsecured.log.%Y%m%d%H%M%S 604800",
     error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_legacy_fqdn}/error_unsecured.log.%Y%m%d%H%M%S 604800",
@@ -207,6 +216,7 @@ Host ${$osuosl_mirroring['host']}
     port                         => 443,
     ssl                          => true,
     docroot                      => $archives_dir,
+    custom_fragment              => $mod_bw_config_fragment,
 
     access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_legacy_fqdn}/access.log.%Y%m%d%H%M%S 604800",
     error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_legacy_fqdn}/error.log.%Y%m%d%H%M%S 604800",
@@ -226,6 +236,7 @@ Host ${$osuosl_mirroring['host']}
     use_port_for_filenames       => true,
     port                         => 80,
     docroot                      => $archives_dir,
+    custom_fragment              => $mod_bw_config_fragment,
 
     access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_fqdn}/access_unsecured.log.%Y%m%d%H%M%S 604800",
     error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_fqdn}/error_unsecured.log.%Y%m%d%H%M%S 604800",
@@ -246,6 +257,7 @@ Host ${$osuosl_mirroring['host']}
     port                         => 443,
     ssl                          => true,
     docroot                      => $archives_dir,
+    custom_fragment              => $mod_bw_config_fragment,
 
     access_log_pipe              => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_fqdn}/access.log.%Y%m%d%H%M%S 604800",
     error_log_pipe               => "|/usr/bin/rotatelogs -p ${profile::apachemisc::compress_rotatelogs_path} -t ${apache_log_dir_fqdn}/error.log.%Y%m%d%H%M%S 604800",

--- a/hieradata/clients/archives.do.jenkins.io.yaml
+++ b/hieradata/clients/archives.do.jenkins.io.yaml
@@ -2,6 +2,7 @@
 profile::archives::rsync_hosts_allow:
   - "0.0.0.0/0"
   - "::/0"
+profile::archives::bandwidth_per_vhost_in_bytes: 10240000 # 10 Mbits/s
 ## TODO: uncomment and add values from our mirrors to allow them to download data
 #   - localhost
 #   - archives.jenkins.io


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5163

This change enforces a 10 Mb per virtual host, worst case we'll end up in 20 Mb/s (see note below).

Notes:

- Even though we have 5 virtual hosts, only 2 can be really used in production:
    - The "default" virtual host can only be reached from the VM itself (using `localhost` hostname) of with invalid `Host` headers
    - The 2 vhosts on 80 port only triggers redirects
    - Leaving only archives.jenkins.io and archives.jenkins-ci.org (not redirected to archives.jenkins.io, could be nice to have but might have impacts)
- Vagrant honors the default 1 Mb/s of the modified `profile` but the value is parameterized (see the production 10 Mb override)
    -  Tested manually with a manual override on the Vagrant hieradata in `hieradata/vagrant/roles/archives.yaml`
- Tested locally with=
    - A 400 Mb `jenkins.war` pu in the `/srv/release` of the local Vagrant instance
    - With a `curl -kLvS -o /dev/null http://archives.jenkins.io/jenkins.war` from outside the VM (shows the download rate) which is less than 1s without this setup and is cap-ed at ~900 Kbit/s with the default setup to test individual request
    - An attack run with [`vegeta`](https://github.com/tsenart/vegeta) to test behavior with a **bunch** of requests: same rate limit as `curl` with 1200 req/s (around ~ 900 Mbits), no visible CPU overhead.