### PR TITLE
Add Groovy 5.0.7 to generic tools on cert.ci

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -51,8 +51,9 @@ profile::jenkinscontroller::jcasc:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.6.zip"
       groovy-4.0.22:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-4.0.22.zip"
-      groovy-5.0.7:
+      groovy-5.0:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-5.0.7.zip"
+        subdir: "groovy-5.0.7"
   cloud_agents:
     azure_vm_agents:
       clouds:

--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -51,6 +51,8 @@ profile::jenkinscontroller::jcasc:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-3.0.6.zip"
       groovy-4.0.22:
         url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-4.0.22.zip"
+      groovy-5.0.7:
+        url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-5.0.7.zip"
   cloud_agents:
     azure_vm_agents:
       clouds:


### PR DESCRIPTION
Noting https://github.com/jenkins-infra/jenkins-infra/issues/4984 -- if that's happening soonish, might make more sense to delay this a bit.