### PR TITLE
feat(ci.jenkins.io) enable spot instances again + new instance size for Windows Spot

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -99,6 +99,10 @@ jenkins:
         remoteAdmin: "<%= $remoteAdmin %>"
         remoteFS: "<%= agent['customDataDisk'] ? agent['customDataDisk'] + '/agent' : (agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir']) %>"
         securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
+      <%- if agent['spot'] && $os == "windows" -%>
+        spotConfig:
+          useBidPrice: false
+      <%- end -%>
         stopOnTerminate: false
         subnetId: "<%= agent['subnetId'] ? agent['subnetId'] : (ec2_cloud_setup['subnetId'] ? ec2_cloud_setup['subnetId'] : "") %>"
         t2Unlimited: false
@@ -193,7 +197,7 @@ jenkins:
                 <%- if $remoteAdmin != 'Administrator' -%>
                 # Enable Developer mode to allow creating symlinks for non-admin users
                 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /v "AllowDevelopmentWithoutDevLicense" /t REG_DWORD /d 1 /f
-                
+
                   <%- if agent['customDataDisk'] -%>
                 # Set up Windows default Users profiles location to the custom data disk drive
                 $userpath = '<%= agent['customDataDisk'] %>\Users'

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -576,7 +576,7 @@ profile::jenkinscontroller::jcasc:
           # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
           - description: "Spot Windows 2019 x86_64 with JDK8"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -593,7 +593,7 @@ profile::jenkinscontroller::jcasc:
           # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
           - description: "Spot Windows 2019 x86_64 with JDK11"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -608,7 +608,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2019 x86_64 with JDK17"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -623,7 +623,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Nonspot Windows 2019 x86_64 with JDK17"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -638,7 +638,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2019 x86_64 with JDK21"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -671,7 +671,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2019 x86_64 with JDK25"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -701,7 +701,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2022 x86_64 with JDK17"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2022"
             ebsOptimized: true
@@ -724,7 +724,7 @@ profile::jenkinscontroller::jcasc:
           # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
           - description: "Spot Windows 2025 x86_64 with JDK8"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -743,7 +743,7 @@ profile::jenkinscontroller::jcasc:
           # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
           - description: "Spot Windows 2025 x86_64 with JDK11"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -760,7 +760,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2025 x86_64 with JDK17"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -796,7 +796,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2025 x86_64 with JDK21"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -837,7 +837,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2025 x86_64 with JDK25"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # See https://github.com/jenkins-infra/helpdesk/issues/5185
             os: "windows"
             os_version: "2025"
             ebsOptimized: true


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5185

This PR re-enable Spot for EC2 Windows agents in ci.jenkins.io which are set with `spot: true` in hieradata.

It also changes their instance size to `m8id.xlarge` (see issue on the reasoning) to get less reclaim