### PR TITLE
fix(jenkinscontroller): EC2 Fleet with Windows agents - do not start the agent process until cloud init is finished

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
@@ -21,6 +21,10 @@ jenkins:
           maxNumRetries: 10
           retryWaitTime: 15
           port: 22
+          # Do not start the agent process until cloud-init (EC2Launchv2) is finished. See https://github.com/jenkins-infra/terraform-aws-sponsorship/blob/main/templates/ci.jenkins.io/ec2-windows-userdata.tpl#L162
+          prefixStartSlaveCmd: "powershell -Command \"& {while (-not (Test-Path Z:/Temp/.cloud-init.done))\
+            \ { Start-Sleep -Milliseconds 1000; echo 'Cloud Init not finished yet.\
+            \ waiting 1s'}; echo 'Cloud Init finished'}\" &&"
           sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
       disableTaskResubmit: false
       executorScaler: "noScaler"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5202

We don't want to start a build too soon while the "Cloud Init" (EC2LaunchV2 in Windows) is still retrieving the Maven cache or doing other stuff