### PR TITLE
 fix(jenkinscontroller) EC2Fleet: specify maxSize from hieradata or default to 1 and force ephemeral agent (no reuse)

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
@@ -40,8 +40,9 @@ jenkins:
         <%- $labels += [eC2Fleet_cloud_setup['customLabels']] -%>
       <%- end -%>
       labelString: "<%= $labels.join(" ") %>"
-      maxSize: 20
-      maxTotalUses: -1
+      maxSize: <%= eC2Fleet_cloud_setup['maxSize'] ? eC2Fleet_cloud_setup['maxSize'].to_i : 1 %>
+      # Ephemeral agents: no reuse
+      maxTotalUses: 1
       minSize: 0
       minSpareSize: 0
       name: "<%= $fleetName %>"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -134,7 +134,7 @@ profile::jenkinscontroller::jcasc:
       sshCredential: dummy-ssh-jenkins
       region: us-east-2
       # Value from https://github.com/jenkins-infra/terraform-states/tree/main/aws-sponsored (terraform output ec2fleet_vagrant_access_key_id)
-      awsAccessKeyId: AKIAUYEMYSOUPYWXMAON
+      awsAccessKeyId: AKIAUYEMYSOUELITHJ6Z
       # Read by vagrant. Environment variable value from https://github.com/jenkins-infra/terraform-states/tree/main/aws-sponsored (terraform output ec2fleet_vagrant_access_key_secret_access_key)
       awsSecretKeyEnvName: JENKINS_EC2_FLEET_AWS_SECRET_KEY # Passed by Vagrant as an env. var
       fleets:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -151,7 +151,7 @@ profile::jenkinscontroller::jcasc:
           osVersion: 2025
           jdks: [25]
           spot: true
-          maxSize: 10
+          maxSize: 7
           autoMavenLabels: false
           autoDefaultOSLabel: false
           customLabels: windows-infratest
@@ -165,7 +165,7 @@ profile::jenkinscontroller::jcasc:
           osVersion: 2019
           jdks: [25]
           spot: true
-          maxSize: 20
+          # maxSize: 20 # Commented to "test" the default value in the ERB template
           autoDefaultOSLabel: true
         ## Not supported yet, but gives and idea of the data structure
         # - os: ubuntu


### PR DESCRIPTION
Fixup of #4937 

Ref. https://github.com/jenkins-infra/helpdesk/issues/5202

This PR also fixes the AWS Key ID used for local vagrant tests as it was changed in https://github.com/jenkins-infra/terraform-states/commit/628e61aaa247a77f03dd6b982b4a8cffd543c494 but I missed updating it (merge conflict mistake I made in 4937).
=> local vagrant test worked very well and I was able to test the changes of this PR.