### PR TITLE
feat(jenkins::controller/aws.ci.jenkins.io) Enable Spot for Windows EC2 agents only and use `m8id` family

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -101,7 +101,7 @@ jenkins:
         securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
       <%- if agent['spot'] -%>
         spotConfig:
-          fallbackToOndemand: true
+          fallbackToOndemand: false
           useBidPrice: false
       <%- end -%>
         stopOnTerminate: false

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -99,7 +99,7 @@ jenkins:
         remoteAdmin: "<%= $remoteAdmin %>"
         remoteFS: "<%= agent['customDataDisk'] ? agent['customDataDisk'] + '/agent' : (agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir']) %>"
         securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
-      <%- if agent['spot'] -%>
+      <%- if $os == "windows" && agent['spot'] -%>
         spotConfig:
           fallbackToOndemand: false
           useBidPrice: false

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -99,6 +99,11 @@ jenkins:
         remoteAdmin: "<%= $remoteAdmin %>"
         remoteFS: "<%= agent['customDataDisk'] ? agent['customDataDisk'] + '/agent' : (agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir']) %>"
         securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
+      <%- if agent['spot'] -%>
+        spotConfig:
+          fallbackToOndemand: true
+          useBidPrice: false
+      <%- end -%>
         stopOnTerminate: false
         subnetId: "<%= agent['subnetId'] ? agent['subnetId'] : (agent['spot'] ? ec2_cloud_setup['spotSubnetIds'] : ec2_cloud_setup['subnetIds']) %>"
         ## Availability zone are extrapolated from the subnet's implied zone. Do NOT specify both.

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -100,7 +100,9 @@ jenkins:
         remoteFS: "<%= agent['customDataDisk'] ? agent['customDataDisk'] + '/agent' : (agent['agentDir'] ? agent['agentDir'] : @jcasc['agents_setup'][$os]['agentDir']) %>"
         securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
         stopOnTerminate: false
-        subnetId: "<%= agent['subnetId'] ? agent['subnetId'] : (ec2_cloud_setup['subnetId'] ? ec2_cloud_setup['subnetId'] : "") %>"
+        subnetId: "<%= agent['subnetId'] ? agent['subnetId'] : (agent['spot'] ? ec2_cloud_setup['spotSubnetIds'] : ec2_cloud_setup['subnetIds']) %>"
+        ## Availability zone are extrapolated from the subnet's implied zone. Do NOT specify both.
+        # zone: ""
         t2Unlimited: false
         tags:
         - name: "architecture"
@@ -193,7 +195,7 @@ jenkins:
                 <%- if $remoteAdmin != 'Administrator' -%>
                 # Enable Developer mode to allow creating symlinks for non-admin users
                 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /v "AllowDevelopmentWithoutDevLicense" /t REG_DWORD /d 1 /f
-                
+
                   <%- if agent['customDataDisk'] -%>
                 # Set up Windows default Users profiles location to the custom data disk drive
                 $userpath = '<%= agent['customDataDisk'] %>\Users'

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -355,8 +355,10 @@ profile::jenkinscontroller::jcasc:
         sshKeysCredentialsId: "ec2-agent-ssh"
         # TODO: maintain with updatecli
         securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
-        # TODO: maintain with updatecli
-        subnetId: "subnet-0095ee74f5cd48290"
+        # TODO: maintain with updatecli (set up in https://github.com/jenkins-infra/terraform-aws-sponsorship/blob/main/outputs.tf to use https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json)
+        subnetIds: "subnet-0095ee74f5cd48290"
+        # TODO: maintain with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+        spotSubnetIds: "subnet-0f76ffb1385bec3db, subnet-0cbf5a4a8a81322f5, subnet-0095ee74f5cd48290"
         # TODO: maintain with updatecli
         registryMirror: "k8s-hubmirro-hubmirro-477f7dfd76-9bbe4e560ee83036.elb.us-east-2.amazonaws.com:5000"
         agent_definitions:

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -578,7 +578,7 @@ profile::jenkinscontroller::jcasc:
           # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
           - description: "Spot Windows 2019 x86_64 with JDK8"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -595,7 +595,7 @@ profile::jenkinscontroller::jcasc:
           # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
           - description: "Spot Windows 2019 x86_64 with JDK11"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -610,7 +610,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2019 x86_64 with JDK17"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -640,7 +640,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2019 x86_64 with JDK21"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -673,7 +673,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2019 x86_64 with JDK25"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -703,7 +703,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2022 x86_64 with JDK17"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2022"
             ebsOptimized: true
@@ -726,7 +726,7 @@ profile::jenkinscontroller::jcasc:
           # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
           - description: "Spot Windows 2025 x86_64 with JDK8"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -745,7 +745,7 @@ profile::jenkinscontroller::jcasc:
           # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
           - description: "Spot Windows 2025 x86_64 with JDK11"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -762,7 +762,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2025 x86_64 with JDK17"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -798,7 +798,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2025 x86_64 with JDK21"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -839,7 +839,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2025 x86_64 with JDK25"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -877,7 +877,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Windows Infra Test"
             maxInstances: 5
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
             os: "windows"
             os_version: "2025"
             ebsOptimized: true

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -121,7 +121,8 @@ profile::jenkinscontroller::jcasc:
         useInstanceProfileForCredentials: true
         sshKeysCredentialsId: "ec2-agent-ssh"
         securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
-        subnetId: "subnet-0138ee90cd53d58f7"
+        subnetIds: "subnet-on-demand-xxx"
+        spotSubnetIds: "subnet-spot-1-xxx, subnet-spot-2-xxx"
         registryMirror: "urltodockerproxy:5000"
         agent_definitions:
           - description: "ARM64 ubuntu 22.04"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5185#issuecomment-4745430696

New take after #4908 (which was reverted by #4909)

Tested with:

- Local Vagrant which shows the new "spot subnets" and spot setup enabled (with no fallback to on demand) for spot enabled hieradata templates
- Manually tested the setup on ci.jenkins.io using `infra-test`