### PR TITLE
fix(profile::mirrorbits) install from our own built container images as there are no pre-built binaries since 0.6.2

### DIFF
--- a/dist/profile/manifests/mirrorbits.pp
+++ b/dist/profile/manifests/mirrorbits.pp
@@ -1,25 +1,32 @@
 # Profile to ensure `mirrorbits` CLI is installed
 class profile::mirrorbits (
   String $mirrorbits_version,
-  String $install_dir   = '/usr/local/bin',
+  String $mirrorbits_docker_image_tag, # Assuming this image has the correct mirrorbits version. With an update per year we're safe
+  String $mirrorbits_docker_image_name = 'dockerhubmirror.azurecr.io/jenkinsciinfra/mirrorbits',
+  String $install_dir = '/usr/local/bin',
 ) {
-  # Only x86_64 is currently supported out of the box - https://github.com/etix/mirrorbits/issues/150
-  # If arm64 CLI is needed, extract it from https://github.com/jenkins-infra/docker-mirrorbits built container images
+  if $mirrorbits_docker_image_tag {
+    $mirrorbits_docker_image = "${mirrorbits_docker_image_name}:${mirrorbits_docker_image_tag}"
+    $check_mirrorbits_command = "/usr/bin/test -f ${install_dir}/mirrorbits && { ${install_dir}/mirrorbits version || true; } 2>/dev/null | /bin/grep --quiet ${mirrorbits_version}"
 
-  # Dependencies used to install mirrorbits CLI
-  include apt
-  ensure_packages([
-      'curl',
-      'tar',
-  ])
+    if str2bool($facts['vagrant']) {
+      # Our mirrorbits images are private and can't be reached from developer machines so we build the image
+      $mirrorbits_docker_image_command = "/usr/bin/docker image build --tag=${mirrorbits_docker_image} https://github.com/jenkins-infra/docker-mirrorbits.git"
+    } else {
+      $mirrorbits_docker_image_command = "/usr/bin/docker image pull ${mirrorbits_docker_image}"
+    }
+    exec { "Ensure container image ${mirrorbits_docker_image} is present":
+      require => [Class['profile::docker']],
+      command => $mirrorbits_docker_image_command,
+      unless  => "${check_mirrorbits_command} && /usr/bin/docker image ls | /bin/grep --quiet ${mirrorbits_docker_image}",
+    }
 
-  if $mirrorbits_version {
-    $mirrorbits_url = "https://github.com/etix/mirrorbits/releases/download/${mirrorbits_version}/mirrorbits-${mirrorbits_version}.tar.gz"
+    $container_name = 'mirrorbits-cli'
 
     exec { 'Install mirrorbits CLI':
-      require => [Package['curl'], Package['tar']],
-      command => "/usr/bin/curl --location ${mirrorbits_url} | /bin/tar --extract --gzip --strip-components=1 --directory=${install_dir}/ mirrorbits/mirrorbits && chmod a+x ${install_dir}/mirrorbits",
-      unless  => "/usr/bin/test -f ${install_dir}/mirrorbits && { ${install_dir}/mirrorbits version || true; } 2>/dev/null | /bin/grep --quiet ${mirrorbits_version}",
+      require => [Exec["Ensure container image ${mirrorbits_docker_image} is present"]],
+      command => "/usr/bin/docker container rm --force ${container_name} && /usr/bin/docker container create --name ${container_name} ${mirrorbits_docker_image} && /usr/bin/docker container cp ${container_name}:/usr/bin/mirrorbits ${install_dir}/mirrorbits",
+      unless  => $check_mirrorbits_command,
     }
   }
 }

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -272,7 +272,8 @@ docker::version: 5:29.8.0-1~ubuntu.22.04~jammy
 profile::azcopy::azcopy_version: 10.32.8
 profile::azcopy::az_cli_version: 2.90.0
 profile::awscli::install_dir: /var/awscli
-profile::mirrorbits::mirrorbits_version: v0.6.2
+profile::mirrorbits::mirrorbits_version: 0.6.2
+profile::mirrorbits::mirrorbits_docker_image_tag: 0.4.0 # should have the profile::mirrorbits::mirrorbits_version for mirrorbits CLI.
 profile::golang::golang_version: 1.26.2
 profile::datadog_pluginsite_check::sites:
   - plugins.jenkins.io

--- a/updatecli/updatecli.d/mirrorbits.yaml
+++ b/updatecli/updatecli.d/mirrorbits.yaml
@@ -14,35 +14,49 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  lastReleaseVersion:
+  containerImageVersion:
+    name: Get latest version of jenkinsciinfra/mirrorbits
     kind: githubrelease
-    name: Get the latest `mirrorbits-cli` version
     spec:
-      owner: "etix"
-      repository: "mirrorbits"
+      owner: jenkins-infra
+      repository: docker-mirrorbits
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-      versionFilter:
-        kind: semver
-        strict: false
+  mirrorbitsVersion:
+    name: Get the version mirrorbits provided by latest jenkinsciinfra/mirrorbits
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/docker-mirrorbits/refs/tags/{{ source "containerImageVersion" }}/Dockerfile
+      matchpattern: 'ARG mirrorbits_version=v(.*)'
+    transformers:
+      - findsubmatch:
+          pattern: 'ARG mirrorbits_version=v(.*)'
+          captureindex: 1
 
 targets:
-  updateHieradataVersion:
+  updateHieradataMirrorbitsVersion:
     name: Update the `mirrorbits-cli` version in the hieradata/common.yaml file
-    sourceid: lastReleaseVersion
+    sourceid: mirrorbitsVersion
     kind: yaml
     spec:
       file: hieradata/common.yaml
       key: $.profile::mirrorbits::mirrorbits_version
     scmid: default
+  updateHieradataContainerImageVersion:
+    name: Update the `mirrorbits` container image version in the hieradata/common.yaml file
+    sourceid: containerImageVersion
+    kind: yaml
+    spec:
+      file: hieradata/common.yaml
+      key: $.profile::mirrorbits::mirrorbits_docker_image_tag
+    scmid: default
 
 actions:
   default:
     kind: github/pullrequest
-    title: Bump `mirrorbits-cli` version to {{ source "lastReleaseVersion" }}
+    title: 'Bump the mirrorbits container image version to {{ source `containerImageVersion` }} (with mirrorbits CLI version to {{ source `mirrorbitsVersion` }})'
     scmid: default
     spec:
       labels:
         - updatecli
         - mirrorbits
-


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5279#issuecomment-5605441513

Note: updatecli manifest updated. Tested locally with success but should fail in the PR checks until merged. I'll check its execution once deployed.