### PR TITLE
feat(ci.jenkins.io/jenkinscontroller) switch all Linux VM agent to EC2 Fleet

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/clouds-ec2-fleet.yaml.erb
@@ -5,8 +5,7 @@ jenkins:
     <%- eC2FleetCloudSetup['pricingTypes'].each do |pricingType| -%>
       <%- eC2FleetCloudSetup['jdks'].each do |jdkMajorVersion| -%>
         <%- $fleetName = (pricingType == "spot" ? "spot-" : "ondemand-") -%>
-        <%- $fleetName += eC2FleetCloudSetup['os'] + "_" + eC2FleetCloudSetup['osVersion'].to_s + "-" -%>
-        <%- $fleetName += (eC2FleetCloudSetup['architecture'] ? eC2FleetCloudSetup['architecture'] + "-" : "") -%>
+        <%- $fleetName += eC2FleetCloudSetup['os'] + "_" + eC2FleetCloudSetup['osVersion'].to_s + (eC2FleetCloudSetup['architecture'] ? "_" + eC2FleetCloudSetup['architecture'] : "") + "-" -%>
         <%- $fleetName += (eC2FleetCloudSetup['customName'] ? eC2FleetCloudSetup['customName'] + "-" : "") -%>
         <%- $fleetName += "jdk" + jdkMajorVersion.to_s -%>
   - eC2Fleet:

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -399,7 +399,7 @@ profile::jenkinscontroller::jcasc:
           maxSize: 50
           autoDefaultOSLabel: true
           autoMavenLabels: false
-          customLabels: linux-amd64 docker vm linux
+          customLabels: linux-amd64 docker vm linux amd64
         - os: ubuntu
           osVersion: 22.04
           architecture: arm64

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -392,230 +392,32 @@ profile::jenkinscontroller::jcasc:
           autoMavenLabels: false
           autoDefaultOSLabel: false
           customLabels: ubuntu-infratest
-    ec2:
-      aws-us-east-2:
-        region: us-east-2
-        useInstanceProfileForCredentials: true
-        iamInstanceProfile: "arn:aws:iam::326712726440:instance-profile/ci-jenkins-io-ec2-agents"
-        sshKeysCredentialsId: "ec2-agent-ssh"
-        # TODO: maintain with updatecli
-        securityGroups: "ephemeral-vm-agents,unrestricted-out-http"
-        # TODO: maintain with updatecli (set up in https://github.com/jenkins-infra/terraform-aws-sponsorship/blob/main/outputs.tf to use https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json)
-        subnetIds: "subnet-0095ee74f5cd48290"
-        # TODO: maintain with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
-        spotSubnetIds: "subnet-0f76ffb1385bec3db, subnet-0cbf5a4a8a81322f5, subnet-0095ee74f5cd48290"
-        # TODO: maintain with updatecli
-        registryMirror: "k8s-hubmirro-hubmirro-477f7dfd76-9bbe4e560ee83036.elb.us-east-2.amazonaws.com:5000"
-        agent_definitions:
-          ####
-          # x86_64 Linux VMs
-          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK8 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-8
-            labels:
-              - ubuntu-22-amd64-maven8
-            spot: true
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK11 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-11
-            labels:
-              - ubuntu-22-amd64-maven11
-            spot: true
-            acpServerId: aws-internal
-          - description: "Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-17
-            labels:
-              - ubuntu-22-amd64-maven17-nonspot
-            spot: false
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK17 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-17
-            labels:
-              - ubuntu-22-amd64-maven17
-            spot: true
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-21
-            labels:
-              - ubuntu-22-amd64-maven21
-              # Labels indicating it is the default VM template
-              - linux-amd64
-              - java
-              - docker
-            spot: true
-            acpServerId: aws-internal
-          - description: "Non Spot Ubuntu 22.04 LTS x86_64 with JDK21 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-21
-            labels:
-              - ubuntu-22-amd64-maven21-nonspot
-              # Note: we need to get rid of these labels from doc. and caller as they can be used either by spot or non spot
-              - linux-amd64
-              - docker
-            spot: false
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS x86_64 with JDK25 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.xlarge" # 4 vCPUs / 16 Gb / nvme 150Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-25
-            labels:
-              - ubuntu-22-amd64-maven25
-            spot: true
-            acpServerId: aws-internal
-          ####
-          # arm64 Linux VMs
-          ####
-          - description: "Spot Ubuntu 22.04 LTS arm64 with JDK17 set as default java CLI"
-            maxInstances: 50
-            instanceType: T4gXlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "arm64"
-            javaHome: /opt/jdk-17
-            labels:
-              - ubuntu-22-arm64-maven17
-            spot: true
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS arm64 with JDK21 set as default java CLI"
-            maxInstances: 50
-            instanceType: T4gXlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "arm64"
-            javaHome: /opt/jdk-21
-            labels:
-              - ubuntu-22-arm64-maven21
-              # Labels indicating it is the default VM template (for arm64)
-              - arm64docker
-              - arm64linux
-              - linux-arm64
-            spot: true
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS arm64 with JDK25 set as default java CLI"
-            maxInstances: 50
-            instanceType: T4gXlarge # 4 vCPUs / 16 Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "arm64"
-            javaHome: /opt/jdk-25
-            labels:
-              - ubuntu-22-arm64-maven25
-            spot: true
-            acpServerId: aws-internal
-          ####
-          # High Memory Linux VMs
-          ####
-          - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK17 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.2xlarge" # 8 vCPUs / 32 Gb / nvme 300Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-17
-            labels:
-              - ubuntu-22-amd64-highmem-maven17-nonspot
-            spot: false
-            acpServerId: aws-internal
-          # High Memory SPOT Linux VMs (ATH mostly)
-          - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK17 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.2xlarge" # 8 vCPUs / 32 Gb / nvme 300Gb            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-17
-            labels:
-              - ubuntu-22-amd64-highmem-maven17
-            spot: true
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.2xlarge" # 8 vCPUs / 32 Gb / nvme 300Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-21
-            labels:
-              - ubuntu-22-amd64-highmem-maven21
-              # Labels indicating it is the default VM template for high mem x86_64
-              - highmem
-              - highram
-              - docker-highmem
-              - linux-amd64-big
-              # temporarily adding manually the false label spot to avoid job failure since https://github.com/jenkins-infra/helpdesk/issues/4795
-              - spot
-            # we switch temporarily to non spot as per https://github.com/jenkins-infra/helpdesk/issues/4795
-            spot: false
-            acpServerId: aws-internal
-          - description: "Ubuntu 22.04 LTS x86_64 High Memory instance with JDK21 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.2xlarge" # 8 vCPUs / 32 Gb / nvme 300Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-21
-            labels:
-              - ubuntu-22-amd64-highmem-maven21-nonspot
-              # Labels indicating it is the default VM template (for arm64)
-              - docker-highmem-nonspot
-            spot: false
-            acpServerId: aws-internal
-          - description: "Spot Ubuntu 22.04 LTS x86_64 High Memory instance with JDK25 set as default java CLI"
-            maxInstances: 50
-            instanceType: "m5ad.2xlarge" # 8 vCPUs / 32 Gb / nvme 300Gb
-            os: "ubuntu"
-            os_version: "22.04"
-            ebsOptimized: true
-            architecture: "amd64"
-            javaHome: /opt/jdk-25
-            labels:
-              - ubuntu-22-amd64-highmem-maven25
-            spot: true
-            acpServerId: aws-internal
+        - os: ubuntu
+          osVersion: 22.04
+          jdks: [21]
+          pricingTypes: ["spot", "ondemand"]
+          maxSize: 50
+          autoDefaultOSLabel: true
+          autoMavenLabels: false
+          customLabels: linux-amd64 docker vm linux
+        - os: ubuntu
+          osVersion: 22.04
+          architecture: arm64
+          jdks: [21]
+          pricingTypes: ["spot"]
+          maxSize: 50
+          autoDefaultOSLabel: false
+          autoMavenLabels: false
+          customLabels: arm64docker arm64linux linux-arm64
+        - customName: "highmem"
+          os: ubuntu
+          osVersion: 22.04
+          jdks: [21]
+          pricingTypes: ["spot", "ondemand"]
+          maxSize: 50
+          autoDefaultOSLabel: false
+          autoMavenLabels: false
+          customLabels: linux-amd64-big highmem highram docker-highmem
 profile::jenkinscontroller::plugins:
   - ansicolor # Provides ANSI color in the UI when checking log outputs
   - artifact-manager-s3 # https://github.com/jenkins-infra/helpdesk/issues/4596
@@ -631,7 +433,6 @@ profile::jenkinscontroller::plugins:
   - datadog # Datadog plugin
   - dark-theme # Dark theme
   - docker-workflow # Provides the "withDockerContainer" pipeline keyword
-  - ec2 # For Jenkins EC2 VM agents
   - ec2-fleet # For Jenkins EC2 VM agents too (but better)
   - embeddable-build-status # https://github.com/jenkins-infra/helpdesk/issues/3013
   - git # Used for... git

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -176,18 +176,32 @@ profile::jenkinscontroller::jcasc:
           autoMavenLabels: false
           autoDefaultOSLabel: false
           customLabels: linux-infratest
-        ## Not supported yet, but gives and idea of the data structure
-        # - os: ubuntu
-        #   osVersion: 22.04
-        #   jdks: ["8","11","17","21","25"]
-        #   spot: true
-        #   maxSize: 50
-        # - os: ubuntu
-        #   osVersion: 22.04
-        #   jdks: [25"]
-        #   spot: true
-        #   architecture: arm64
-        #   maxSize: 20
+        - os: ubuntu
+          osVersion: 22.04
+          jdks: [21]
+          pricingTypes: ["spot", "ondemand"]
+          maxSize: 50
+          autoDefaultOSLabel: true
+          autoMavenLabels: false
+          customLabels: linux-amd64 docker vm linux
+        - os: ubuntu
+          osVersion: 22.04
+          architecture: arm64
+          jdks: [21]
+          pricingTypes: ["spot"]
+          maxSize: 50
+          autoDefaultOSLabel: false
+          autoMavenLabels: false
+          customLabels: arm64docker arm64linux linux-arm64
+        - customName: "highmem"
+          os: ubuntu
+          osVersion: 22.04
+          jdks: [21]
+          pricingTypes: ["spot", "ondemand"]
+          maxSize: 50
+          autoDefaultOSLabel: false
+          autoMavenLabels: false
+          customLabels: linux-amd64-big highmem highram docker-highmem
     ec2:
       aws-us-east-2:
         region: us-east-2

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -183,7 +183,7 @@ profile::jenkinscontroller::jcasc:
           maxSize: 50
           autoDefaultOSLabel: true
           autoMavenLabels: false
-          customLabels: linux-amd64 docker vm linux
+          customLabels: linux-amd64 docker vm linux amd64
         - os: ubuntu
           osVersion: 22.04
           architecture: arm64


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5190 and https://github.com/jenkins-infra/helpdesk/issues/5202

Requires https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/559 and https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/560

This PR removes all remaining EC2 agent templates and adds the following EC2 Fleet clouds:

- 2 "Ubuntu 22.04" x86_64 (spot and on-demand) which implement `linux-amd64 docker vm linux amd64` labels, should be used by:
  - https://github.com/jenkins-infra/pipeline-library/blob/4d0b42f2b19664c837523354bb6c61bddac25b7d/vars/infra.groovy#L582-L583
  - https://github.com/jenkinsci/docker/blob/daead720a964ff1f7899f98af904c9a547e79799/Jenkinsfile#L19

- 2 "Ubuntu 22.04 highmem" x86_64 (spot and on-demand) which implement `linux-amd64-big highmem highram docker-highmem` labels
  - https://github.com/jenkinsci/docker-ssh-agent/blob/ba5312c02d1566334b2d2d82f1506804f74059e8/Jenkinsfile#L30
  - https://github.com/jenkinsci/jenkins/blob/c61f51cf5f618c3d03143abfbb52ef84809847c7/Jenkinsfile#L224
- 1 "Ubuntu 22.04" arm64 (spot only) which implement `arm64docker arm64linux linux-arm64` labels. Should be used by:
  - https://github.com/jenkinsci/docker/blob/daead720a964ff1f7899f98af904c9a547e79799/Jenkinsfile#L20
  - https://github.com/jenkinsci/acceptance-test-harness/blob/c7349fe6d7352a820286bffe94315ed055930e57/Jenkinsfile#L115