### PR TITLE
chore(updatecli) track NodeJS version in `incremental-publishers` Dockerfile

### DIFF
--- a/updatecli/updatecli.d/allinone-agent-dependencies/nodejs-consumers.yaml.tpl
+++ b/updatecli/updatecli.d/allinone-agent-dependencies/nodejs-consumers.yaml.tpl
@@ -53,6 +53,18 @@ targets:
       file: .nvmrc
       matchpattern: 'v?\d+\.\d+\.\d+'
 {{ end }}
+{{ if $val.dockerfile }}
+  dockerfile:
+    name: Bump NodeJS version in Dockerfile
+    kind: dockerfile
+    sourceid: getNodeJSVersionFromPackerImages
+    scmid: default
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: NODEJS_VERSION
+{{ end }}
 
 actions:
   default:

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -27,6 +27,7 @@ nodejs_consumers:
     nvmrc: true
   - repository: gatsby-plugin-jenkins-layout
   - repository: incrementals-publisher
+    dockerfile: true
 
 playwright_consumers:
   - repository: jenkins-io-components


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/incrementals-publisher/pull/135#pullrequestreview-4845907907

Requires https://github.com/jenkins-infra/incrementals-publisher/pull/143 first to ensure the build `ARG` instruction is present for tracking.