### PR TITLE
feat(jenkinscontroller/jcasc/generic-tools) Decouple tool name from internal zip archive structure

### DIFF
--- a/dist/profile/manifests/jenkinscontroller.pp
+++ b/dist/profile/manifests/jenkinscontroller.pp
@@ -422,7 +422,7 @@ class profile::jenkinscontroller (
     'kubernetes' => 'cloud_agents.kubernetes',
     'pipeline-graph-view' => 'appearance.pipeline_graph_view',
     'ssh-slaves' => 'permanent_agents',
-    'toolenv' => 'tools.generic',
+    'generic-tool' => 'tools.generic',
     'workflow-aggregator' => 'global_libraries',
   }
 

--- a/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
@@ -9,7 +9,7 @@ tool:
       - installSource:
           installers:
           - zip:
-              subdir: "<%= name %>"
+              subdir: "<%= setup['subdir'] ? setup['subdir'] : name %>"
               url: "<%= setup['url'] %>"
               <%- if setup['label'] -%>
               label: "<%= setup['label'] %>"

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -92,6 +92,12 @@ profile::jenkinscontroller::jcasc:
     groovy:
       groovy: # Default version is named "groovy"
         version: "2.4.21"
+    generic:
+      groovy-4.0.22:
+        url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-4.0.22.zip"
+      groovy-5:
+        url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-5.0.7.zip"
+        subdir: groovy-5.0.7
     jdk:
       jdk8:
         installers:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/jenkins-infra/issues/4984

Notes:
- I chose  to use the attribute `subdir` to stay homogeneous with JCasC internal and avoid confusion
- The former behavior (e.g. using the tool name as subdir) is kept as default fallback unless specified otherwise to allow a quick shipping without breaking too much things. 
- Also fix a bug in the plugins auto-detection (whether we keep it or not): the plugin providing the `generic` tools installer is not `toolenv` (which we want to get rid of). See https://github.com/jenkins-infra/helpdesk/issues/4890#issuecomment-5104911360

Tested on the local vagrant VM which has both cases:

```yaml
profile::jenkinscontroller::jcasc:
  tools:
    generic:
      groovy-4.0.22:
        url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-4.0.22.zip"
      groovy-5:
        url: "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-binary-5.0.7.zip"
        subdir: groovy-5.0.7
```

Result is:

<img width="625" height="918" alt="Capture d’écran 2026-07-28 à 15 39 29" src="https://github.com/user-attachments/assets/fd8717fd-990a-447e-a27f-b7238e712733" />
