### PR TITLE
fix(ci.jenkins.io) EC2 Fleet Windows agents uses JDK21 by default

### DIFF
--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -354,22 +354,22 @@ profile::jenkinscontroller::jcasc:
       fleets:
         - os: windows
           osVersion: 2025
-          jdks: [8, 11, 17, 21, 25]
-          defaultJdk: 25
+          jdks: [8,11,17,21,25]
+          defaultJdk: 21
           spot: true
           maxSize: 50
           autoDefaultOSLabel: true
           autoMavenLabels: true
         - os: windows
           osVersion: 2022
-          jdks: [25]
+          jdks: [21]
           spot: true
           maxSize: 20
           autoDefaultOSLabel: true
           autoMavenLabels: false
         - os: windows
           osVersion: 2019
-          jdks: [25]
+          jdks: [21]
           spot: true
           maxSize: 20
           autoDefaultOSLabel: true
@@ -377,7 +377,7 @@ profile::jenkinscontroller::jcasc:
         - customName: "infratest"
           os: windows
           osVersion: 2025
-          jdks: [25]
+          jdks: [21]
           spot: true
           maxSize: 5
           autoDefaultOSLabel: false

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -140,8 +140,8 @@ profile::jenkinscontroller::jcasc:
       fleets:
         - os: windows
           osVersion: 2025
-          jdks: [8, 11, 17, 21, 25]
-          defaultJdk: 25
+          jdks: [8,11,17,21,25]
+          defaultJdk: 21
           spot: true
           maxSize: 50
           autoMavenLabels: true
@@ -149,7 +149,7 @@ profile::jenkinscontroller::jcasc:
         - customName: "infratest"
           os: windows
           osVersion: 2025
-          jdks: [25]
+          jdks: [21]
           spot: true
           maxSize: 7
           autoMavenLabels: false
@@ -157,13 +157,13 @@ profile::jenkinscontroller::jcasc:
           customLabels: windows-infratest
         - os: windows
           osVersion: 2022
-          jdks: [25]
+          jdks: [21]
           spot: true
           maxSize: 20
           autoDefaultOSLabel: true
         - os: windows
           osVersion: 2019
-          jdks: [25]
+          jdks: [21]
           spot: true
           # maxSize: 20 # Commented to "test" the default value in the ERB template
           autoDefaultOSLabel: true


### PR DESCRIPTION
Follows up (and requires) https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/550

> The expected JDK (outside the `maven-XX-windows` agents) is 21. Not 25 (ref. https://github.com/jenkins-infra/acceptance-tests/blob/240c14b40248e82e2de34e53a7482e3cdf35d939/checks.ps1#L17).