### PR TITLE
fix(cert.ci.jenkins.io) use the new agent UAID

### DIFF
--- a/hieradata/clients/controller.cert.ci.jenkins.io.yaml
+++ b/hieradata/clients/controller.cert.ci.jenkins.io.yaml
@@ -66,7 +66,7 @@ profile::jenkinscontroller::jcasc:
           subnetName: cert-ci-jenkins-io-sponsored-vnet-ephemeral-agents
           disableSpot: true # Not enough quota available
           storageAccount: certciagentssub
-          userInstanceIdentity: '/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/cert-ci-jenkins-io-controller/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cert-ci-jenkins-io-agents-sponsored'
+          userInstanceIdentity: '/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/cert-ci-jenkins-io-sponsored-commons/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cert-ci-jenkins-io-agents-sponsored'
       agent_definitions:
         ## Linux agent templates
         - name: "ubuntu-22-amd64-maven-11"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5269#issuecomment-5541021978


Following https://github.com/jenkins-infra/azure/pull/1528 which re-created a new UAID, we have to update it.

Retrieved from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json:

```
$ curl --silent --location https://reports.jenkins.io/jenkins-infra-data-reports/azure.json | jq -r '.["cert.ci.jenkins.io"]["agents_azure_vms_jenkins_sponsored"]["user_assigned_identity"]'
/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/cert-ci-jenkins-io-sponsored-commons/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cert-ci-jenkins-io-agents-sponsored
```