### PR TITLE
cleanup(updatecli): remove obsolete `windowsVersions` from values

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -11,11 +11,6 @@ jdks:
   - major: 21
   - major: 25
 
-windowsVersions:
-  - version: 2019
-  - version: 2022
-  - version: 2025
-
 nodejs_consumers:
   - repository: plugin-site
     nvmrc: true


### PR DESCRIPTION
This change removes that (now) unused section from updatecli values.

Amends:
- https://github.com/jenkins-infra/jenkins-infra/pull/4979