### PR TITLE
fix(profile/golang) force IPv4 to retrieve the golang archive

### DIFF
--- a/dist/profile/manifests/golang.pp
+++ b/dist/profile/manifests/golang.pp
@@ -13,7 +13,7 @@ class profile::golang (
   $golang_installation_prefix='/usr/local'
 
   exec { "Install golang version ${golang_version}":
-    command => "/usr/bin/curl --silent --location --verbose --show-error --output ${golang_dl_archive} \"${golang_dl_url}\" && /usr/bin/rm -rf ${golang_installation_prefix}/go && /usr/bin/tar -C ${golang_installation_prefix} -xzf ${golang_dl_archive} && /usr/bin/rm -f ${golang_dl_archive} && ln -s ${golang_installation_prefix}/go/bin/go /usr/local/bin/go",
+    command => "/usr/bin/curl --ipv4 --silent --location --verbose --show-error --output ${golang_dl_archive} \"${golang_dl_url}\" && /usr/bin/rm -rf ${golang_installation_prefix}/go && /usr/bin/tar -C ${golang_installation_prefix} -xzf ${golang_dl_archive} && /usr/bin/rm -f ${golang_dl_archive} && ln -s ${golang_installation_prefix}/go/bin/go /usr/local/bin/go",
     unless  => "/usr/bin/test -f /usr/local/bin/go && /usr/local/bin/go version 2>/dev/null | /bin/grep ${golang_version}",
   }
 }


### PR DESCRIPTION
As it seems to answer HTTP/404 when using IPv6

We only used this Puppet code on agent-2.trusted.ci.jenkins.io which is IPv4 only until https://github.com/jenkins-infra/jenkins-infra/pull/5024 was applied to census.