### PR TITLE
cleanup: remove all LVM leftovers

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -45,7 +45,6 @@ mod 'saz-ssh', '5.0.0'
 # Dependency
 mod 'puppetlabs-sshkeys_core', '2.4.0'
 
-mod 'puppetlabs-lvm', '1.4.0'
 mod 'datadog-datadog_agent', '3.21.0'
 
 # Used for grabbing certificates for jenkins.io

--- a/dist/profile/manifests/usage.pp
+++ b/dist/profile/manifests/usage.pp
@@ -22,12 +22,6 @@ class profile::usage (
 ) {
   include stdlib # Required to allow using stlib methods and custom datatypes
   include apache
-
-  $lvm_enable = lookup('lvm::volume_groups', { default_value => {}, value_type => Hash, merge => hash })
-  if $lvm_enable {
-    # volume configuration is in hiera
-    include lvm
-  }
   include profile::accounts
   include profile::apachemisc
   include profile::firewall
@@ -36,12 +30,6 @@ class profile::usage (
 
   if $letsencrypt {
     include profile::letsencrypt
-  }
-
-  if $lvm_enable {
-    package { 'lvm2':
-      ensure => present,
-    }
   }
   $mounted_logs_dir = "${home_dir}/apache-logs"
   $mounted_stats_dir = "${home_dir}/usage-stats"

--- a/dist/profile/manifests/vagrant.pp
+++ b/dist/profile/manifests/vagrant.pp
@@ -2,7 +2,7 @@
 # Vagrant profile for capturing some of the spceifics we need for Vagrant boxes
 # to pvoision cleanly
 class profile::vagrant {
-  Exec { '/usr/bin/apt-get update --quiet':
+  Exec { '/usr/bin/apt-get update --quiet':,
   }
   include sudo
 
@@ -12,101 +12,4 @@ class profile::vagrant {
     priority => '10',
     content  => 'vagrant ALL=(ALL) NOPASSWD: ALL',
   }
-
-  ######
-  # The following code block is a hack to ensure that LVM volumes are created without any errors in the Vagrant environment.
-  # Challenge comes from LVM requiring `udev` to discover and manage devices. But udev is not working inside a docker container (other than sharing the host udev).
-  # The trick is to run the custom lv commands and then delegate to the lvm the missing part
-  # Main point is the "lvcreate" that should use the flag `--zero n` but the puppet module does not allow it alas.
-  $default_extent_size_bytes = 4194304 # 4Mb
-
-  lookup('lvm::volume_groups', undef, undef, {}).each | $vg_name, $vg_config| {
-    # Create an array with the list of specified logicial volumes sizes in bytes
-    # Ref. https://puppet.com/docs/puppet/6/function.html#reduce
-    $lv_sizes_in_byte = $vg_config['logical_volumes'].reduce([]) |$memo, $value| {
-      $memo + to_bytes($value[1]['size'])
-    }
-
-    # Calculate the sum of all these sizes from the array
-    $total_lv_size_in_bytes = $lv_sizes_in_byte.reduce(0) |$memo, $value| {
-      if ( $value % $default_extent_size_bytes > 0) {
-        # Need to round up to the next extent
-        $memo + $value + $default_extent_size_bytes - ($value % $default_extent_size_bytes)
-      } else {
-        $memo + $value
-      }
-    }
-    notice("== Found a specified total of ${total_lv_size_in_bytes} bytes required for all LVM logical volumes")
-
-    # How much PV to create ?
-    $pv_count = $vg_config['physical_volumes'].size
-
-    # Size per PV.
-
-    $pv_size_in_megabyte = (($total_lv_size_in_bytes / $pv_count + $default_extent_size_bytes) / 1024 / 1024)
-    notice("== Calculated a size of ${pv_size_in_megabyte} megabytes per LVM physical volumes")
-
-    $vg_config['physical_volumes'].each | $index, $loopback_device| {
-      # Store dummy device on root: NOT in /tmp, not in /dev (because these are tmpfs in containers)
-      $dummy_device = "/dummy${index}"
-
-      exec { "create ${dummy_device}":
-        command => "dd if=/dev/zero of=${dummy_device} bs=1M count=${pv_size_in_megabyte}",
-        unless  => "test -f ${dummy_device}",
-        path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-      }
-
-      $dmsetup_remove_cmd = 'dmsetup ls | awk \'{print $1}\' | xargs -I{} dmsetup remove {}'
-
-      exec { "setup ${dummy_device} dummy device to ${loopback_device} loop device":
-        # dmsetup is used to "force" remove the loopback
-        command => "${dmsetup_remove_cmd} || true && losetup --detach-all && losetup --partscan ${loopback_device} ${dummy_device}",
-        unless  => "losetup --associated ${dummy_device} | grep '${loopback_device}'",
-        path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-        require => Exec["create ${dummy_device}"],
-      }
-
-      # The lvm puppet module does not provide a 'disable zeroing' feature that would avoid requiring udev in the vagrant docker-container
-      exec { "setup ${loopback_device} as a physical volume":
-        command => "pvcreate ${loopback_device}",
-        unless  => "pvscan | grep ${loopback_device}",
-        path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-        require => Exec["setup ${dummy_device} dummy device to ${loopback_device} loop device"],
-        before  => Exec["setup volume group ${vg_name}"],
-      }
-    }
-
-    # Create Volume Group
-    $pv_list = join($vg_config['physical_volumes'], ' ')
-    exec { "setup volume group ${vg_name}":
-      command => "vgcreate ${vg_name} ${pv_list}",
-      unless  => "vgscan | grep ${vg_name}",
-      path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-      notify  => Exec['ensure vg nodes are created'],
-    }
-
-    # Create Logical Volumes
-    $vg_config['logical_volumes'].each | $lv_name, $lv_config| {
-      $lv_size_in_bytes = to_bytes($lv_config['size'])
-      $new_lv_size_in_bytes = floor($lv_size_in_bytes / $default_extent_size_bytes) * $default_extent_size_bytes
-      $new_lvsize =  $new_lv_size_in_bytes / 1024 / 1024
-      $lv_create_cmd = "lvcreate --name ${lv_name} --size ${$new_lvsize} --zero n data"
-
-      exec { "setup logical volume ${lv_name}":
-        # Note the `--zero n` flag: it disable zeroing blocks to avoid requiring udev (nifty part)
-        command => $lv_create_cmd,
-        unless  => "lvscan | grep ${lv_name}",
-        path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-        require => Exec["setup volume group ${vg_name}"],
-        before  => Exec['ensure vg nodes are created'],
-      }
-    }
-
-    # To avoid the mkfs errors 'The file <whatever> does not exist and no size was specified'
-    exec { 'ensure vg nodes are created':
-      command => 'vgscan --mknodes',
-      path    => '/usr/bin:/usr/sbin:/bin:/sbin',
-    }
-  }
-  ###### End custom hack LVM for Docker
 }

--- a/hieradata/clients/usage.yaml
+++ b/hieradata/clients/usage.yaml
@@ -1,12 +1,4 @@
 ---
-lvm::volume_groups:
-  data:
-    physical_volumes:
-      - /dev/xvdf
-    logical_volumes:
-      usage:
-        size: 200G
-        mountpath: /srv/usage
 # Per-host Datadog configuration
 datadog_agent::host: "usage.jenkins.io"
 accounts:

--- a/spec/classes/profile/usage_spec.rb
+++ b/spec/classes/profile/usage_spec.rb
@@ -1,89 +1,86 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe 'profile::usage' do
-  it { expect(subject).to contain_class 'profile::usage' }
+describe "profile::usage" do
+  it { expect(subject).to contain_class "profile::usage" }
 
-  context 'mounted volume setup' do
-    let(:volume) { '/srv/usage' }
-    it { expect(subject).to contain_class 'lvm' }
-    it { expect(subject).to contain_class 'stdlib' }
-    it { expect(subject).to contain_package 'lvm2' }
+  context "mounted volume setup" do
+    let(:volume) { "/srv/usage" }
+    it { expect(subject).to contain_class "stdlib" }
   end
 
-  context 'apache setup' do
+  context "apache setup" do
     let(:params) do
       {
-        :docroot => '/tmp/rspec-docroot',
+        :docroot => "/tmp/rspec-docroot",
       }
     end
 
-    it { expect(subject).to contain_class 'apache' }
-    it { expect(subject).to contain_class 'profile::accounts' }
-    it { expect(subject).to contain_class 'profile::apachemisc' }
-    it { expect(subject).to contain_class 'profile::firewall' }
-    it { expect(subject).to contain_class 'profile::letsencrypt' }
+    it { expect(subject).to contain_class "apache" }
+    it { expect(subject).to contain_class "profile::accounts" }
+    it { expect(subject).to contain_class "profile::apachemisc" }
+    it { expect(subject).to contain_class "profile::firewall" }
+    it { expect(subject).to contain_class "profile::letsencrypt" }
 
-    it 'should contain File[$docroot]' do
+    it "should contain File[$docroot]" do
       expect(subject).to contain_file(params[:docroot]).with({
         :ensure => :directory,
-        :require => 'Package[httpd]',
+        :require => "Package[httpd]",
       })
     end
 
-    it 'should contain File[usage-stats.js]' do
-      expect(subject).to contain_file('usage-stats.js').with({
+    it "should contain File[usage-stats.js]" do
+      expect(subject).to contain_file("usage-stats.js").with({
         :ensure => :file,
         :path => "#{params[:docroot]}/usage-stats.js",
         :require => "File[#{params[:docroot]}]",
       })
     end
 
-
-    it 'should contain a logging directory' do
-      expect(subject).to contain_file('/var/log/apache2/usage.jenkins.io').with({
+    it "should contain a logging directory" do
+      expect(subject).to contain_file("/var/log/apache2/usage.jenkins.io").with({
         :ensure => :link,
-        :target => '/srv/bigger-usage/apache-logs',
+        :target => "/srv/bigger-usage/apache-logs",
       })
     end
 
-    it 'usage.jenkins.io vhost' do
-      expect(subject).to contain_apache__vhost('usage.jenkins.io').with({
+    it "usage.jenkins.io vhost" do
+      expect(subject).to contain_apache__vhost("usage.jenkins.io").with({
         :port => 443,
         :ssl => true,
         :docroot => params[:docroot],
-        :options => ['Indexes', 'FollowSymLinks', 'MultiViews'],
-        :override => ['All'],
+        :options => ["Indexes", "FollowSymLinks", "MultiViews"],
+        :override => ["All"],
       })
     end
 
-    it 'usage.jenkins.io unsecured vhost' do
-      expect(subject).to contain_apache__vhost('usage.jenkins.io unsecured').with({
+    it "usage.jenkins.io unsecured vhost" do
+      expect(subject).to contain_apache__vhost("usage.jenkins.io unsecured").with({
         :port => 80,
         :ssl => false,
         :docroot => params[:docroot],
-        :options => ['Indexes', 'FollowSymLinks', 'MultiViews'],
-        :override => ['All'],
+        :options => ["Indexes", "FollowSymLinks", "MultiViews"],
+        :override => ["All"],
       })
     end
 
-    it 'usage.jenkins-ci.org' do
-      expect(subject).to contain_apache__vhost('usage.jenkins-ci.org').with({
+    it "usage.jenkins-ci.org" do
+      expect(subject).to contain_apache__vhost("usage.jenkins-ci.org").with({
         :port => 443,
         :ssl => true,
         :docroot => params[:docroot],
-        :ssl_key   => '/etc/ssl/private/ssl-cert-snakeoil.key',
-        :ssl_cert  => '/etc/ssl/certs/ssl-cert-snakeoil.pem',
-        :redirect_dest => 'https://usage.jenkins.io/',
+        :ssl_key => "/etc/ssl/private/ssl-cert-snakeoil.key",
+        :ssl_cert => "/etc/ssl/certs/ssl-cert-snakeoil.pem",
+        :redirect_dest => "https://usage.jenkins.io/",
       })
     end
 
-    context 'in a production environment' do
-      let(:fqdn) { 'usage.jenkins.io' }
-      let(:environment) { 'production' }
+    context "in a production environment" do
+      let(:fqdn) { "usage.jenkins.io" }
+      let(:environment) { "production" }
 
       it { expect(subject).to contain_letsencrypt__certonly(fqdn) }
 
-      it 'should configure the letsencrypt ssl keys on the vhost' do
+      it "should configure the letsencrypt ssl keys on the vhost" do
         expect(subject).to contain_apache__vhost(fqdn).with({
           :servername => fqdn,
           :port => 443,
@@ -94,55 +91,55 @@ describe 'profile::usage' do
     end
   end
 
-  context 'usagestats account support' do
+  context "usagestats account support" do
     let(:params) do
       {
-        :user => 'rspecuser',
-        :group => 'rspecuser',
+        :user => "rspecuser",
+        :group => "rspecuser",
       }
     end
 
-    it 'should set up the home dir' do
+    it "should set up the home dir" do
       # This path is legacy :/
       expect(subject).to contain_file("#{params[:user]}_home").with({
         :ensure => :directory,
         :owner => params[:user],
-        :path => '/srv/bigger-usage',
+        :path => "/srv/bigger-usage",
       })
     end
 
     it { expect(subject).to contain_user(params[:user]) }
     it { expect(subject).to contain_group(params[:user]) }
 
-    it 'should have the usage public key in authorized keys' do
-      expect(subject).to contain_ssh_authorized_key('usage').with({
+    it "should have the usage public key in authorized keys" do
+      expect(subject).to contain_ssh_authorized_key("usage").with({
         :user => params[:user],
-        :type => 'ssh-rsa',
+        :type => "ssh-rsa",
       })
     end
   end
 
-  context 'legacy support' do
+  context "legacy support" do
     let(:params) do
       {
-        :group => 'rspeclegacygroup',
+        :group => "rspeclegacygroup",
       }
     end
 
-    it 'should symlink /var/log/apache2/usage.jenkins-ci.org' do
-      expect(subject).to contain_file('/var/log/apache2/usage.jenkins-ci.org').with({
+    it "should symlink /var/log/apache2/usage.jenkins-ci.org" do
+      expect(subject).to contain_file("/var/log/apache2/usage.jenkins-ci.org").with({
         :ensure => :link,
-        :target => '/var/log/apache2/usage.jenkins.io',
+        :target => "/var/log/apache2/usage.jenkins.io",
       })
     end
 
-    it 'should symlink /var/log/usage-stats to /srv/usage' do
-      expect(subject).to contain_file('/var/log/usage-stats').with({
+    it "should symlink /var/log/usage-stats to /srv/usage" do
+      expect(subject).to contain_file("/var/log/usage-stats").with({
         :ensure => :link,
-        :target => '/srv/bigger-usage/usage-stats',
+        :target => "/srv/bigger-usage/usage-stats",
       })
     end
 
-    it { expect(subject).to contain_user('kohsuke') }
+    it { expect(subject).to contain_user("kohsuke") }
   end
 end

--- a/vagrant-docker/Dockerfile.22.04
+++ b/vagrant-docker/Dockerfile.22.04
@@ -15,7 +15,6 @@ RUN apt-get update \
   iproute2 \
   iptables \
   locales \
-  lvm2 \
   openssh-server \
   passwd \
   rsyslog \


### PR DESCRIPTION
We don't need LVM since we moved `usage.jenkins.io` and `census.jenkins.io` from AWS EC2 to DigitalOcean as we now use resizable data disks instead.


Note: Need to manually remove packages from the 2 VMs once applied.