### PR TITLE
fix(ci.jenkins.io/jenkins::controller) on container agents, mount the whole HOMEDIR/.m2 into an emptyDir

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-kubernetes.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-kubernetes.yaml.erb
@@ -136,9 +136,9 @@ jenkins:
               mountPath: "<%= agent['m2Repository'] %>"
           <%- else -%>
             <%- if $os == "windows" -%>
-              mountPath: "C:/Users/<%= @jcasc['agents_setup'][$os]['remoteAdmin'] %>/.m2/repository"
+              mountPath: "C:/Users/<%= @jcasc['agents_setup'][$os]['remoteAdmin'] %>/.m2"
             <%- else -%>
-              mountPath: "/home/<%= @jcasc['agents_setup'][$os]['remoteAdmin'] %>/.m2/repository"
+              mountPath: "/home/<%= @jcasc['agents_setup'][$os]['remoteAdmin'] %>/.m2"
             <%- end -%>
           <%- end -%>
           <%- if agent['additionalPVCs'] -%>


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5193#issuecomment-4787320063

This PR mounts the parent directory of the "M2_REPO" (aka `$HOME/.m2/repository`).

I have not found any immediate cases where it could bite us in https://github.com/search?q=org%3Ajenkins-infra+.m2%2Frepository&type=code&p=1 and https://github.com/search?q=org%3Ajenkinsci+.m2%2Frepository&type=code.

I can't find why we did it that way: my guess is that we initially misunderstood the way Config File provider is used to provide a custom `settings.xml` but it's never in $HOME/.m2 so we should be fine.