### PR TITLE
cleanup(ci.jenkins.io) remove the EC2 windows-infratest agent template in favor of its EC2Fleet counterpart

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -802,23 +802,6 @@ profile::jenkinscontroller::jcasc:
               - maven-25-windows-nonspot
             spot: false
             acpServerId: aws-internal
-          - description: "Windows Infra Test"
-            maxInstances: 5
-            instanceType: "r8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
-            os: "windows"
-            os_version: "2025"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-21'
-            # # Utilizes the local NVMe mounted in Z:
-            # customDataDisk: 'Z:'
-            # # Don't use local NVMe as data-root for docker
-            # customDataDiskNotUsedForDocker: true
-            remoteAdmin: jenkins
-            labels:
-              - infratest-windows
-            spot: true
-            acpServerId: aws-internal
           - description: "Ubuntu Infra Test"
             maxInstances: 5
             instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb


### PR DESCRIPTION
ref. https://github.com/jenkins-infra/helpdesk/issues/5202

With https://ci.jenkins.io/job/Plugins/job/jenkins-infra-test-plugin/job/master/391 as a successful "test" build, we can remove the EC2 agent template and move forward.