### PR TITLE
fix(jenkinscontroller/EC2Fleet) Fine tune initial configurations for EC2Fleet clouds

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
@@ -26,22 +26,28 @@ jenkins:
             \ { Start-Sleep -Milliseconds 1000; echo 'Cloud Init not finished yet.\
             \ waiting 1s'}; echo 'Cloud Init finished'}\" &&"
           sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
-      disableTaskResubmit: false
+      # Rely on "retry()" instead (to avoid triggering too much builds)
+      disableTaskResubmit: true
       executorScaler: "noScaler"
       fleet: "ci-jenkins-io-<%= $fleetName %>"
       fsRoot: "<%= eC2Fleet_cloud_setup['os'] == "windows" ? "Z:/agent" : "/home/jenkins/agent" %>"
-      idleMinutes: 0
+      idleMinutes: 1
       initOnlineCheckIntervalSec: 15
-      initOnlineTimeoutSec: 240
+      initOnlineTimeoutSec: <%= eC2Fleet_cloud_setup['os'] == "windows" ? 300 : 180 %>
       <%- $labels = [$fleetName] -%>
       <%- if eC2Fleet_cloud_setup['autoDefaultOSLabel'] && (eC2Fleet_cloud_setup['jdks'].length== 1 || jdkMajorVersion == eC2Fleet_cloud_setup['defaultJdk']) -%>
         <%- $labels += [eC2Fleet_cloud_setup['os'] + "-" + eC2Fleet_cloud_setup['osVersion'].to_s] -%>
       <%- end -%>
       <%- if eC2Fleet_cloud_setup['autoMavenLabels'] -%>
-        <%- $labels += ["maven-" + jdkMajorVersion.to_s + (eC2Fleet_cloud_setup['os'] == "windows" ? "-windows" : "")] -%>
+        <%- $labels += ["maven-" + jdkMajorVersion.to_s + (eC2Fleet_cloud_setup['os'] == "windows" ? "-windows" : "") + (eC2Fleet_cloud_setup['spot'] ? "" : "-nonspot")] -%>
       <%- end -%>
       <%- if eC2Fleet_cloud_setup['customLabels'] -%>
         <%- $labels += [eC2Fleet_cloud_setup['customLabels']] -%>
+      <%- end -%>
+      <%- if eC2Fleet_cloud_setup['spot'] -%>
+        <%- $labels += ["spot"] -%>
+      <%- else -%>
+        <%- $labels += ["nonspot"] -%>
       <%- end -%>
       labelString: "<%= $labels.join(" ") %>"
       maxSize: <%= eC2Fleet_cloud_setup['maxSize'] ? eC2Fleet_cloud_setup['maxSize'].to_i : 1 %>
@@ -50,7 +56,7 @@ jenkins:
       minSize: 0
       minSpareSize: 0
       name: "<%= $fleetName %>"
-      noDelayProvision: false
+      noDelayProvision: true
       numExecutors: 1
       privateIpUsed: true
       region: "<%= @jcasc['cloud_agents']['eC2Fleet']['region'] %>"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5202

Initial testing with the `windows-infratest` shows a few hiccups in the initial setup. This PR introduces the following fixes:

- Add missing labels for spot/nonspot (fixup of #4937)
- Disable re-submitting jobs otherwise we cannot use the "retry()" mechanism" (otherwise we waste resources as jobs usually have parallel branches on other kind of agents)
- Provision without delays (might result in overprovisioning)
- Increase agent startup timeout to 300 for Windows but set it up to 180 for Linux (The cloud init execution time varies between 1min30 and 4min sometimes)
- Delete nodes after 1 min. of idle (in case of over provisioning)