### PR TITLE
chore(jenkins::controller): put `unclassified` in hieradata instead o in erb template to avoid weird indentation

### DIFF
--- a/dist/profile/templates/jenkinscontroller/casc/unclassified.yaml.erb
+++ b/dist/profile/templates/jenkinscontroller/casc/unclassified.yaml.erb
@@ -1,4 +1,3 @@
 <% if @jcasc['unclassified'] && @jcasc['unclassified']['data'] -%>
-unclassified:
-  <%= @jcasc['unclassified']['data'] %>
+<%= @jcasc['unclassified']['data'] %>
 <% end %>

--- a/hieradata/clients/aws.ci.jenkins.io.yaml
+++ b/hieradata/clients/aws.ci.jenkins.io.yaml
@@ -37,15 +37,14 @@ profile::jenkinscontroller::jcasc:
   datadog_api_key: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAERRz+gDvppQtJ6Z8vlOFie10T5PqYiCpQF4CXEKO37opax1XkLY3DppRcHszB5fhRQQuLKJbvRPHi+IG+M8+3OGX97UNpz+Qc7PzEUHzf/ltMmPjBsRlwRbievY1Eedsc0x2ChHoNGB3SfWnoBlQpswLMNIjtbBpxvsq3IU7VQh/7B4nKYsJf6WxCeSzHAsUWUnLD4h4HDCkO8J8CzcnzLY+LuSgZoKoAngzZQZGPjR0d8E4p7I0CkBAdC5oAb7c0I/LCG+VEHS0f3K2lZEr+x0r2/Uik5WQUCd6GGUPvgR1Dgjq+wpG6KpIrywMP1Zyu8v3k37a9oPKPjUmaenGOzBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCfXME/Pwao7EY9I6jnauX8gDDuL/Rtl8kjppZBAeRepKsaqio7N9Q2s/8zbADk4Gn+iSMRnGSHDCu13dRYURiFjYw=]
   unclassified:
     data: |-
-      buildDiscarders:
+      unclassified:
+        buildDiscarders:
           configuredBuildDiscarders:
           - "jobBuildDiscarder"
           - defaultBuildDiscarder:
               discarder:
                 logRotator:
                   numToKeepStr: "5"
-        # Weird indentation: we would expect 2 less spaces below
-        # but hieradata is behaving weirdly (bug in YAML parser?)
         defaultDisplayUrlProvider:
           providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
   appearance:

--- a/hieradata/vagrant/common.yaml
+++ b/hieradata/vagrant/common.yaml
@@ -48,15 +48,14 @@ profile::jenkinscontroller::jcasc:
   datadog_api_key: SuperSecretThatShouldBeEncryptedInProduction
   unclassified:
     data: |-
-      buildDiscarders:
+      unclassified:
+        buildDiscarders:
           configuredBuildDiscarders:
           - "jobBuildDiscarder"
           - defaultBuildDiscarder:
               discarder:
                 logRotator:
                   numToKeepStr: "5"
-        # Weird indentation: we would expect 2 less spaces below
-        # but hierdata is behaving weirdly (bug in YAML parser?)
         defaultDisplayUrlProvider:
           providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
       # Allow to check authenticated_access in http://localhost:8080/manage/configureSecurity/


### PR DESCRIPTION
Extracted from:
- #5050

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/5282
- https://github.com/jenkins-infra/helpdesk/issues/4714

### Testing done

No change, same 3 top level directives:
```yaml
$ vagrant up --provision jenkins::controller
$ vagrant ssh jenkins::controller
vagrant@localhost:~$ sudo su -
root@localhost:~$ cat /var/lib/jenkins/casc.d/unclassified.yaml 
unclassified:
  buildDiscarders:
    configuredBuildDiscarders:
    - "jobBuildDiscarder"
    - defaultBuildDiscarder:
        discarder:
          logRotator:
            numToKeepStr: "5"
  defaultDisplayUrlProvider:
    providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
# Allow to check authenticated_access in http://localhost:8080/manage/configureSecurity/
jenkins:
  securityRealm:
    local:
      allowsSignup: false
      users:
        - id: vagrantadmin
          password: butler
        - id: developer
          password: butler
credentials:
    system:
      domainCredentials:
        - credentials:
          - basicSSHUserPrivateKey:
              description: "Dummy (e.g. not working, clear value) SSH key"
              id: "dummy-ssh-jenkins"
              privateKeySource:
                directEntry:
                  privateKey: "DummyValueOnlyForTestingNotASecurityIssue"
              scope: SYSTEM
              username: "jenkins"