### PR TITLE
feat(jenkinscontroller) add support of the ec2-fleet plugin

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,16 @@ Vagrant.configure("2") do |config|
         end
 
         config.vm.define(veggie) do |node|
-            # https://www.vagrantup.com/docs/provisioning/puppet_apply
+            # TODO: move this to puppet instead
+            if veggie == "jenkins::controller"
+                secret_env_vars = {JENKINS_EC2_FLEET_AWS_SECRET_KEY:ENV['JENKINS_EC2_FLEET_AWS_SECRET_KEY']}
+                node.vm.provision "shell" do |shell|
+                    shell.path = './scripts/write-secrets.sh'
+                    shell.args = secret_env_vars.keys.join(" ")
+                    shell.env = secret_env_vars
+                end
+            end
+
             node.vm.provision "puppet" do |puppet|
                 puppet.binary_path = "/opt/puppetlabs/bin"
                 puppet.module_path = ["dist","modules"]

--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -189,6 +189,8 @@ class profile::jenkinscontroller (
       'jenkinscontroller/casc/clouds-azurevm.yaml.erb',
       # Opt-out of all agent clouds with `profile::jenkinscontroller::jcasc.cloud_agents.ec2.disabled: true` or `profile::jenkinscontroller::jcasc.cloud_agents.ec2: {}`
       'jenkinscontroller/casc/clouds-ec2.yaml.erb',
+      # Opt-out of all agent clouds with `profile::jenkinscontroller::jcasc.cloud_agents.eC2Fleet.disabled: true` or `profile::jenkinscontroller::jcasc.cloud_agents.eC2Fleet: {}`
+      'jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb',
       # Opt-out of all agent clouds with `profile::jenkinscontroller::jcasc.cloud_agents.kubernetes.disabled: true` or `profile::jenkinscontroller::jcasc.cloud_agents.kubernetes: {}`
       'jenkinscontroller/casc/clouds-kubernetes.yaml.erb',
       # Opt-out with `profile::jenkinscontroller::jcasc.global_libraries: false`
@@ -360,6 +362,18 @@ class profile::jenkinscontroller (
     $kubeconfig_envvar_value = ''
   }
 
+  if $jcasc_final_config.get('cloud_agents.eC2Fleet.awsAccessKeyId', false) {
+    $env_aws_access_key_id = "AWS_ACCESS_KEY_ID=${$jcasc_final_config['cloud_agents']['eC2Fleet']['awsAccessKeyId']}"
+  } else {
+    $env_aws_access_key_id = ''
+  }
+
+  if $jcasc_final_config.get('cloud_agents.eC2Fleet.awsSecretKeyEnvName', false) {
+    $extra_env_aws_secret_access_key = " -e AWS_SECRET_ACCESS_KEY=`cat /var/run/jenkins-secrets/${jcasc_final_config['cloud_agents']['eC2Fleet']['awsSecretKeyEnvName']}`"
+  } else {
+    $extra_env_aws_secret_access_key = ''
+  }
+
   docker::run { $docker_container_name:
     memory_limit     => $memory_limit,
     image            => "${docker_image}:${docker_tag}",
@@ -369,7 +383,7 @@ class profile::jenkinscontroller (
     # actually map the UIDs properly. Using the extra_parameters option because
     # the `username` parameter will get shellescaped in the docker_run_flags()
     # function provided by garethr/docker
-    extra_parameters => '-u `id -u jenkins`:`id -g jenkins`',
+    extra_parameters => "-u `id -u jenkins`:`id -g jenkins`${extra_env_aws_secret_access_key}",
     # Hard-coding some environment variables because there is no "parent" shell
     # environment to inherit some of these environment settings from.
     # Additionally, Jenkins picks up `user.home` as "?" without the explicit
@@ -384,6 +398,7 @@ class profile::jenkinscontroller (
       'LANG=C.UTF-8', # For context, cfr https://github.com/jenkinsci/docker/pull/1194
       "PATH=${final_container_path}",
       $kubeconfig_envvar_value,
+      $env_aws_access_key_id,
     ].filter |$item| { $item != '' },
     ports            => ['8080:8080', '50000:50000'],
     volumes          => concat([
@@ -406,6 +421,7 @@ class profile::jenkinscontroller (
     'configuration-as-code' => 'enabled',
     'datadog' => 'datadog',
     'ec2' => 'cloud_agents.ec2',
+    'ec2-fleet' => 'cloud_agents.eC2Fleet',
     'kubernetes' => 'cloud_agents.kubernetes',
     'pipeline-graph-view' => 'appearance.pipeline_graph_view',
     'ssh-slaves' => 'permanent_agents',

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
@@ -1,0 +1,57 @@
+
+<%- if @jcasc['cloud_agents'] && @jcasc['cloud_agents']['disabled'].to_s != "true" && @jcasc['cloud_agents']['eC2Fleet'] && @jcasc['cloud_agents']['eC2Fleet']['fleets'] -%>
+jenkins:
+  clouds:
+  <%- @jcasc['cloud_agents']['eC2Fleet']['fleets'].each do |eC2Fleet_cloud_setup| -%>
+    <%- eC2Fleet_cloud_setup['jdks'].each do |jdkMajorVersion| -%>
+      <%- $fleetName = (eC2Fleet_cloud_setup['spot'] ? "spot-" : "") -%>
+      <%- $fleetName += eC2Fleet_cloud_setup['os'] + "_" + eC2Fleet_cloud_setup['osVersion'].to_s + "-" -%>
+      <%- $fleetName += (eC2Fleet_cloud_setup['architecture'] ? eC2Fleet_cloud_setup['architecture'] + "-" : "") -%>
+      <%- $fleetName += (eC2Fleet_cloud_setup['customName'] ? eC2Fleet_cloud_setup['customName'] + "-" : "") -%>
+      <%- $fleetName += "jdk" + jdkMajorVersion.to_s -%>
+  - eC2Fleet:
+      addNodeOnlyIfRunning: false
+      alwaysReconnect: true
+      cloudStatusIntervalSec: 10
+      computerConnector:
+        sSHConnector:
+          credentialsId: "<%= @jcasc['cloud_agents']['eC2Fleet']['sshCredential'] %>"
+          javaPath: "<%= @jcasc['agents_setup'][eC2Fleet_cloud_setup['os']]['agentJavaBin'] %>"
+          jvmOptions: "-XX:+PrintCommandLineFlags"
+          launchTimeoutSeconds: 60
+          maxNumRetries: 10
+          retryWaitTime: 15
+          port: 22
+          sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+      disableTaskResubmit: false
+      executorScaler: "noScaler"
+      fleet: "ci-jenkins-io-<%= $fleetName %>"
+      fsRoot: "<%= eC2Fleet_cloud_setup['os'] == "windows" ? "Z:/agent" : "/home/jenkins/agent" %>"
+      idleMinutes: 0
+      initOnlineCheckIntervalSec: 15
+      initOnlineTimeoutSec: 240
+      <%- $labels = [$fleetName] -%>
+      <%- if eC2Fleet_cloud_setup['autoDefaultOSLabel'] && (eC2Fleet_cloud_setup['jdks'].length== 1 || jdkMajorVersion == eC2Fleet_cloud_setup['defaultJdk']) -%>
+        <%- $labels += [eC2Fleet_cloud_setup['os'] + "-" + eC2Fleet_cloud_setup['osVersion'].to_s] -%>
+      <%- end -%>
+      <%- if eC2Fleet_cloud_setup['autoMavenLabels'] -%>
+        <%- $labels += ["maven-" + jdkMajorVersion.to_s + (eC2Fleet_cloud_setup['os'] == "windows" ? "-windows" : "")] -%>
+      <%- end -%>
+      <%- if eC2Fleet_cloud_setup['customLabels'] -%>
+        <%- $labels += [eC2Fleet_cloud_setup['customLabels']] -%>
+      <%- end -%>
+      labelString: "<%= $labels.join(" ") %>"
+      maxSize: 20
+      maxTotalUses: -1
+      minSize: 0
+      minSpareSize: 0
+      name: "<%= $fleetName %>"
+      noDelayProvision: false
+      numExecutors: 1
+      privateIpUsed: true
+      region: "<%= @jcasc['cloud_agents']['eC2Fleet']['region'] %>"
+      restrictUsage: true
+      scaleExecutorsByWeight: false
+    <%- end -%>
+  <%- end -%>
+<%- end -%>

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
@@ -1,4 +1,3 @@
-
 <%- if @jcasc['cloud_agents'] && @jcasc['cloud_agents']['disabled'].to_s != "true" && @jcasc['cloud_agents']['eC2Fleet'] && @jcasc['cloud_agents']['eC2Fleet']['fleets'] -%>
 jenkins:
   clouds:

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -348,6 +348,19 @@ profile::jenkinscontroller::jcasc:
               - claimName: ci-jenkins-io-maven-cache
                 mountPath: "/cache"
                 readOnly: true
+    eC2Fleet:
+      sshCredential: ec2-agent-ssh
+      region: us-east-2
+      fleets:
+        - customName: "infratest"
+          os: windows
+          osVersion: 2025
+          jdks: [25]
+          spot: true
+          maxSize: 10
+          autoMavenLabels: false
+          autoDefaultOSLabel: false
+          customLabels: windows-infratest
     ec2:
       aws-us-east-2:
         region: us-east-2
@@ -834,6 +847,7 @@ profile::jenkinscontroller::plugins:
   - dark-theme # Dark theme
   - docker-workflow # Provides the "withDockerContainer" pipeline keyword
   - ec2 # For Jenkins EC2 VM agents
+  - ec2-fleet # For Jenkins EC2 VM agents too (but better)
   - embeddable-build-status # https://github.com/jenkins-infra/helpdesk/issues/3013
   - git # Used for... git
   - git-forensics # Discovering reference builds, used in buildPlugin

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -127,6 +127,58 @@ profile::jenkinscontroller::jcasc:
         PATH+MAVEN: /home/jenkins/tools/apache-maven-3.9.15/bin
         JAVA_HOME: /opt/jdk-21
   cloud_agents:
+    ## IMPORTANT for EC2Fleet: JCasC (and controller) fails to load if the specified fleets are not mapped to a real AWS ASG/Fleet. \
+    ## As such a valid AWS credential is required and passed through the local environment variable `JENKINS_EC2_FLEET_AWS_SECRET_KEY` read by Vagrant. \
+    ## Alternatively you can comment out the EC2Fleet block above. Remember: no credential in persistant files on your machine!
+    eC2Fleet:
+      sshCredential: dummy-ssh-jenkins
+      region: us-east-2
+      # Value from https://github.com/jenkins-infra/terraform-states/tree/main/aws-sponsored (terraform output ec2fleet_vagrant_access_key_id)
+      awsAccessKeyId: AKIAUYEMYSOUPYWXMAON
+      # Read by vagrant. Environment variable value from https://github.com/jenkins-infra/terraform-states/tree/main/aws-sponsored (terraform output ec2fleet_vagrant_access_key_secret_access_key)
+      awsSecretKeyEnvName: JENKINS_EC2_FLEET_AWS_SECRET_KEY # Passed by Vagrant as an env. var
+      fleets:
+        - os: windows
+          osVersion: 2025
+          jdks: [8,11,17,21,25]
+          defaultJdk: 25
+          spot: true
+          maxSize: 50
+          autoMavenLabels: true
+          autoDefaultOSLabel: true
+        - customName: "infratest"
+          os: windows
+          osVersion: 2025
+          jdks: [25]
+          spot: true
+          maxSize: 10
+          autoMavenLabels: false
+          autoDefaultOSLabel: false
+          customLabels: windows-infratest
+        - os: windows
+          osVersion: 2022
+          jdks: [25]
+          spot: true
+          maxSize: 20
+          autoDefaultOSLabel: true
+        - os: windows
+          osVersion: 2019
+          jdks: [25]
+          spot: true
+          maxSize: 20
+          autoDefaultOSLabel: true
+        ## Not supported yet, but gives and idea of the data structure
+        # - os: ubuntu
+        #   osVersion: 22.04
+        #   jdks: ["8","11","17","21","25"]
+        #   spot: true
+        #   maxSize: 50
+        # - os: ubuntu
+        #   osVersion: 22.04
+        #   jdks: [25"]
+        #   spot: true
+        #   architecture: arm64
+        #   maxSize: 20
     ec2:
       aws-us-east-2:
         region: us-east-2

--- a/scripts/write-secrets.sh
+++ b/scripts/write-secrets.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Avoid debug mode (as it would print the secret value to stderr)
+set -eu -o pipefail
+
+secrets_host_dir=/var/run/jenkins-secrets
+# TODO: move to puppet to avoid having to write the custom GID of the "jenkins" group in advance
+owners="root:1001"
+
+mkdir -p "${secrets_host_dir}"
+
+chown "${owners}" "${secrets_host_dir}"
+chmod 0750 "${secrets_host_dir}"
+
+for secret in "$@"
+do
+  secret_file="${secrets_host_dir}"/"${secret}"
+  touch "${secret_file}"
+  chown "${owners}" "${secret_file}"
+  chmod 0640 "${secret_file}"
+
+  echo "${!secret}" > "${secret_file}"
+done


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5202

Requires:
- #4934 and #4936 to ensure puppet manages the new plugin properly without weird bugs
- https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/547 to ensure we have the ASG `windows-infratest`
- terraform-state AWS credential with readonly permission: https://github.com/jenkins-infra/terraform-states/commit/628e61aaa247a77f03dd6b982b4a8cffd543c494

This PR introduces support of EC2 fleet plugin as a Jenkins cloud with the following important notes:

- ⚠️ The EC2 Fleet plugin, when set up through JCasC, must specify only valid ASG or fleets otherwise it fails to instantiate and makes JCasC and further controller restarts to FAIL.
  - ASG must exist or be commented in hieradata (hence https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/547 as a prerequisite and now Ubuntu fleets for now)
  - It also requires a valid AWS authentication (see below) EVEN on the local Vagrant setup.
- Authentication with AWS API: we have 2 distinct cases:
  - On ci.jenkins.io (production), the controller already set up with an instance profile and the associated full permissions (as already verified in the PoC: https://github.com/jenkins-infra/helpdesk/issues/5202#issuecomment-4809693165). Nothing changed in this PR as we don't plan to set up any explicit Jenkins credential.
  - On the local vagrant setup, we will use the usual AWS client-side `AWS_*` environment variables passed to the controller container. As we don't want to persist these values in a file, Vagrant now expects the environment variable `JENKINS_EC2_FLEET_AWS_SECRET_KEY` to be set when called and it will write its value in `/var/run/jenkins-secrets` which is owned by `root` and only readable by the `jenkins` group in the Vagrant VM (which is considered not "that much" persistent.
    - As an additional layer of protection in case we expose this secret API key, the associated permissions are only the subset of `Describe*` and `List*`