### PR TITLE
chore(updatecli): track nodejs version in .nvmrc for consumer repos

### DIFF
--- a/updatecli/updatecli.d/nodejs-consumers.yaml.tpl
+++ b/updatecli/updatecli.d/nodejs-consumers.yaml.tpl
@@ -43,6 +43,16 @@ targets:
     spec:
       file: .tool-versions
       matchpattern: 'nodejs .*'
+{{ if $val.nvmrc }}
+  nvmrc:
+    name: Bump NodeJS version in {{ $val.repository }} .nvmrc
+    kind: file
+    sourceid: getNodeJSVersionFromPackerImages
+    scmid: default
+    spec:
+      file: .nvmrc
+      matchpattern: 'v?\d+\.\d+\.\d+'
+{{ end }}
 
 actions:
   default:

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -18,10 +18,12 @@ windowsVersions:
 
 nodejs_consumers:
   - repository: plugin-site
+    nvmrc: true
   - repository: contributor-spotlight
   - repository: stats.jenkins.io
   - repository: docs.jenkins.io
   - repository: stories
   - repository: jenkins-io-components
+    nvmrc: true
   - repository: gatsby-plugin-jenkins-layout
   - repository: incrementals-publisher


### PR DESCRIPTION
Ref: 
- https://github.com/jenkins-infra/helpdesk/issues/5175

Follow-up to #4895. We discovered some consumer repos also keep a `.nvmrc` as a contributor hint for the Node version in use, separate from `.tool-versions`. This extends the manifest to keep those in sync too.


### Testing

Local `updatecli diff` across all 8 repos: source resolves correctly (packer-image `2.110.0` -> nodejs `24.16.0`). `.tool-versions` already up to date everywhere; `.nvmrc` would be bumped for the two flagged repos with a clean single-line replace:

```diff
--- .nvmrc        (plugin-site)
+++ .nvmrc
@@ -1 +1 @@
-20.20.0
+24.16.0

--- .nvmrc        (jenkins-io-components)
+++ .nvmrc
@@ -1 +1 @@
-v18.13.0
+24.16.0

