### PR TITLE
chore(updatecli) adapt PR title for `nodejs-consumers` to handle non-chore cases

### DIFF
--- a/updatecli/updatecli.d/allinone-agent-dependencies/nodejs-consumers.yaml.tpl
+++ b/updatecli/updatecli.d/allinone-agent-dependencies/nodejs-consumers.yaml.tpl
@@ -70,7 +70,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: 'chore: Bump NodeJS version to {{ source "getNodeJSVersionFromPackerImages" }}'
+    title: '{{ if $val.dockerfile }}feat{{ else }}chore{{ end }}: Bump NodeJS version to {{ source "getNodeJSVersionFromPackerImages" }}'
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
Fixup of #5000 : if we change the build `ARG` in a `Dockerfile` then it's not really a `chore` anymore