### PR TITLE
chore(updatecli) remove repo name in update nodejs automated PR title

### DIFF
--- a/updatecli/updatecli.d/nodejs-consumers.yaml.tpl
+++ b/updatecli/updatecli.d/nodejs-consumers.yaml.tpl
@@ -34,7 +34,7 @@ sources:
 
 targets:
   default:
-    name: Bump NodeJS version in {{ $val.repository }} .tool-versions
+    name: Bump NodeJS version in .tool-versions
     kind: file
     sourceid: getNodeJSVersionFromPackerImages
     scmid: default
@@ -45,7 +45,7 @@ targets:
       matchpattern: 'nodejs .*'
 {{ if $val.nvmrc }}
   nvmrc:
-    name: Bump NodeJS version in {{ $val.repository }} .nvmrc
+    name: Bump NodeJS version in .nvmrc
     kind: file
     sourceid: getNodeJSVersionFromPackerImages
     scmid: default
@@ -58,7 +58,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump NodeJS version in {{ $val.repository }} .tool-versions
+    title: Bump NodeJS version to {{ source "getNodeJSVersionFromPackerImages" }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5175

This PR removes the redundant repo name in the 'Bump NodeJS version" automated updatecli PR

Tested locally with success

```
✔ Track NodeJS version from production agents in incrementals-publisher:
        Source:
                ✔ [getNodeJSVersionFromPackerImages] Get the NodeJS Linux version set in the production Packer images
                ✔ [getPackerImageDeployedVersion] Retrieve the current version of the Packer images used in production
        Target:
                ✔ [default] Bump NodeJS version in .tool-versions


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  8
  * Total:      8

4 action(s) to follow up:
  * https://github.com/jenkins-infra/plugin-site/pull/2553
  * https://github.com/jenkins-infra/stories/pull/405
  * https://github.com/jenkins-infra/jenkins-io-components/pull/207
  * https://github.com/jenkins-infra/incrementals-publisher/pull/126
```