### PR TITLE
fix(cijenkinsio/EC2-windows-agents) fine tune spot setup and remove deprecated templates

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb
@@ -101,7 +101,7 @@ jenkins:
         securityGroups: "<%= agent['securityGroups'] ? agent['securityGroups'] : (ec2_cloud_setup['securityGroups'] ? ec2_cloud_setup['securityGroups'] : "") %>"
       <%- if $os == "windows" && agent['spot'] -%>
         spotConfig:
-          fallbackToOndemand: false
+          fallbackToOndemand: true
           useBidPrice: false
       <%- end -%>
         stopOnTerminate: false

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -576,7 +576,7 @@ profile::jenkinscontroller::jcasc:
           ####
           - description: "Spot Windows 2019 x86_64 with JDK25"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
+            instanceType: "r8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -608,7 +608,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2022 x86_64 with JDK25"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
+            instanceType: "r8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2022"
             ebsOptimized: true
@@ -644,7 +644,7 @@ profile::jenkinscontroller::jcasc:
           ###
           - description: "Spot Windows 2025 x86_64 with JDK8"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
+            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -661,7 +661,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2025 x86_64 with JDK11"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
+            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2025"
             ebsOptimized: true

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -574,106 +574,9 @@ profile::jenkinscontroller::jcasc:
           ####
           # Windows VMs
           ####
-          ## TODO: deprecate JDK8 Windows?
-          # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
-          - description: "Spot Windows 2019 x86_64 with JDK8"
-            maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "windows"
-            os_version: "2019"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-8'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2019-amd64-maven-8
-            spot: true
-            acpServerId: aws-internal
-          ## TODO: deprecate JDK11 Windows?
-          # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
-          - description: "Spot Windows 2019 x86_64 with JDK11"
-            maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "windows"
-            os_version: "2019"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-11'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2019-amd64-maven-11
-            spot: true
-            acpServerId: aws-internal
-          - description: "Spot Windows 2019 x86_64 with JDK17"
-            maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "windows"
-            os_version: "2019"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-17'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2019-amd64-maven-17
-            spot: true
-            acpServerId: aws-internal
-          - description: "Nonspot Windows 2019 x86_64 with JDK17"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "windows"
-            os_version: "2019"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-17'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2019-amd64-maven-17-nonspot
-            spot: false
-            acpServerId: aws-internal
-          - description: "Spot Windows 2019 x86_64 with JDK21"
-            maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "windows"
-            os_version: "2019"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-21'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2019-amd64-maven-21
-              # Label(s) indicating default VM templates
-              - docker-windows-2019
-              - win-2019
-            spot: true
-            acpServerId: aws-internal
-          - description: "Nonspot Windows 2019 x86_64 with JDK21"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "windows"
-            os_version: "2019"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-21'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2019-amd64-maven-21-nonspot
-            spot: false
-            acpServerId: aws-internal
           - description: "Spot Windows 2019 x86_64 with JDK25"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -684,11 +587,12 @@ profile::jenkinscontroller::jcasc:
             remoteAdmin: jenkins
             labels:
               - win-2019-amd64-maven-25
+              - docker-windows-2019
             spot: true
             acpServerId: aws-internal
           - description: "Nonspot Windows 2019 x86_64 with JDK25"
             maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2019"
             ebsOptimized: true
@@ -699,34 +603,48 @@ profile::jenkinscontroller::jcasc:
             remoteAdmin: jenkins
             labels:
               - win-2019-amd64-maven-25-nonspot
+              - docker-windows-2019-nonspot
             spot: false
             acpServerId: aws-internal
-          - description: "Spot Windows 2022 x86_64 with JDK17"
+          - description: "Spot Windows 2022 x86_64 with JDK25"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2022"
             ebsOptimized: true
             architecture: "amd64"
-            javaHome: 'C:/tools/jdk-17'
+            javaHome: 'C:/tools/jdk-25'
             # Utilizes the local NVMe mounted in Z:
             customDataDisk: 'Z:'
             remoteAdmin: jenkins
             labels:
-              - win-2022-amd64-maven-17
+              - win-2022-amd64-maven-25
               # Label(s) indicating default VM templates
               - docker-windows-2022
               - win-2022
             spot: true
             acpServerId: aws-internal
+          - description: "NonSpot Windows 2022 x86_64 with JDK25"
+            maxInstances: 50
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
+            os: "windows"
+            os_version: "2022"
+            ebsOptimized: true
+            architecture: "amd64"
+            javaHome: 'C:/tools/jdk-25'
+            # Utilizes the local NVMe mounted in Z:
+            customDataDisk: 'Z:'
+            remoteAdmin: jenkins
+            labels:
+              - win-2022-amd64-maven-25-nonspot
+            spot: true
+            acpServerId: aws-internal
           ###
           # Windows 2025 VM
           ###
-          ## TODO: deprecate JDK8 Windows?
-          # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
           - description: "Spot Windows 2025 x86_64 with JDK8"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -741,11 +659,9 @@ profile::jenkinscontroller::jcasc:
               - maven-8-windows
             spot: true
             acpServerId: aws-internal
-          ## TODO: deprecate JDK11 Windows?
-          # Do we still have consumers of this JDK on ci.jenkins.io? Time for a scream test?
           - description: "Spot Windows 2025 x86_64 with JDK11"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -762,7 +678,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2025 x86_64 with JDK17"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -798,7 +714,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2025 x86_64 with JDK21"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2025"
             ebsOptimized: true
@@ -815,9 +731,6 @@ profile::jenkinscontroller::jcasc:
               - maven-21-windows
               - docker-windows
               - maven-windows
-              # Placeholder label to fill a hole
-              # See https://github.com/jenkins-infra/acceptance-tests/pull/48#issuecomment-3810490237
-              - nonspot
             spot: true
             acpServerId: aws-internal
           - description: "Nonspot Windows 2025 x86_64 with JDK21"
@@ -839,7 +752,7 @@ profile::jenkinscontroller::jcasc:
             acpServerId: aws-internal
           - description: "Spot Windows 2025 x86_64 with JDK25"
             maxInstances: 50
-            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
+            instanceType: "m8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
             os: "windows"
             os_version: "2025"
             ebsOptimized: true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5185#issuecomment-4770406571

- Removed the Windows 2019/2022 templates which are not using JDK25
- Ensured that Windows 22 has a nonspot template
- Spread the Windows Spot to other instance types with close prices (to limit capacity issues)
- Enable fallback to ondemand