### PR TITLE
feat(ci.jenkins.io/jenkinscontroller) add a new EC2 Fleet for `ubuntu-infratest` agent template with our Ubuntu 22.04 amd64 image

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
@@ -26,7 +26,7 @@ jenkins:
           <%- if eC2FleetCloudSetup['os'] == "windows" -%>
           prefixStartSlaveCmd: "powershell -Command \"& {while (-not (Test-Path Z:/Temp/.cloud-init.done)) { Start-Sleep -Milliseconds 1000; echo 'Cloud Init not finished yet. waiting 1s'}; echo 'Cloud Init finished'}\" && refreshenv && "
           <%- else -%>
-          prefixStartSlaveCmd: "until [ -e '/tmp/.cloud-init.done' ]; do sleep 1; echo 'Waiting for Cloud Init to finish...'; done; echo 'Cloud Init finished'. && source /etc/environment && "
+          prefixStartSlaveCmd: "until [ -e '/tmp/.cloud-init.done' ]; do sleep 1; echo 'Cloud Init not finished yet. waiting 1s'; done; echo 'Cloud Init finished'. && source /etc/environment && "
           <%- end -%>
           sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
       # Rely on "retry()" instead (to avoid triggering too much builds)

--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
@@ -24,11 +24,11 @@ jenkins:
           port: 22
           # Do not start the agent process until cloud-init (EC2Launchv2) is finished. See https://github.com/jenkins-infra/terraform-aws-sponsorship/blob/main/templates/ci.jenkins.io/ec2-windows-userdata.tpl#L162
           <%- if eC2FleetCloudSetup['os'] == "windows" -%>
-          prefixStartSlaveCmd: "powershell -Command \"& {while (-not (Test-Path Z:/Temp/.cloud-init.done))\
-            \ { Start-Sleep -Milliseconds 1000; echo 'Cloud Init not finished yet.\
-            \ waiting 1s'}; echo 'Cloud Init finished'}\" && refreshenv && "
-          sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+          prefixStartSlaveCmd: "powershell -Command \"& {while (-not (Test-Path Z:/Temp/.cloud-init.done)) { Start-Sleep -Milliseconds 1000; echo 'Cloud Init not finished yet. waiting 1s'}; echo 'Cloud Init finished'}\" && refreshenv && "
+          <%- else -%>
+          prefixStartSlaveCmd: "until [ -e '/tmp/.cloud-init.done' ]; do sleep 1; echo 'Waiting for Cloud Init to finish...'; done; echo 'Cloud Init finished'. && source /etc/environment && "
           <%- end -%>
+          sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
       # Rely on "retry()" instead (to avoid triggering too much builds)
       disableTaskResubmit: true
       executorScaler: "noScaler"

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -383,6 +383,15 @@ profile::jenkinscontroller::jcasc:
           autoDefaultOSLabel: false
           autoMavenLabels: false
           customLabels: windows-infratest
+        - customName: "infratest"
+          os: ubuntu
+          osVersion: 22.04
+          jdks: [21]
+          pricingTypes: ["spot"]
+          maxSize: 5
+          autoMavenLabels: false
+          autoDefaultOSLabel: false
+          customLabels: linux-infratest
     ec2:
       aws-us-east-2:
         region: us-east-2
@@ -605,18 +614,6 @@ profile::jenkinscontroller::jcasc:
             javaHome: /opt/jdk-25
             labels:
               - ubuntu-22-amd64-highmem-maven25
-            spot: true
-            acpServerId: aws-internal
-          - description: "Ubuntu Infra Test"
-            maxInstances: 5
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-21
-            labels:
-              - infratest-ubuntu
             spot: true
             acpServerId: aws-internal
 profile::jenkinscontroller::plugins:

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -391,7 +391,7 @@ profile::jenkinscontroller::jcasc:
           maxSize: 5
           autoMavenLabels: false
           autoDefaultOSLabel: false
-          customLabels: linux-infratest
+          customLabels: ubuntu-infratest
     ec2:
       aws-us-east-2:
         region: us-east-2

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -167,6 +167,15 @@ profile::jenkinscontroller::jcasc:
           pricingTypes: ["spot", "ondemand"]
           # maxSize: 20 # Commented to "test" the default value in the ERB template
           autoDefaultOSLabel: true
+        - customName: "infratest"
+          os: ubuntu
+          osVersion: 22.04
+          jdks: [21]
+          pricingTypes: ["spot"]
+          maxSize: 5
+          autoMavenLabels: false
+          autoDefaultOSLabel: false
+          customLabels: linux-infratest
         ## Not supported yet, but gives and idea of the data structure
         # - os: ubuntu
         #   osVersion: 22.04


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5190#issuecomment-4876488201

Requires https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/556

This PR adds support for Linux (ubuntu) EC2 fleet templates with a new `linux-infratest` cloud:

- Specify the Linux `prefixstartcommand` with the wait for the `.cloudinit.done` file and then the `/etc/environment` file
- Remove the EC2 `infratest-ubuntu` template
- Note: the new EC2 template uses the label `ubuntu-infratest` to be in line with windows and the template names

----

Note: tested on local vagrant with success!

<img width="1367" height="276" alt="Capture d’écran 2026-07-03 à 13 32 16" src="https://github.com/user-attachments/assets/55f14910-746b-4f64-82d0-636ae07c49c7" />
