### PR TITLE
feat(ci.jenkins.io) move all Windows EC2 agent templates to EC2 fleet templates

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
@@ -50,7 +50,7 @@ jenkins:
         <%- if pricingType == "spot" -%>
           <%- $labels += ["spot"] -%>
         <%- else -%>
-          <%- $labels += ["nonspot", "ondemand"] -%>
+          <%- $labels += ["nonspot", "ondemand", "maven-" + jdkMajorVersion.to_s + (eC2FleetCloudSetup['os'] == "windows" ? "-windows" : "") + "-nonspot"] -%>
         <%- end -%>
       labelString: "<%= $labels.join(" ") %>"
       maxSize: <%= eC2FleetCloudSetup['maxSize'] ? eC2FleetCloudSetup['maxSize'].to_i : 1 %>

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -356,21 +356,21 @@ profile::jenkinscontroller::jcasc:
           osVersion: 2025
           jdks: [8,11,17,21,25]
           defaultJdk: 21
-          pricingTypes: ["spot"]
+          pricingTypes: ["spot", "ondemand"]
           maxSize: 50
           autoDefaultOSLabel: true
           autoMavenLabels: true
         - os: windows
           osVersion: 2022
           jdks: [21]
-          pricingTypes: ["spot"]
+          pricingTypes: ["spot", "ondemand"]
           maxSize: 20
           autoDefaultOSLabel: true
           autoMavenLabels: false
         - os: windows
           osVersion: 2019
           jdks: [21]
-          pricingTypes: ["spot"]
+          pricingTypes: ["spot", "ondemand"]
           maxSize: 20
           autoDefaultOSLabel: true
           autoMavenLabels: false
@@ -378,7 +378,7 @@ profile::jenkinscontroller::jcasc:
           os: windows
           osVersion: 2025
           jdks: [21]
-          pricingTypes: ["spot", "ondemand"]
+          pricingTypes: ["spot"]
           maxSize: 5
           autoDefaultOSLabel: false
           autoMavenLabels: false
@@ -606,94 +606,6 @@ profile::jenkinscontroller::jcasc:
             labels:
               - ubuntu-22-amd64-highmem-maven25
             spot: true
-            acpServerId: aws-internal
-          ####
-          # Windows VMs
-          ####
-          - description: "Nonspot Windows 2019 x86_64 with JDK25"
-            maxInstances: 50
-            instanceType: "r8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
-            os: "windows"
-            os_version: "2019"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-25'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2019-amd64-maven-25-nonspot
-              - docker-windows-2019-nonspot
-            spot: false
-            acpServerId: aws-internal
-          - description: "NonSpot Windows 2022 x86_64 with JDK25"
-            maxInstances: 50
-            instanceType: "r8id.xlarge" # 4 vCPUs / 16 Gb / local NVMe
-            os: "windows"
-            os_version: "2022"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-25'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2022-amd64-maven-25-nonspot
-            spot: false
-            acpServerId: aws-internal
-          ###
-          # Windows 2025 VM
-          ###
-          - description: "Nonspot Windows 2025 x86_64 with JDK17"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "windows"
-            os_version: "2025"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-17'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2025-amd64-maven-17-nonspot
-              # Label(s) indicating default VM templates
-              - maven-17-windows-nonspot
-            spot: false
-            acpServerId: aws-internal
-          - description: "Nonspot Windows 2025 x86_64 with JDK21"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "windows"
-            os_version: "2025"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-21'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2025-amd64-maven-21-nonspot
-              # Label(s) indicating default VM templates
-              - maven-21-windows-nonspot
-            spot: false
-            acpServerId: aws-internal
-          - description: "Nonspot Windows 2025 x86_64 with JDK25"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "windows"
-            os_version: "2025"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: 'C:/tools/jdk-25'
-            # Utilizes the local NVMe mounted in Z:
-            customDataDisk: 'Z:'
-            remoteAdmin: jenkins
-            labels:
-              - win-2025-amd64-maven-25-nonspot
-              # Label(s) indicating default VM templates
-              - maven-25-windows-nonspot
-            spot: false
             acpServerId: aws-internal
           - description: "Ubuntu Infra Test"
             maxInstances: 5

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -142,7 +142,7 @@ profile::jenkinscontroller::jcasc:
           osVersion: 2025
           jdks: [8,11,17,21,25]
           defaultJdk: 21
-          pricingTypes: ["spot"]
+          pricingTypes: ["spot", "ondemand"]
           maxSize: 50
           autoMavenLabels: true
           autoDefaultOSLabel: true
@@ -150,7 +150,7 @@ profile::jenkinscontroller::jcasc:
           os: windows
           osVersion: 2025
           jdks: [21]
-          pricingTypes: ["spot", "ondemand"]
+          pricingTypes: ["spot"]
           maxSize: 7
           autoMavenLabels: false
           autoDefaultOSLabel: false
@@ -158,13 +158,13 @@ profile::jenkinscontroller::jcasc:
         - os: windows
           osVersion: 2022
           jdks: [21]
-          pricingTypes: ["spot"]
+          pricingTypes: ["spot", "ondemand"]
           maxSize: 20
           autoDefaultOSLabel: true
         - os: windows
           osVersion: 2019
           jdks: [21]
-          pricingTypes: ["spot"]
+          pricingTypes: ["spot", "ondemand"]
           # maxSize: 20 # Commented to "test" the default value in the ERB template
           autoDefaultOSLabel: true
         ## Not supported yet, but gives and idea of the data structure


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5202#issuecomment-4867776831

Includes a few minor changes required to avoid outages:

- Add back the `-nonspot` label for Jenkins Core (ref. https://github.com/jenkinsci/jenkins/blob/e390a65c53d39a1dcb726a66772103694e09464c/Jenkinsfile#L73)
  - Note: it means that requesting "only" `maven-XX-windows` does not ensure a spot instance. But most of our cases are buildPlugin() or Jenkins Core (for Windows) so we accept the 2 cases until we've switched the pipeline library.
- Remove the 'windows-infra && ondemand' cloud, not needed anymore

Tested with Vagrant after https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/554