### PR TITLE
chore(ci.jenkins.io): try `infratest-windows` without Z: data disk

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -881,10 +881,10 @@ profile::jenkinscontroller::jcasc:
             ebsOptimized: true
             architecture: "amd64"
             javaHome: 'C:/tools/jdk-21'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            # Don't use local NVMe as data-root for docker
-            customDataDiskNotUsedForDocker: true
+            # # Utilizes the local NVMe mounted in Z:
+            # customDataDisk: 'Z:'
+            # # Don't use local NVMe as data-root for docker
+            # customDataDiskNotUsedForDocker: true
             remoteAdmin: jenkins
             labels:
               - infratest-windows


### PR DESCRIPTION
Trying to get more reliable docker controller builds, currently failing almost every time with `hcs::CreateComputeSystem be23e766abdf18dca7bbba96b10ffe79047b7462b9437f12f247dcebfe5f2b5f: Incorrect function` errors on Windows 2025 images built from a Windows 2025 agent.

Ref:
- https://github.com/jenkinsci/docker/pull/2370