### PR TITLE
fix(jenkinscontroller) ensure plugins autodetection works as expected and avoid empty element in `docker run`

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -384,13 +384,13 @@ class profile::jenkinscontroller (
       'LANG=C.UTF-8', # For context, cfr https://github.com/jenkinsci/docker/pull/1194
       "PATH=${final_container_path}",
       $kubeconfig_envvar_value,
-    ].map |$item| { if $item != '' { $item } },
+    ].filter |$item| { $item != '' },
     ports            => ['8080:8080', '50000:50000'],
     volumes          => concat([
       "${jenkins_home}:/var/jenkins_home:rw"],
       $awscli_container_volume,
       $kubeconfig_container_volume,
-    ).map |$item| { if $item != '' { $item } },
+    ).filter |$item| { $item != '' },
     pull_on_start    => true,
     require          => [
       File[$jenkins_home],
@@ -413,21 +413,13 @@ class profile::jenkinscontroller (
     'workflow-aggregator' => 'global_libraries',
   }
 
-  $all_plugins = ($plugins + $known_plugins_configs.keys).unique.map |$plugin| {
-    # If the specified plugin is in our "known" list and has a config then we want it
-    if $known_plugins_configs.get($plugin, false) {
-      if $jcasc_final_config.get($known_plugins_configs[$plugin],false) or
-      # If the user specified the plugin: return it early because they want it
-      ($plugin in $plugins) {
-        $plugin
-      } else {
-        break()
-      }
-    } else {
-      # Return the plugin if not in our "known list"
-      $plugin
-    }
-  }.sort
+  # Auto-detect plugins by checking the known JCasC directives in the resolved hieradata tree
+  $autodetected_plugins = $known_plugins_configs.keys.filter |$plugin| {
+    $jcasc_final_config.get($known_plugins_configs[$plugin], false)
+  }
+
+  # Merge autodetected plugins with user-specified and avoid duplicates
+  $all_plugins = ($plugins + $autodetected_plugins).sort.unique
 
   $all_plugins.each |$plugin| {
     exec { "install-plugin-${plugin}":

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -74,8 +74,8 @@ profile::jenkinscontroller::jcasc:
             domainCredentials:
               - credentials:
                 - basicSSHUserPrivateKey:
-                    description: "Dummy (e.g. not working, clear value) SSH key for s390x"
-                    id: "jenkins-s390x"
+                    description: "Dummy (e.g. not working, clear value) SSH key"
+                    id: "dummy-ssh-jenkins"
                     privateKeySource:
                       directEntry:
                         privateKey: "DummyValueOnlyForTestingNotASecurityIssue"
@@ -121,7 +121,7 @@ profile::jenkinscontroller::jcasc:
       mode: EXCLUSIVE
       ssh:
         host: "148.100.84.76"
-        credentialsId: "jenkins-s390x"
+        credentialsId: dummy-ssh-jenkins
         hostKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIaGnnWz9Q/MvlscCUZslFxH8JJ01OQ6FXyuQMQWVuNe"
       envVars:
         PATH+MAVEN: /home/jenkins/tools/apache-maven-3.9.15/bin

--- a/spec/classes/profile/jenkinscontroller_spec.rb
+++ b/spec/classes/profile/jenkinscontroller_spec.rb
@@ -37,8 +37,6 @@ describe "profile::jenkinscontroller" do
           :pull_on_start => true,
           :volumes => [
             "/var/lib/jenkins:/var/jenkins_home:rw",
-            nil,
-            nil,
           ],
         })
       end
@@ -100,7 +98,6 @@ describe "profile::jenkinscontroller" do
         :volumes => [
           "/var/lib/jenkins:/var/jenkins_home:rw",
           "/var/awscli:/var/awscli:ro",
-          nil,
         ],
         :env => [
           "HOME=/var/jenkins_home",
@@ -109,7 +106,6 @@ describe "profile::jenkinscontroller" do
           "JENKINS_OPTS=--httpKeepAliveTimeout=60000",
           "LANG=C.UTF-8",
           "PATH=/var/awscli/v2/current/bin:/opt/java/openjdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-          nil,
         ],
       })
     end
@@ -139,7 +135,6 @@ describe "profile::jenkinscontroller" do
         :pull_on_start => true,
         :volumes => [
           "/var/lib/jenkins:/var/jenkins_home:rw",
-          nil,
           "/var/jenkins_kubeconfigs:/var/jenkins_kubeconfigs:ro",
         ],
         :env => [


### PR DESCRIPTION
Following up #4934 , I realized that instead of using the `map` lambda (ref. https://www.puppet.com/docs/puppet/6/function.html#map) which results in arrays with `nil` elements, we could use the `filter` lambda (ref. https://www.puppet.com/docs/puppet/6/function.html#filter).


It fixes 2 elements:

- (major) autodetection of plugins, which removed some detected plugins when sorting/removing duplicates
- (nit) avoids empty elements in the `env` and `volumes` arrays passed to docker run. Also unit tests have been updated for clarity