### PR TITLE
Revert "Bump Packer Agent Templates (All-In-One) Version to 2.112.0"

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -227,17 +227,17 @@ profile::jenkinscontroller::jcasc:
       registryMirror: https://dockerhubmirror.azurecr.io
   agent_images:
     ec2_amis:
-      ubuntu-22.04-amd64: ami-09e7b55b3eb2511e5
-      ubuntu-22.04-arm64: ami-02472065c9626dedf
-      windows-2019-amd64: ami-0709e196ef39ec63b
-      windows-2022-amd64: ami-08fc85321d40780b7
-      windows-2025-amd64: ami-0223a2d4a142d4062
+      ubuntu-22.04-amd64: ami-0571df73db04bb47e
+      ubuntu-22.04-arm64: ami-0aa893145b12032e0
+      windows-2019-amd64: ami-08cd25057a6374614
+      windows-2022-amd64: ami-03f677f1a5fedb29c
+      windows-2025-amd64: ami-0a4b3c47e75aa0cce
     azure_vms_gallery_image:
-      version: 2.112.0
+      version: 2.111.0
       subscription_id: 1e7d5219-acbc-4495-8629-bdbb22e9b3ed
     container_images:
       # All in one image (same as VM templates)
-      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.112.0@sha256:32f960735c7bc7dc3178ad850e4dbae2300209ccc218172e721b5e973e8953e6
+      jnlp-maven-all-in-one: jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.111.0@sha256:1196c8ddd455d5557bdff74d4a87bc2905e298951de2de367635b2e919caa5d0
       jnlp-packaging: jenkinsciinfra/packaging:latest
   tools_default_versions:
     jdk21:


### PR DESCRIPTION
Reverts jenkins-infra/jenkins-infra#4912

See https://github.com/jenkins-infra/packer-images/pull/2838#issuecomment-4753042211